### PR TITLE
Fix broken dependency - Parser 2.5.0.4 has been yanked

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,7 +88,7 @@ GEM
       mini_portile2 (~> 2.3.0)
     oauth (0.5.4)
     parallel (1.12.1)
-    parser (2.5.0.4)
+    parser (2.5.0.5)
       ast (~> 2.4.0)
     powerpack (0.1.1)
     rack (2.0.4)


### PR DESCRIPTION
Updated parser to 2.5.0.5 as the previous version has
has been yanked by author, and no longer available.
https://rubygems.org/gems/parser/versions/2.5.0.4