### PR TITLE
Fix broken downvote menu on bad comments

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -115,22 +115,25 @@ var _Lobsters = Class.extend({
       d.append(a);
     });
 
-    if (thingType == "story")
-      li.after(d);
-    else
+    if (thingType == "story") {
       $(voterEl).after(d);
-
-    d.position({
-      my: "left top",
-      at: "left bottom",
-      offset: "-2 -2",
-      of: $(voterEl),
-      collision: "none",
-    });
-
-    /* XXX: why is this needed? */
-    if (thingType == "story")
+      d.position({
+        my: "left top",
+        at: "left bottom",
+        offset: "-2 -2",
+        of: $(voterEl),
+        collision: "none",
+      });
       d.css("left", $(voterEl).position().left);
+    } else {
+      // place downvote menu outside of the comment to avoid inheriting opacity
+      var voterPos = $(voterEl).position();
+      d.appendTo($(voterEl).closest(".comments_subtree"));
+      d.css({
+        left: voterPos.left,
+        top: voterPos.top + $(voterEl).outerHeight()
+      });
+    }
   },
 
   vote: function(thingType, voterEl, point, reason) {

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -822,7 +822,7 @@ a.pagelink.curpage {
 	width: 100px;
 	border: 1px solid #ccc;
 	border-bottom: 0;
-	z-index: 2;
+	z-index: 15;
 }
 #downvote_why a {
 	background-color: white;


### PR DESCRIPTION
Here's a screenshot of the broken downvote menu:

![bug](https://user-images.githubusercontent.com/1444515/32735088-1dc31bc2-c894-11e7-937e-02c25160b154.png)

The reduced opacity from comments with the 'bad'-class affects the
stacking order of its child elements and breaks the downvote menu. This
is avoided by appending the downvote reason menu below the comment
instead of inside it.