### PR TITLE
Add Skylight instrumentation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem "jquery-rails", "~> 4.3"
 gem "dynamic_form"
 
 gem "exception_notification"
+gem "skylight"
 
 gem "bcrypt", "~> 3.1.2"
 gem "rotp"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,7 +88,7 @@ GEM
       mini_portile2 (~> 2.3.0)
     oauth (0.5.4)
     parallel (1.12.1)
-    parser (2.5.0.4)
+    parser (2.5.0.5)
       ast (~> 2.4.0)
     powerpack (0.1.1)
     rack (2.0.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,6 +155,8 @@ GEM
       railties (>= 4.0.0)
     scenic-mysql (0.1.0)
       scenic (>= 1.3)
+    skylight (1.6.0)
+      activesupport (>= 3.0.0)
     sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -204,6 +206,7 @@ DEPENDENCIES
   rubocop
   scenic
   scenic-mysql
+  skylight
   sqlite3
   uglifier (>= 1.3.0)
   unicorn


### PR DESCRIPTION
Closes #454

Skylight dashboard URL: https://oss.skylight.io/app/applications/UVOwCQJiWlFy

The dashboard is public, so any (potential) contributors will be able to access it without creating a Skylight account.

It currently doesn't have data yet, I will need to work with @pushcx to add an environment variable on production. I'll email the details off-thread (I sent it to your Git email, I hope that's okay).