### PR TITLE
Make SMTP settings configurable from the env

### DIFF
--- a/config/initializers/email.rb
+++ b/config/initializers/email.rb
@@ -1,6 +1,8 @@
 ActionMailer::Base.smtp_settings = {
-  :address => "127.0.0.1",
-  :port => 25,
+  :address => ENV.fetch("SMTP_HOST", "127.0.0.1"),
+  :port => Integer(ENV.fetch("SMTP_PORT", 25)),
   :domain => Rails.application.domain,
-  :enable_starttls_auto => false,
+  :enable_starttls_auto => ("true" == ENV["SMTP_STARTTLS_AUTO"]),
+  :user_name => ENV.fetch("SMTP_USERNAME", ""),
+  :password => ENV.fetch("SMTP_PASSWORD", ""),
 }


### PR DESCRIPTION
The changes made here does not affect how the older SMTP settings were configured. I have kept the earlier values as default and code won't break even if none of the environment values is not set.

I am curious how main lobsters site is running in production. Does this file is manually overwritten during deployment?