### PR TITLE
Fixing homecontroller activerecord bug

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -195,8 +195,8 @@ private
     end
 
     if how[:tag] || how[:hottest]
-      stories = stories.where("(CAST(upvotes AS integer) - " <<
-        "CAST(downvotes AS integer)) >= -2")
+      stories = stories.where("(CAST(upvotes AS unsigned) - " <<
+        "CAST(downvotes AS unsigned)) >= -2")
     end
 
     if how[:tag]
@@ -269,7 +269,7 @@ private
     if how[:newest] || how[:recent]
       order = "stories.created_at DESC"
     elsif how[:top]
-      order = "(CAST(upvotes AS integer) - CAST(downvotes AS integer)) DESC"
+      order = "(CAST(upvotes AS unsigned) - CAST(downvotes AS unsigned)) DESC"
     end
 
     stories = stories.includes(


### PR DESCRIPTION
I was trying to deploy an instance of lobste.rs over the last couple of days and when I launched it for the first time I received a SQL syntax error stating:

ActiveRecord::StatementInvalid in HomeController#index
Mysql2::Error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'integer) - CAST(downvotes AS integer)) >= -2) ORDER BY hotness LIMIT 26 OFFSET ' at line 1: SELECT `stories`.\* FROM `stories` WHERE `stories`.`merged_story_id` IS NULL AND `stories`.`is_expired` = 0 AND ((CAST(upvotes AS integer) - CAST(downvotes AS integer)) >= -2) ORDER BY hotness LIMIT 26 OFFSET 0

I made the following changes to the code, as it appears in the MySQL docs that one cannot CAST to an `integer`, but must `CAST` to `signed` or `unsigned`. I'm not sure how you (the maintainers) aren't hitting this bug so I'm wondering if this is part of my own setup, but in case it isn't I wanted to submit a pull request just in case this is a bug that you can reproduce, since this change did fix it for me.
