### PR TITLE
Add unread reply count to header for in-app visual notifications of replies

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -240,6 +240,7 @@ class CommentsController < ApplicationController
       cs = Comment.ordered_for_story_or_thread_for_user(nil, r, @showing_user)
 
       if @user && (@showing_user.id == @user.id)
+        @user.reset_unread_reply_count!
         @votes = Vote.comment_votes_by_user_for_story_hash(@user.id,
           cs.map{|c| c.story_id }.uniq)
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -168,6 +168,8 @@ class Comment < ActiveRecord::Base
     if self.parent_comment_id && (u = self.parent_comment.try(:user)) &&
     u.id != self.user.id
       begin
+        u.increment_unread_reply_count!
+
         if u.email_replies?
           EmailReply.reply(self, u).deliver
         end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -73,6 +73,18 @@ class User < ActiveRecord::Base
     Keystore.value_for("user:#{self.id}:unread_messages").to_i
   end
 
+  def unread_reply_count
+    Keystore.value_for("user:#{self.id}:unread_replies").to_i
+  end
+
+  def increment_unread_reply_count!
+    count = Keystore.increment_value_for("user:#{self.id}:unread_replies")
+  end
+
+  def reset_unread_reply_count!
+    Keystore.put("user:#{self.id}:unread_replies", 0)
+  end
+
   def update_unread_message_count!
     Keystore.put("user:#{self.id}:unread_messages",
       Message.where(:recipient_user_id => self.id,

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -42,7 +42,7 @@
         } %>
 
         <% if @user %>
-          <% links.merge!({ "/threads" => "Your Threads",
+          <% links.merge!({ "/threads" => "Your Threads#{@user.unread_reply_count > 0 ? " (#{@user.unread_reply_count})" : "" }",
             "/stories/new" => "Submit Story" }) %>
         <% end %>
 


### PR DESCRIPTION
One of the things that bothers me most about HN is the lack of any good visual notification of new replies to comments. While pushover and email notifications are great options, some users may prefer a less intrusive manner of reply notifications. This commit adds an unread reply count in parentheses next to the "Your Threads" link - the unread reply count resets when "Your Threads" is visited and looks like this:

![screenshot](http://i.imgur.com/nOCSO.png)
