### PR TITLE
enable use_authenticated_cookie_encryption

### DIFF
--- a/config/initializers/new_framework_defaults_5_2.rb
+++ b/config/initializers/new_framework_defaults_5_2.rb
@@ -17,7 +17,7 @@ Rails.application.config.active_record.cache_versioning = true
 # It's best enabled when your entire app is migrated and stable on 5.2.
 #
 # Existing cookies will be converted on read then written with the new scheme.
-# Rails.application.config.action_dispatch.use_authenticated_cookie_encryption = true
+Rails.application.config.action_dispatch.use_authenticated_cookie_encryption = true
 
 # Use AES-256-GCM authenticated encryption as default cipher for encrypting messages
 # instead of AES-256-CBC, when use_authenticated_message_encryption is set to true.

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -39,3 +39,6 @@ RSpec.configure do |config|
 end
 
 RSpec::Expectations.configuration.on_potential_false_positives = :nothing
+
+# Checks for pending migration and applies them before tests are run.
+ActiveRecord::Migration.maintain_test_schema!


### PR DESCRIPTION
Fixes all of the individual configuration settings on https://github.com/lobsters/lobsters/issues/509
The next step will be to enable 5.2 defaults and remove these initializer files.

from the comments:
```
Use AES-256-GCM authenticated encryption for encrypted cookies.
Also, embed cookie expiry in signed or encrypted cookies for increased security.

This option is not backwards compatible with earlier Rails versions.
It's best enabled when your entire app is migrated and stable on 5.2.

Existing cookies will be converted on read then written with the new scheme.
```