### PR TITLE
filter by tag and domain when searching for comments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,4 +47,5 @@ group :test, :development do
   gem "sqlite3"
   gem "faker"
   gem "byebug"
+  gem "rb-readline"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,6 +153,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
+    rb-readline (0.5.5)
     rotp (3.3.1)
     rqrcode (0.10.1)
       chunky_png (~> 1.0)
@@ -241,6 +242,7 @@ DEPENDENCIES
   nokogiri (>= 1.7.2)
   oauth
   rails (~> 5.2.0)
+  rb-readline
   rotp
   rqrcode
   rspec-rails


### PR DESCRIPTION
Fix to issue [#491 Comment search doesn't use tag/domain scope.](https://github.com/lobsters/lobsters/issues/491).

<!--
Issues and PRs are typically reviewed Wednesday and some Thursday mornings.
-->
