### PR TITLE
Fall back to other data when no description given.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,4 +11,19 @@ module ApplicationHelper
 
     raw(html)
   end
+
+  def description_for(story)
+    if story.markeddown_description.present?
+      raw coder.encode \
+        story.markeddown_description, :decimal
+    else
+      if story.comments.any?
+        story.comments.each do |comment|
+          raw coder.encode comment.comment, decimal
+        end
+      else
+        link_to story.url
+      end
+    end
+  end
 end

--- a/app/views/home/rss.erb
+++ b/app/views/home/rss.erb
@@ -14,10 +14,9 @@
         <author><%= story.user.username %></author>
         <pubDate><%= story.created_at.rfc2822 %></pubDate>
         <comments><%= story.comments_url %></comments>
-        <% if story.markeddown_description.present? %>
-          <description><%= raw coder.encode(story.markeddown_description,
-            :decimal) %></description>
-        <% end %>
+        <description>
+          <%= description_for story %>
+        </description>
         <% story.taggings.each do |tagging| %>
           <category><%= tagging.tag.tag %></category>
         <% end %>


### PR DESCRIPTION
The RSS description should always be filled in. Either use the "marked down" description provided by the Story, use the Story's comments (if it has any), or as a last-resort, show the URL. Resolves #28
