### PR TITLE
submit: fix resubmitting old URLs

### DIFF
--- a/app/views/stories/_form.html.erb
+++ b/app/views/stories/_form.html.erb
@@ -1,5 +1,5 @@
 <%= render :partial => "stories/form_errors", :locals => {
-  :story => f.object } %>
+  :f => f, :story => f.object } %>
 
 <div class="box">
   <% unless defined?(suggesting) %>

--- a/app/views/stories/_form_errors.html.erb
+++ b/app/views/stories/_form_errors.html.erb
@@ -24,6 +24,10 @@
 
     <% if defined?(f) %>
       <%= f.hidden_field :seen_previous %>
+    <% else %>
+      <%= form_for story do |f| %>
+        <%= f.hidden_field :seen_previous %>
+      <% end %>
     <% end %>
   <% end %>
 </div>


### PR DESCRIPTION
also now only requires hitting Submit a single time,
instead of twice, if you already see the AJAX warning

Fixes #440 