### PR TITLE
Fix story tags not being rendered in preview

### DIFF
--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -624,8 +624,7 @@ class Story < ApplicationRecord
           # we can't lookup whether the user is allowed to use this tag yet
           # because we aren't assured to have a user_id by now; we'll do it in
           # the validation with check_tags
-          tg = self.taggings.build
-          tg.tag_id = t.id
+          self.tags << t
         end
       end
     end


### PR DESCRIPTION
https://github.com/lobsters/lobsters/issues/522

Accessing tags from a story involves a database query. For records that haven't been persisted yet, resorting to fetch tags from the instantiated taggings.