### PR TITLE
Add hats to private messages

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -147,7 +147,7 @@ private
 
   def message_params
     params.require(:message).permit(
-      :recipient_username, :subject, :body,
+      :recipient_username, :subject, :body, :hat_id
     )
   end
 

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -15,6 +15,12 @@ class Message < ApplicationRecord
 
   validates :subject, length: { :in => 1..100 }
   validates :body, length: { :maximum => (64 * 1024) }
+  validate :hat do
+    next if hat.blank?
+    if author.blank? || author.wearable_hats.exclude?(hat)
+      errors.add(:hat, 'not wearable by author')
+    end
+  end
 
   scope :unread, -> { where(:has_been_read => false, :deleted_by_recipient => false) }
 

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -7,6 +7,7 @@ class Message < ApplicationRecord
              :class_name => "User",
              :foreign_key => "author_user_id",
              :inverse_of => :sent_messages
+  belongs_to :hat
 
   validates :recipient, presence: true
 

--- a/app/views/messages/index.html.erb
+++ b/app/views/messages/index.html.erb
@@ -35,17 +35,22 @@
       <% @messages.includes(:author, :recipient).each do |message| %>
         <tr class="<%= message.has_been_read? ? "" : "bold" %>">
           <td><%= check_box_tag "delete_#{message.short_id}" %></td>
-          <td><% if @direction == :in %>
-              <% if message.author %>
-                <a href="/u/<%= message.author.username %>"><%=
-                  message.author.username %></a>
+          <td>
+            <div style="white-space:nowrap;">
+              <% if @direction == :in %>
+                <% if message.author %>
+                  <a href="/u/<%= message.author.username %>"><%=
+                    message.author.username %></a>
+                <% else %>
+                  <%= message.author_username %>
+                <% end %>
+                <%= message.hat.to_html_label if message.hat %>
               <% else %>
-                <%= message.author_username %>
+                <a href="/u/<%= message.recipient.username %>"><%=
+                  message.recipient.username %></a>
               <% end %>
-            <% else %>
-              <a href="/u/<%= message.recipient.username %>"><%=
-                message.recipient.username %></a>
-            <% end %></td>
+            </div>
+          </td>
           <td><%= time_ago_in_words_label(message.created_at) %></td>
           <td><a href="/messages/<%= message.short_id %>"><%= message.subject
             %></a></td>
@@ -87,6 +92,14 @@
       <%= f.label :body, "Message:", :class => "required" %>
       <%= f.text_area :body, :style => "width: 500px;", :rows => 5 %>
     </div>
+
+    <% if @user.wearable_hats.any? %>
+      <div class="boxline">
+        <%= f.label :hat_id, 'Put on hat:', :class => "required" %>
+        <%= f.select "hat_id", options_from_collection_for_select(@user.hats, "id", "hat", nil), :include_blank => true %>
+      </div>
+      </div>
+    <% end %>
 
     <div class="boxline">
       <p></p>

--- a/app/views/messages/show.html.erb
+++ b/app/views/messages/show.html.erb
@@ -23,6 +23,7 @@
       <% else %>
         <%= @message.author_username %>
       <% end %>
+      <%= @message.hat.to_html_label if @message.hat %>
       to
       <a href="/u/<%= @message.recipient.username %>"><%=
         @message.recipient.username %></a>

--- a/db/migrate/20180503150810_add_hat_to_message.rb
+++ b/db/migrate/20180503150810_add_hat_to_message.rb
@@ -1,0 +1,7 @@
+class AddHatToMessage < ActiveRecord::Migration[5.1]
+
+  def change
+    add_reference :messages, :hat, index: true
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180411131217) do
+ActiveRecord::Schema.define(version: 20180503150810) do
 
   create_table "comments", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.datetime "created_at", null: false
@@ -99,6 +99,8 @@ ActiveRecord::Schema.define(version: 20180411131217) do
     t.string "short_id", limit: 30
     t.boolean "deleted_by_author", default: false
     t.boolean "deleted_by_recipient", default: false
+    t.bigint "hat_id"
+    t.index ["hat_id"], name: "index_messages_on_hat_id"
     t.index ["short_id"], name: "random_hash", unique: true
   end
 

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -5,4 +5,17 @@ describe Message do
     m = Message.make!
     expect(m.short_id).to match(/^\A[a-zA-Z0-9]{1,10}\z/)
   end
+  describe "hat_id" do
+    it "must be wearable by author" do
+      expect {
+        Message.make!(hat: Hat.make!)
+      }.to raise_error(ActiveRecord::RecordInvalid, /hat/i)
+
+      user = User.make!
+      hat = Hat.make!(user_id: user.id)
+      expect {
+        Message.make!(author_user_id: user.id, hat: hat)
+      }.to_not raise_error
+    end
+  end
 end

--- a/spec/support/blueprints.rb
+++ b/spec/support/blueprints.rb
@@ -32,6 +32,13 @@ Story.blueprint do
   tags_a { ["tag1", "tag2"] }
 end
 
+Hat.blueprint do
+  user_id { User.make!.id }
+  hat { "hat #{rand}" }
+  granted_by_user_id { User.make!.id }
+  link { 'http://example.com' }
+end
+
 Comment.blueprint do
   user_id { User.make!.id }
   story_id { Story.make!.id }
@@ -43,6 +50,7 @@ Message.blueprint do
   author_user_id { User.make!.id }
   subject { "message subject #{sn}" }
   body { "message body #{sn}" }
+  hat { nil }
 end
 
 Vote.blueprint do


### PR DESCRIPTION
Users with hats can add a hat to a private message.  Hat is visible in inbox next to username.

<!--
Issues and PRs are typically reviewed Wednesday and some Thursday mornings.
-->
