### PR TITLE
Set `Cache-Control` header for the assets

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -32,6 +32,11 @@ Lobsters::Application.configure do
   # Generate digests for assets URLs.
   config.assets.digest = true
 
+  # Specify how the assets should be cached by the browser
+  config.public_file_server.headers = {
+    'Cache-Control' => 'public, max-age=31536000'
+  }
+  
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 
   # Specifies the header that your server uses for sending files.


### PR DESCRIPTION
Since we use asset digests in the production environment, I think its beneficial if we also set max allowed Cache Control headers.

Reference: http://edgeguides.rubyonrails.org/asset_pipeline.html#cdns