### PR TITLE
Added link to tags list on story submission page

### DIFF
--- a/app/views/stories/_form.html.erb
+++ b/app/views/stories/_form.html.erb
@@ -115,7 +115,7 @@
           </p></li>
 
           <li><p>
-          If no tags clearly apply to the story you are submitting, chances
+          If no <a href="/tags">tags</a> clearly apply to the story you are submitting, chances
           are it does not belong here.  Do not overreach with tags if they
           are not the primary focus of the story.
           </p></li>


### PR DESCRIPTION
This change would simply add a link to the "tags" page on the story submission page. Currently if a user would like to see a new list of tags, they would need to navigate through the about page.