### PR TITLE
Use max-width instead of max-device-width

### DIFF
--- a/app/assets/stylesheets/mobile.css
+++ b/app/assets/stylesheets/mobile.css
@@ -1,4 +1,4 @@
-@media only screen and (max-device-width: 480px) {
+@media only screen and (max-width: 480px) {
 	html {
 		-webkit-text-size-adjust: none;
 	}


### PR DESCRIPTION
Max-device-width will only kick in on physical devices with width smaller than
480px. It makes sense though to trigger the responsive layout on any device
where the viewport is that narrow, not just ones where the device itself is
that narrow.

For an example of this in practice, visit barackobama.com on a desktop, resize
your browser window and watch the layout change responsively.
