### PR TITLE
Add a "Comment" link if there is no markeddown_description present

### DIFF
--- a/app/views/home/rss.erb
+++ b/app/views/home/rss.erb
@@ -18,7 +18,8 @@
           <description><%= raw coder.encode(story.markeddown_description,
             :decimal) %></description>
         <% else %>
-          <description><%= cdata_section(link_to("Comments", story.comments_url)) %></description>
+          <description><%= cdata_section(link_to("Comments", 
+            story.comments_url)) %></description>
         <% end %>
         <% story.taggings.each do |tagging| %>
           <category><%= tagging.tag.tag %></category>


### PR DESCRIPTION
I added a "Comment" link for stories which have no markeddown_description present in them, but it might even be a better idea to **always** add a comment link. Let me know if that is preferable.
