### PR TITLE
use sha1 digests

### DIFF
--- a/config/initializers/new_framework_defaults_5_2.rb
+++ b/config/initializers/new_framework_defaults_5_2.rb
@@ -32,4 +32,4 @@ Rails.application.config.active_record.cache_versioning = true
 Rails.application.config.active_record.sqlite3.represent_boolean_as_integer = true
 
 # Use SHA-1 instead of MD5 to generate non-sensitive digests, such as the ETag header.
-# Rails.application.config.active_support.use_sha1_digests = true
+Rails.application.config.active_support.use_sha1_digests = true


### PR DESCRIPTION
https://github.com/lobsters/lobsters/issues/509

from http://guides.rubyonrails.org/configuring.html

> config.active_support.use_sha1_digests specifies whether to use SHA-1 instead of MD5 to generate non-sensitive digests, such as the ETag header. Defaults to false.