### PR TITLE
Removes link to reply on comment when not on a story page.

### DIFF
--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -57,7 +57,7 @@ class="comment <%= comment.current_vote ? (comment.current_vote[:vote] == 1 ?
           <a class="comment_deletor">delete</a>
         <% end %>
 
-        <% if !story.is_gone? && !comment.is_gone? %>
+        <% if !story.is_gone? && !comment.is_gone? && !show_story %>
             |
             <a class="comment_replier">reply</a>
         <% end %>


### PR DESCRIPTION
The reply link does not work on any page that isn't a story page because
it replies on the fact that a comment_form div exists on a page. That
form is the base comment field present on a story page. Therefore,
removing the link when the story is displayed next to the comment
selects for that case easily.

Closes #36 by virtue of removing the link.
