### PR TITLE
Cancel button for replies to comments

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -217,8 +217,7 @@ $(document).ready(function() {
     box.html($("#comment_form").clone());
     box.find("ol").remove();
 
-    console.log(box.find('button.comment-preview'));
-    box.find('button.comment-preview').after('<a class="comment-cancel" href="#">Cancel</a>');
+    box.find("button.comment-preview").after("&nbsp;\n&nbsp;<button class=\"comment-cancel\" name=\"button\" type=\"button\">Cancel</button>");
 
     box.find("textarea").focus();
 
@@ -231,8 +230,8 @@ $(document).ready(function() {
     return false;
   });
 
-  $("a.comment-cancel").live("click", function() {
-    $(this).parents('div.comment_reply form').remove();
+  $("button.comment-cancel").live("click", function() {
+    $(this).parents("div.comment_reply form").remove();
   });
 
   $("a.comment_editor").live("click", function() {

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -553,13 +553,8 @@ div.comment_reply form {
 	padding-top: 1em;
 }
 
-div.comment_reply a.comment-cancel {
-  margin-left: 15px;
+div.comment_reply button.comment-cancel {
   color: #AC130D;
-}
-
-div.comment_reply a.comment-cancel:hover {
-  color: #DD4B3C;
 }
 
 a.pagelink {


### PR DESCRIPTION
Sometimes I hit "reply" to a comment but end up not wanting to say anything. On occasion, these empty forms build up and there is no current way to remove them. This merge adds a "cancel" button to comment replies that, when clicked, removes the box. You can then click "reply" again if you change your mind.

The screenshot below is taken after I hit reply on the top-level comment. You can see the new "cancel" option.

![comment reply cancel](http://i.imgur.com/Yr283.png)
