### PR TITLE
Add GitHub style '@' mentions to comments.

### DIFF
--- a/app/mailers/email_reply.rb
+++ b/app/mailers/email_reply.rb
@@ -9,4 +9,13 @@ class EmailReply < ActionMailer::Base
       :subject => "[Lobsters] Reply from #{comment.user.username} on " <<
       "#{comment.story.title}")
   end
+
+  def mention(comment, user)
+    @comment = comment 
+    @user = user
+
+    mail(:to => user.email, :from => "Lobsters <nobody@lobste.rs>",
+      :subject => "[Lobsters] Mention from #{comment.user.username} on " <<
+      "#{comment.story.title}")
+  end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -12,7 +12,7 @@ class Comment < ActiveRecord::Base
     :indent_level, :highlighted
 
   before_create :assign_short_id_and_upvote
-  after_create :assign_votes, :mark_submitter, :deliver_reply_notifications
+  after_create :assign_votes, :mark_submitter, :deliver_reply_notifications, :deliver_mention_notifications
   after_destroy :unassign_votes
 
   MAX_EDIT_MINS = 45
@@ -96,6 +96,24 @@ class Comment < ActiveRecord::Base
 
   def mark_submitter
     Keystore.increment_value_for("user:#{self.user_id}:comments_posted")
+  end
+
+  def deliver_mention_notifications
+    self[:comment].gsub(/\B\@([\w\-]+)/) do |u|
+      if user = User.find_by_username(u[1..-1])
+        if user.email_mentions?
+          EmailReply.mention(self, user).deliver
+        end
+        if user.pushover_mentions? && user.pushover_user_key.present?
+          Pushover.push(user.pushover_user_key, user.pushover_device, {
+            :title => "Lobsters mention by #{self.user.username} on #{self.story.title}",
+            :message => self.plaintext_comment,
+            :url => self.url,
+            :url_title => "Reply to #{self.user.username}",
+          })
+        end
+      end
+    end
   end
 
   def deliver_reply_notifications

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,7 +22,7 @@ class User < ActiveRecord::Base
 
   attr_accessible :username, :email, :password, :password_confirmation,
     :about, :email_replies, :pushover_replies, :pushover_user_key,
-    :pushover_device, :email_messages, :pushover_messages
+    :pushover_device, :email_messages, :pushover_messages, :email_mentions, :pushover_mentions
 
   before_save :check_session_token
   after_create :create_default_tag_filters

--- a/app/views/email_reply/mention.text.erb
+++ b/app/views/email_reply/mention.text.erb
@@ -1,0 +1,5 @@
+<%= @comment.user.username %> has mention you in a comment:
+
+  <%= word_wrap(@comment.plaintext_comment, :line_width => 72).gsub(/\n/, "\n  ") %>
+
+Continue this discussion at <%= @comment.url %>

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -90,6 +90,27 @@
     <br>
 
     <div class="legend">
+      Comment Mention Notification Settings
+    </div>
+
+    <div class="boxline">
+      <%= f.label :email_mentions, "Receive E-mail:", :class => "required" %>
+      <%= f.check_box :email_mentions %>
+    </div>
+
+    <div class="boxline">
+      <%= f.label :pushover_mentions,
+        raw("Receive <a href=\"https://pushover.net/\">Pushover</a> Alert:"),
+        :class => "required" %>
+      <%= f.check_box :pushover_mentions %>
+      <span class="hint">
+        Requires user key entered above
+      </span>
+    </div>
+
+    <br>
+
+    <div class="legend">
       Private Message Notification Settings
     </div>
 

--- a/db/migrate/20120910172514_mention_notification_options.rb
+++ b/db/migrate/20120910172514_mention_notification_options.rb
@@ -1,0 +1,11 @@
+class MentionNotificationOptions < ActiveRecord::Migration
+  def up
+    add_column :users, :email_mentions, :boolean, :default => false
+    add_column :users, :pushover_mentions, :boolean, :default => false
+  end
+
+  def down
+    remove_column :users, :pushover_mentions
+    remove_column :users, :email_mentions
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20120906183346) do
+ActiveRecord::Schema.define(:version => 20120910172514) do
 
   create_table "comments", :force => true do |t|
     t.datetime "created_at",                                                                          :null => false
@@ -137,6 +137,8 @@ ActiveRecord::Schema.define(:version => 20120906183346) do
     t.boolean  "email_messages",                      :default => true
     t.boolean  "pushover_messages",                   :default => true
     t.boolean  "is_moderator",                        :default => false
+    t.boolean  "email_mentions",                      :default => false
+    t.boolean  "pushover_mentions",                   :default => false
   end
 
   add_index "users", ["session_token"], :name => "session_hash", :unique => true

--- a/extras/markdowner.rb
+++ b/extras/markdowner.rb
@@ -22,6 +22,15 @@ class Markdowner
       # make links have rel=nofollow
       html.gsub!(/<a href/, "<a rel=\"nofollow\" href")
 
+      # make @mentions into links to user profile
+      html.gsub!(/\B\@([\w\-]+)/) do |u|
+        if User.find_by_username(u[1..-1])
+          "<a href=\"/u/#{u[1..-1]}\">#{u}</a>"
+        else
+          u
+        end
+      end
+
       html
     end
   end


### PR DESCRIPTION
Since better conversation and comments seems to have been one of the main goals of Lobsters I thought GitHub style '@' mentions might be handy in the comments. This would allow multiple users to receive notifications of a reply and also provide some deeper context to conversations.

This commit adds a link to the profile of valid usernames preceded by an '@', and notifies the mentioned user according to their preferences. Currently, the profile link looks like this in a comment:
![screenshot1](http://i.imgur.com/UiFK5.png)
But it may or may not make sense to remove the '@' in the final comment.

This commit also adds notification preferences for mentions like so:
![screenshot2](http://i.imgur.com/RFAQa.png)

If [pull request 16](https://github.com/jcs/lobsters/pull/16) gets merged I can add a commit that would add mentions to the visual alert count as well.
