### PR TITLE
Added Docker container & docker-compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+# Copyright 2015, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+.git
+log/*
+tmp/*

--- a/.dockerignore
+++ b/.dockerignore
@@ -14,3 +14,4 @@
 .git
 log/*
 tmp/*
+Dockerfile

--- a/.dockerignore
+++ b/.dockerignore
@@ -15,3 +15,4 @@
 log/*
 tmp/*
 Dockerfile
+docker-compose.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,61 @@
+# Lobsters
+#
+# VERSION latest
+
+FROM ruby:2.3-alpine
+LABEL maintainer="lobsters"
+LABEL decription="Lobsters Rails Project"
+LABEL version="latest"
+
+# Setting this to true will retain linux
+# build tools and dev packages.
+ARG developer_build=false
+
+# Create lobsters user and group.
+RUN addgroup -S lobsters && adduser -S -h /lobsters -s /bin/sh -G lobsters lobsters
+
+# Install needed dependencies. If this is a developer_build, install build-deps as well.
+RUN apk --no-cache --update --virtual deps add mariadb-client-libs sqlite-libs tzdata nodejs \
+    && gem install bundler \
+    && if [ "${developer_build}" = "true" ]; then \
+        apk --no-cache --virtual build-deps add \
+            build-base gcc mariadb-dev linux-headers sqlite-dev; fi
+
+# Copy lobsters into the container.
+COPY ./ /lobsters
+
+# Install build-deps if needed and install gems. If this is a developer_build, we do not remove build-deps.
+RUN apk --no-cache --virtual build-deps add build-base gcc mariadb-dev linux-headers sqlite-dev \
+    && cd /lobsters \
+    && bundle install --no-cache \
+    && if [ "${developer_build}" = "false" ]; then apk del build-deps; fi \
+    && mv /lobsters/docker-assets/docker-entrypoint.sh /usr/local/bin/ \
+    && chmod 755 /usr/local/bin/docker-entrypoint.sh \
+    && mv /lobsters/docker-assets/config/database.yml /lobsters/config/ \
+    && mv /lobsters/docker-assets/config/initializers/production.rb /lobsters/config/initializers/ \
+    && mv /lobsters/docker-assets/config/initializers/secret_token.rb /lobsters/config/initializers/ \
+    && chown -R lobsters:lobsters /usr/local/bundle/ \
+    && chown -R lobsters:lobsters /lobsters
+
+# Set environment variables.
+ENV MARIADB_HOST="mariadb" \
+    MARIADB_PORT="3306" \
+    MARIADB_PASSWORD="password" \
+    MARIADB_USER="root" \
+    LOBSTER_DATABASE="lobsters" \
+    LOBSTER_HOSTNAME="localhost" \
+    LOBSTER_SITE_NAME="Example News" \
+    RAILS_ENV="development" \
+    SECRET_KEY=""
+
+# Drop down to unprivileged users
+USER lobsters
+
+# Set our working directory.
+WORKDIR /lobsters/
+
+# Expose HTTP port.
+EXPOSE 3000
+
+# Execute our entry script.
+CMD ["/usr/local/bin/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,28 +14,40 @@ ARG developer_build=false
 # Create lobsters user and group.
 RUN addgroup -S lobsters && adduser -S -h /lobsters -s /bin/sh -G lobsters lobsters
 
-# Install needed dependencies. If this is a developer_build, install build-deps as well.
+# Copy Gemfile to container.
+COPY Gemfile Gemfile.lock /lobsters/
+
+# Install needed runtime & development dependencies. If this is a developer_build we don't remove
+# the build-deps after doing a bundle install.
 RUN apk --no-cache --update --virtual deps add mariadb-client-libs sqlite-libs tzdata nodejs \
+    && apk --no-cache --virtual build-deps add build-base gcc mariadb-dev linux-headers sqlite-dev \
     && gem install bundler \
+    && cd /lobsters \
+    && bundle install --no-cache \
     && if [ "${developer_build}" = "true" ]; then \
-        apk --no-cache --virtual build-deps add \
-            build-base gcc mariadb-dev linux-headers sqlite-dev; fi
+          chown -R lobsters:lobsters /usr/local/bundle; \
+          chown -R lobsters:lobsters /usr/local/lib/ruby; \
+        else \
+          apk del build-deps; \
+        fi
 
 # Copy lobsters into the container.
 COPY ./ /lobsters
 
-# Install build-deps if needed and install gems. If this is a developer_build, we do not remove build-deps.
-RUN apk --no-cache --virtual build-deps add build-base gcc mariadb-dev linux-headers sqlite-dev \
-    && cd /lobsters \
-    && bundle install --no-cache \
-    && if [ "${developer_build}" = "false" ]; then apk del build-deps; fi \
+# Set proper permissions and move assets and configs.
+RUN chown -R lobsters:lobsters /lobsters \
     && mv /lobsters/docker-assets/docker-entrypoint.sh /usr/local/bin/ \
     && chmod 755 /usr/local/bin/docker-entrypoint.sh \
     && mv /lobsters/docker-assets/config/database.yml /lobsters/config/ \
     && mv /lobsters/docker-assets/config/initializers/production.rb /lobsters/config/initializers/ \
     && mv /lobsters/docker-assets/config/initializers/secret_token.rb /lobsters/config/initializers/ \
-    && chown -R lobsters:lobsters /usr/local/bundle/ \
-    && chown -R lobsters:lobsters /lobsters
+    && rm -rf /lobsters/docker-assets
+
+# Drop down to unprivileged users
+USER lobsters
+
+# Set our working directory.
+WORKDIR /lobsters/
 
 # Set environment variables.
 ENV MARIADB_HOST="mariadb" \
@@ -47,12 +59,6 @@ ENV MARIADB_HOST="mariadb" \
     LOBSTER_SITE_NAME="Example News" \
     RAILS_ENV="development" \
     SECRET_KEY=""
-
-# Drop down to unprivileged users
-USER lobsters
-
-# Set our working directory.
-WORKDIR /lobsters/
 
 # Expose HTTP port.
 EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,15 +21,14 @@ COPY Gemfile Gemfile.lock /lobsters/
 # the build-deps after doing a bundle install.
 RUN apk --no-cache --update --virtual deps add mariadb-client-libs sqlite-libs tzdata nodejs \
     && apk --no-cache --virtual build-deps add build-base gcc mariadb-dev linux-headers sqlite-dev \
-    && gem install bundler \
+    && export PATH=/lobsters/.gem/ruby/2.3.0/bin:$PATH \
+    && export GEM_HOME="/lobsters/.gem" \
+    && export GEM_PATH="/lobsters/.gem" \
+    && export BUNDLE_PATH="/lobsters/.bundle" \
     && cd /lobsters \
-    && bundle install --no-cache \
-    && if [ "${developer_build}" = "true" ]; then \
-          chown -R lobsters:lobsters /usr/local/bundle; \
-          chown -R lobsters:lobsters /usr/local/lib/ruby; \
-        else \
-          apk del build-deps; \
-        fi
+    && su lobsters -c "gem install bundler --user-install" \
+    && su lobsters -c "bundle install --no-cache" \
+    && if [ "${developer_build}" != "true" ]; then apk del build-deps; fi
 
 # Copy lobsters into the container.
 COPY ./ /lobsters
@@ -58,7 +57,11 @@ ENV MARIADB_HOST="mariadb" \
     LOBSTER_HOSTNAME="localhost" \
     LOBSTER_SITE_NAME="Example News" \
     RAILS_ENV="development" \
-    SECRET_KEY=""
+    SECRET_KEY="" \
+    GEM_HOME="/lobsters/.gem" \
+    GEM_PATH="/lobsters/.gem" \
+    BUNDLE_PATH="/lobsters/.bundle" \
+    PATH="/lobsters/.gem/ruby/2.3.0/bin:$PATH"
 
 # Expose HTTP port.
 EXPOSE 3000

--- a/docker-assets/config/database.yml
+++ b/docker-assets/config/database.yml
@@ -1,0 +1,25 @@
+default: &default
+  adapter: mysql2
+  encoding: utf8
+  reconnect: false
+  pool: 5
+  username: <%= ENV['MARIADB_USER'] %>
+  password: <%= ENV['MARIADB_PASSWORD'] %>
+  host: localhost
+  port: 3306
+  # please see the update below about using hostnames to
+  # access linked services via docker-compose
+  host: <%= ENV['MARIADB_HOST'] %>
+  port: <%= ENV['MARIADB_PORT'] %>
+
+development:
+  <<: *default
+  database: <%= ENV['LOBSTER_DATABASE'] %>_development
+
+test:
+  <<: *default
+  database: <%= ENV['LOBSTER_DATABASE'] %>_test
+
+production:
+  <<: *default
+  database: <%= ENV['LOBSTER_DATABASE'] %>_production

--- a/docker-assets/config/initializers/production.rb
+++ b/docker-assets/config/initializers/production.rb
@@ -1,0 +1,11 @@
+class << Rails.application
+  def domain
+    ENV["LOBSTER_HOSTNAME"]
+  end
+
+  def name
+    ENV["LOBSTER_SITE_NAME"]
+  end
+end
+
+Rails.application.routes.default_url_options[:host] = Rails.application.domain

--- a/docker-assets/config/initializers/secret_token.rb
+++ b/docker-assets/config/initializers/secret_token.rb
@@ -1,0 +1,1 @@
+Lobsters::Application.config.secret_key_base = ENV["SECRET_KEY"]

--- a/docker-assets/docker-entrypoint.sh
+++ b/docker-assets/docker-entrypoint.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+# TODO
+# This script could use additional logic.
+
+# Install any needed gems. This is useful if you mount
+# the project as a volume to /lobsters
+bundle install
+
+# Provision Database.
+if [ ! -e /var/tmp/first_run_completed ]; then
+  echo "Standing up database."
+  rake db:setup
+  touch /var/tmp/first_run_completed
+else
+  echo "Running database migrations."
+  rake db:migrate
+fi
+
+# Set out SECRET_KEY
+if [ "$SECRET_KEY" = "" ]; then
+  echo "No SECRET_KEY provided, generating one now."
+  export SECRET_KEY=$(bundle exec rake secret)
+  echo "Your new secret key: $SECRET_KEY"
+fi
+
+# Start the rails application.
+rails server -b 0.0.0.0 &
+pid="$!"
+trap "echo 'Stopping Lobsters - pid: $pid'; kill -SIGTERM $pid" SIGINT SIGTERM
+
+# Run the cron job every 5 minutes
+while : ; do
+  echo "Running cron jobs."
+  bundle exec ruby script/mail_new_activity
+  bundle exec ruby script/post_to_twitter
+  sleep 300
+done &
+
+# Wait for process to end.
+while kill -0 $pid > /dev/null 2>&1; do
+    wait
+done
+echo "Exiting"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,49 @@
+version: '2.1'
+
+services:
+  proxy:
+    image: jwilder/nginx-proxy
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+
+  database:
+    image: mariadb
+    environment:
+      - MYSQL_ROOT_PASSWORD=password
+      - MYSQL_DATABASE=lobsters
+    healthcheck:
+      test: "/usr/bin/mysql --user=root --password=password --execute \"SHOW DATABASES;\""
+      timeout: 5s
+      retries: 20
+    volumes:
+      - 'lobsters_database:/var/lib/mysql'
+
+  app:
+    build:
+      context: .
+      args:
+        developer_build: "false"
+    environment:
+      - MARIADB_HOST=database
+      - MARIADB_PORT=3306
+      - MARIADB_PASSWORD=password
+      - MARIADB_USER=root
+      - LOBSTER_DATABASE=lobsters
+      - LOBSTER_SITE_NAME="Example News"
+      - RAILS_ENV=development
+      - LOBSTER_HOSTNAME=localhost
+      - VIRTUAL_HOST=localhost
+    ports:
+      - "3000:3000"
+    depends_on:
+      database:
+        condition: service_healthy
+      proxy:
+        condition: service_started
+
+volumes:
+  lobsters_database:
+    driver: local


### PR DESCRIPTION
Not sure if you have any interest in having this in your public repo, but I had seen mention of it in previous issues and figured I would throw out a PR.

I have added a Dockerfile with some docker-assets, as well as
a docker-compose to fire up the app with minimal effort.

`docker-compose up` will build and run the application locally. You could additionally set the `developer_build` to `true` inside the docker-compose and add a volume pointing to `/lobsters` to use it for active development. 

I used alpine as the base image resulting in a very small image, about 270mb.