### PR TITLE
Basic overall user stats on user tree

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,6 +5,8 @@ class UsersController < ApplicationController
   end
 
   def tree
+    @new_users = User.where('DATE(created_at) between ? AND ?', Date.today.beginning_of_week(:sunday), Date.today)
+
     parents = {}
     karmas = {}
     User.all.each do |u|

--- a/app/views/users/tree.html.erb
+++ b/app/views/users/tree.html.erb
@@ -1,5 +1,5 @@
 <div class="box wide">
-  <strong>Users</strong>
+  <strong><%= number_with_delimiter(@tree.count) %> Users (<%= number_with_delimiter(@new_users.count) %> new this week)</strong>
   <p>
   <% prev_level = 0 %>
   <% @tree.each do |u| %>


### PR DESCRIPTION
With Lobste.rs being a new community I thought it might be interesting for people to see how its growing. This commit adds the total number of registered and the number of users registered in the current week to the top of the user tree view like so:

![image](http://i.imgur.com/GI3ns.png)
