### PR TITLE
Fixed padding issue for some dialogs on mobile devices

### DIFF
--- a/app/assets/stylesheets/mobile.css
+++ b/app/assets/stylesheets/mobile.css
@@ -49,7 +49,7 @@
 		margin: 0;
 	}
 
-	.box {
+	.help, .box {
 		margin: 0 8px;
 	}
 

--- a/app/views/replies/show.html.erb
+++ b/app/views/replies/show.html.erb
@@ -25,7 +25,7 @@
     <% end %>
   </ol>
 <% else %>
-  <p>No replies to show.</p>
+  <p class="help">No replies to show.</p>
 <% end %>
 
 <% if @replies.count > RepliesController::REPLIES_PER_PAGE && @filter != 'unread'%>


### PR DESCRIPTION
Pages like [search](https://lobste.rs/search) don't pad certain parts of the page on mobile devices (at least my browser), as can be seen in the following page:

![alter](https://a.safe.moe/xuN7qUU.png)

My patch just adds the same margin as `.box`'s receive on mobile devices, to instances of `.help`. This means that the desktop UI stays the same. The only thing I had to do, was to add the `.help` tag to `div`s outside of a `div.box`, so that they also get the necessary padding. This might slightly change the appearance of some boxes, if this is a problem, I can try and find another way to fix it.\

**Note:** I couldn't test this "properly" since I don't have all the rails stuff installed, and basically have no idea what is necessary _to be installed_. My suggestions are purely based on playing around with the inspection tools on Firefox and Chromium.