### PR TITLE
enable default_protect_from_forgery and use_authenticated_message_encryption

### DIFF
--- a/config/initializers/new_framework_defaults_5_2.rb
+++ b/config/initializers/new_framework_defaults_5_2.rb
@@ -25,7 +25,7 @@ Rails.application.config.active_record.cache_versioning = true
 
 # Add default protection from forgery to ActionController::Base instead of in
 # ApplicationController.
-# Rails.application.config.action_controller.default_protect_from_forgery = true
+Rails.application.config.action_controller.default_protect_from_forgery = true
 
 # Store boolean values are in sqlite3 databases as 1 and 0 instead of 't' and
 # 'f' after migrating old data.

--- a/config/initializers/new_framework_defaults_5_2.rb
+++ b/config/initializers/new_framework_defaults_5_2.rb
@@ -21,7 +21,7 @@ Rails.application.config.active_record.cache_versioning = true
 
 # Use AES-256-GCM authenticated encryption as default cipher for encrypting messages
 # instead of AES-256-CBC, when use_authenticated_message_encryption is set to true.
-# Rails.application.config.active_support.use_authenticated_message_encryption = true
+Rails.application.config.active_support.use_authenticated_message_encryption = true
 
 # Add default protection from forgery to ActionController::Base instead of in
 # ApplicationController.


### PR DESCRIPTION
https://github.com/lobsters/lobsters/issues/509

from http://guides.rubyonrails.org/configuring.html

> config.action_controller.default_protect_from_forgery determines
> whether forgery protection is added on ActionController:Base. This is
> false by default, but enabled when loading defaults for Rails 5.2.

rails pull request: https://github.com/rails/rails/issues/29193