### PR TITLE
comments: hide top-level sibling tree lines

### DIFF
--- a/app/views/stories/show.html.erb
+++ b/app/views/stories/show.html.erb
@@ -58,7 +58,9 @@
           :was_merged => (comment.story_id != @story.id),
           :children => children %>
 
-        <div class="comment_siblings_tree_line"></div>
+        <% if ancestors.present? %>
+          <div class="comment_siblings_tree_line"></div>
+        <% end %>
 
         <% if children %>
           <% ancestors << subtree %>


### PR DESCRIPTION
since they make it easy to confuse siblings for replies

-----

Example **before:**

User `test2` is replying to the original submission, but the tree lines connecting the top-level comments make it look like a reply to the first comment instead, causing unnecessary confusion.

![screenshot-2017-12-18 something to discuss](https://user-images.githubusercontent.com/87961/34136062-e6c0d77c-e418-11e7-9f23-39d132ab9fa5.png)

Example **after:**

![screenshot-2017-12-18 something to discuss 1](https://user-images.githubusercontent.com/87961/34136066-f26f051c-e418-11e7-960d-3fdde1dca8f9.png)

