### PR TITLE
Increase contrast of visited links’ color in CSS

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -24,7 +24,7 @@ a {
 }
 
 a:visited {
-	color: #6880CB; 
+	color: #7395D9; 
 }
 
 h1 {


### PR DESCRIPTION
As I proposed in my comment https://lobste.rs/s/0d78b8/visited_color_links/comments/yjlmhd, which links to a result demonstration image http://i.imgur.com/GxSOS.png.

I haven’t tested this change in the actual Rails app, but the change is simple enough that I assume it would work.
