### PR TITLE
Don't italizice em tags inside blockquotes

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -112,7 +112,6 @@ pre {
 	overflow-x: auto;
 }
 
-
 /* default form styling */
 
 input,
@@ -795,6 +794,14 @@ div.story_text blockquote {
 	padding: 0 0 0 1em;
 	border-left: 2px solid gray;
 }
+
+/* un-italicize italics inside a blockquote */
+div.comment_text blockquote em, 
+div.markdown_help blockquote em, 
+div.story_text blockquote em {
+    font-style: normal
+}
+
 div#collapsed_story_text div.story_text blockquote {
 	font-style: normal;
 }


### PR DESCRIPTION
Fixes: https://lobste.rs/s/wiwt7a/can_we_get_italics_work_within_block

Just tested this in the Firefox inspector 