### PR TITLE
Feature: Configurable open signups

### DIFF
--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -7,7 +7,9 @@ class SignupController < ApplicationController
       flash[:error] = "You are already signed up."
       return redirect_to "/"
     end
-
+    if Rails.application.open_signups?
+      redirect_to action: :invited, invitation_code: 'open' and return
+    end
     @title = "Signup"
   end
 
@@ -21,32 +23,44 @@ class SignupController < ApplicationController
       return redirect_to "/"
     end
 
-    if !(@invitation = Invitation.where(:code => params[:invitation_code].to_s).first)
-      flash[:error] = "Invalid or expired invitation"
-      return redirect_to "/signup"
+    if not Rails.application.open_signups?
+      if !(@invitation = Invitation.where(:code => params[:invitation_code].to_s).first)
+        flash[:error] = "Invalid or expired invitation"
+        return redirect_to "/signup"
+      end
     end
 
     @title = "Signup"
 
     @new_user = User.new
-    @new_user.email = @invitation.email
+
+    if not Rails.application.open_signups?
+      @new_user.email = @invitation.email
+    end
 
     render :action => "invited"
   end
 
   def signup
-    if !(@invitation = Invitation.where(:code => params[:invitation_code].to_s).first)
-      flash[:error] = "Invalid or expired invitation."
-      return redirect_to "/signup"
+    if not Rails.application.open_signups?
+      if !(@invitation = Invitation.where(:code => params[:invitation_code].to_s).first)
+        flash[:error] = "Invalid or expired invitation."
+        return redirect_to "/signup"
+      end
     end
 
     @title = "Signup"
 
     @new_user = User.new(user_params)
-    @new_user.invited_by_user_id = @invitation.user_id
+
+    if not Rails.application.open_signups?
+      @new_user.invited_by_user_id = @invitation.user_id
+    end
 
     if @new_user.save
-      @invitation.destroy
+      if not Rails.application.open_signups?
+        @invitation.destroy
+      end
       session[:u] = @new_user.session_token
       flash[:success] = "Welcome to #{Rails.application.name}, " <<
         "#{@new_user.username}!"

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -91,6 +91,9 @@
         <% if lookup_context.template_exists?("footer", "layouts", true) %>
           <%= render :partial => "layouts/footer" %>
         <% else %>
+          <% if @user.blank? && Rails.application.open_signups? %>
+            <a href="/invitations/open">Join <%= Rails.application.name %></a>
+          <% end %>
           <a href="/moderations">Moderation Log</a>
           <% if @user && @user.can_see_invitation_requests? &&
           (iqc = InvitationRequest.verified_count) > 0 %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -91,7 +91,7 @@
         <% if lookup_context.template_exists?("footer", "layouts", true) %>
           <%= render :partial => "layouts/footer" %>
         <% else %>
-          <% if @user.blank? && Rails.application.open_signups? %>
+          <% if !@user && Rails.application.open_signups? %>
             <a href="/invitations/open">Join <%= Rails.application.name %></a>
           <% end %>
           <a href="/moderations">Moderation Log</a>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -60,6 +60,9 @@
             <a href="<%= u %>" class="<%= v[:class].join(" ") %>"><%=
               v[:title] %></a>
           <% end %>
+          <% if !@user && Rails.application.open_signups? %>
+            <strong><a href="/invitations/open" class="signup-text">Sign Up Now</a></strong>
+          <% end %>
         </span>
       </div>
 

--- a/app/views/login/index.html.erb
+++ b/app/views/login/index.html.erb
@@ -30,7 +30,7 @@
 
       <% if Rails.application.open_signups? %>
         <p>
-          Not a user yet? <a href="/invitations/open">Sign up here</a>
+          Not a user yet? <a href="/invitations/open">Sign up here</a>.
         </p>
       <% else %>
         <p>

--- a/app/views/login/index.html.erb
+++ b/app/views/login/index.html.erb
@@ -28,16 +28,22 @@
         <%= link_to "Reset your password", forgot_password_path %>.
       </p>
 
-      <p>
-      Not a user yet?  Signup is by invitation only to combat spam and increase
-      accountability.  If you know <a href="/u/">a current user</a> of the site,
-      ask them for an invitation or
-      <% if Rails.application.allow_invitation_requests? %>
-        <a href="/invitations/request">request one publicly</a>.
+      <% if Rails.application.open_signups? %>
+        <p>
+          Not a user yet? <a href="/invitations/open">Sign up here</a>
+        </p>
       <% else %>
-        request one in <a href="/chat">chat</a>.
+        <p>
+        Not a user yet?  Signup is by invitation only to combat spam and increase
+        accountability.  If you know <a href="/u/">a current user</a> of the site,
+        ask them for an invitation or
+        <% if Rails.application.allow_invitation_requests? %>
+          <a href="/invitations/request">request one publicly</a>.
+        <% else %>
+          request one in <a href="/chat">chat</a>.
+        <% end %>
+        </p>
       <% end %>
-      </p>
 
       <% if @referer.present? %>
         <%= hidden_field_tag :referer, @referer %>

--- a/app/views/signup/index.html.erb
+++ b/app/views/signup/index.html.erb
@@ -2,15 +2,20 @@
   <div class="legend">
     Create an Account
   </div>
-
-  <p>
-  Signup is currently by invitation only to combat spam and increase
-  accountability.  If you know <a href="/u/">a current user</a> of the site,
-  ask them for an invitation, or
-  <% if Rails.application.allow_invitation_requests? %>
-    <a href="/invitations/request">request one publicly</a>.
+  <% if Rails.application.open_signups? %>
+    <p>
+      Not a user yet? <a href="/invitations/open">Sign up here</a>
+    </p>
   <% else %>
-    request one in <a href="/chat">chat</a>.
+    <p>
+    Signup is currently by invitation only to combat spam and increase
+    accountability.  If you know <a href="/u/">a current user</a> of the site,
+    ask them for an invitation, or
+    <% if Rails.application.allow_invitation_requests? %>
+      <a href="/invitations/request">request one publicly</a>.
+    <% else %>
+      request one in <a href="/chat">chat</a>.
+    <% end %>
+    </p>
   <% end %>
-  </p>
 </div>

--- a/app/views/signup/index.html.erb
+++ b/app/views/signup/index.html.erb
@@ -4,7 +4,7 @@
   </div>
   <% if Rails.application.open_signups? %>
     <p>
-      Not a user yet? <a href="/invitations/open">Sign up here</a>
+      Not a user yet? <a href="/invitations/open">Sign up here</a>.
     </p>
   <% else %>
     <p>

--- a/app/views/signup/invited.html.erb
+++ b/app/views/signup/invited.html.erb
@@ -4,8 +4,6 @@
   </div>
 
   <%= form_for @new_user, { :url => signup_path } do |f| %>
-    <%= hidden_field_tag "invitation_code", @invitation.code %>
-
     <p>
     To create a new account, enter your e-mail address and a password.
     Your e-mail address will never be shown to users and will only be used
@@ -15,13 +13,16 @@
 
     <%= error_messages_for(@new_user) %>
 
-    <p>
-    <%= f.label :invitation, "Invited By:", :class => "required" %>
-    <span class="d">
-      <a href="/u/<%= @invitation.user.username %>" target="_blank"><%=
-        @invitation.user.username %></a>
-    </span>
-    </p>
+    <% if not Rails.application.open_signups? %>
+      <%= hidden_field_tag "invitation_code", @invitation.code %>
+      <p>
+      <%= f.label :invitation, "Invited By:", :class => "required" %>
+      <span class="d">
+        <a href="/u/<%= @invitation.user.username %>" target="_blank"><%=
+          @invitation.user.username %></a>
+      </span>
+      </p>
+    <% end %>
 
     <p>
     <%= f.label :username, "Username:", :class => "required" %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -54,7 +54,7 @@ class << Rails.application
   end
 
   def open_signups?
-    true
+    "true" == ENV["OPEN_SIGNUPS"]
   end
 
   def domain

--- a/config/application.rb
+++ b/config/application.rb
@@ -53,6 +53,10 @@ class << Rails.application
     true
   end
 
+  def open_signups?
+    true
+  end
+
   def domain
     "example.com"
   end


### PR DESCRIPTION
This PR lets you have complete open sign ups and is configurable with an env var. Set `OPEN_SIGNUPS=true`, any other string or absence of this env will be considered as false. So, existing Lobsters instance will run as expected. 

Changes:
1. If `OPEN_SIGNUPS` is not set or set to any value other than `true`, app works like earlier.
2. If `OPEN_SIGNUPS` is set to `true`, in the header there will be an item `Sign Up Now` and in footer `Join <site name>`, they both point to `/invitations/open`. 
3. I added a new CSS class `signup-text` which can be used to customize `Sign Up Now` text in header.

