### PR TITLE
Fixed an issue where images would exceed their container

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -195,7 +195,7 @@ div.field_with_errors input:focus {
 }
 
 input:disabled, button:disabled {
-	background-color: #e9e9e9; 
+	background-color: #e9e9e9;
 	color: gray;
 }
 
@@ -364,7 +364,7 @@ div.voters div.score {
 
 div.voters a.upvoter,
 div.voters a.downvoter {
-	border-color: transparent transparent #bbb transparent;  
+	border-color: transparent transparent #bbb transparent;
 	border-style: solid;
 	border-width: 6px;
 	text-decoration: none;
@@ -527,6 +527,9 @@ div.story_text {
 }
 div.story_text p {
 	margin: 0.75em 0;
+}
+div.story_text img {
+	max-width: 100%;
 }
 
 div.comment_text {
@@ -1005,8 +1008,8 @@ div#flasher {
 	z-index: 15;
 	height: 1px;
 }
-div#flasher div.flash-error, 
-div#flasher div.flash-notice, 
+div#flasher div.flash-error,
+div#flasher div.flash-notice,
 div#flasher div.flash-success {
 	line-height: 1.5em;
 	display: inline-block;


### PR DESCRIPTION
Quick little one-liner here. I noticed when posting an image on Lobsters that it didn't resize down to fit in its parent `div`, this fixes that.
