### PR TITLE
Bugfix: render privacy page properly

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -44,9 +44,9 @@ class HomeController < ApplicationController
       @title = "Privacy"
       render :action => "privacy"
     rescue ActionView::MissingTemplate
-      render :html => "<div class=\"box wide\">" <<
+      render :html => ("<div class=\"box wide\">" <<
         "You apparently have no privacy." <<
-        "</div>", :layout => "application"
+        "</div>").html_safe, :layout => "application"
     end
   end
 


### PR DESCRIPTION
On a fresh install, this is how it looks:

<img width="1392" alt="screen shot 2018-02-03 at 2 44 30 pm" src="https://user-images.githubusercontent.com/640792/35765789-493489a6-08f1-11e8-9ec1-7b8b4cb30526.png">

This PR fixes above issue.