### PR TITLE
Avoid require memory leak with pathnames in load path

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -16,7 +16,7 @@ module Lobsters
     #config.autoload_paths += %W(#{config.root}/extras)
 
     # Eager load everything in extras/
-    config.eager_load_paths << Rails.root.join("extras")
+    config.eager_load_paths << Rails.root.join("extras").to_s
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.


### PR DESCRIPTION
Any ruby requires that occur in your application will leak with
Pathnames in the $LOAD_PATH in ruby 2.3/2.4.  Beyond that, it's faster
to use strings in the load path.  Please join this bug and add your
support for a fix:

https://bugs.ruby-lang.org/issues/14372