### PR TITLE
Use `scenic-mysql_adapter` over `scenic-mysql`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem "mysql2", "~> 0.3.20"
 # gem "pg"
 
 gem 'scenic'
-gem 'scenic-mysql'
+gem 'scenic-mysql_adapter'
 
 gem "uglifier", ">= 1.3.0"
 gem "jquery-rails", "~> 4.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,8 +163,9 @@ GEM
     scenic (1.4.1)
       activerecord (>= 4.0.0)
       railties (>= 4.0.0)
-    scenic-mysql (0.1.0)
-      scenic (>= 1.3)
+    scenic-mysql_adapter (1.0.1)
+      mysql2
+      scenic (>= 1.4.0)
     sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -216,7 +217,7 @@ DEPENDENCIES
   rspec-rails
   rubocop
   scenic
-  scenic-mysql
+  scenic-mysql_adapter
   sqlite3
   uglifier (>= 1.3.0)
   unicorn

--- a/config/initializers/senic.rb
+++ b/config/initializers/senic.rb
@@ -1,3 +1,3 @@
 Scenic.configure do |config|
-  config.database = Scenic::Adapters::Mysql.new
+  config.database = Scenic::Adapters::MySQL.new
 end


### PR DESCRIPTION
[scenic-mysql](https://github.com/rennanoliveira/scenic-mysql) hasn't been updated in a while and is missing code [to remove the table name from the view in the schema dump](https://github.com/EmpaticoOrg/scenic-mysql_adapter/blob/master/lib/scenic/adapters/my_sql.rb#L86). This should resolve:

* The db/schema.rb churn for new contributes
* Issues with setting up a new database from the schema 