### PR TITLE
New story URL validation update

### DIFF
--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -67,7 +67,7 @@ class Story < ActiveRecord::Base
     if self.url.present?
       check_already_posted
       # URI.parse is not very lenient, so we can't use it
-      unless self.url.match(/\Ahttps?:\/\/([^\.]+\.)+[a-z]+(\/|\z)/i)
+      unless self.url.match(/\Ahttps?:\/\/([^\.]+\.)+[a-z]+(:\d+)?(\/|\z)/i)
         errors.add(:url, "is not valid")
       end
     elsif self.description.to_s.strip == ""


### PR DESCRIPTION
 - should now support custom ports (eg http://example.com:443/)

----

I tried submitting the following URL:

 * https://er.educause.edu:443/blogs/2017/10/time-for-password-expiration-to-die

Unfortunately I received an error saying that it wasn't a valid URL:

![image](https://user-images.githubusercontent.com/1181139/33009551-93b11e18-cdd7-11e7-86fe-90c655077cdb.png)