### PR TITLE
Fix migrations rails5

### DIFF
--- a/db/migrate/00000000000000_create_users.rb
+++ b/db/migrate/00000000000000_create_users.rb
@@ -1,0 +1,18 @@
+class CreateUsers < ActiveRecord::Migration[4.2]
+  def change
+    create_table "users", id: :bigint, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+      t.string "username", limit: 50, collation: "utf8mb4_general_ci"
+      t.string "email", limit: 100, collation: "utf8mb4_general_ci"
+      t.string "password_digest", limit: 75, collation: "utf8mb4_general_ci"
+      t.datetime "created_at"
+      t.boolean "is_admin", default: false
+      t.string "password_reset_token", limit: 75, collation: "utf8mb4_general_ci"
+      t.string "session_token", limit: 75, default: "", null: false, collation: "utf8mb4_general_ci"
+      t.text "about", limit: 16777215, collation: "utf8mb4_general_ci"
+      t.boolean "email_notifications", default: true
+      t.index ["password_reset_token"], name: "password_reset_token", unique: true
+      t.index ["session_token"], name: "session_hash", unique: true
+      t.index ["username"], name: "username", unique: true
+    end
+  end
+end

--- a/db/migrate/00000000000001_create_stories.rb
+++ b/db/migrate/00000000000001_create_stories.rb
@@ -1,0 +1,20 @@
+class CreateStories < ActiveRecord::Migration[4.2]
+  def change
+    create_table "stories", id: :bigint, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+      t.datetime "created_at"
+      t.bigint "user_id", null: false, unsigned: true
+      t.string "url", limit: 250, default: ""
+      t.string "title", limit: 150, default: "", null: false
+      t.text "description", limit: 16777215
+      t.string "short_id", limit: 6, default: "", null: false
+      t.boolean "is_expired", default: false, null: false
+      t.integer "upvotes", default: 0, null: false, unsigned: true
+      t.integer "downvotes", default: 0, null: false, unsigned: true
+      t.boolean "is_moderated", default: false, null: false
+      t.index ["is_expired"], name: "index_stories_on_is_expired"
+      t.index ["is_moderated"], name: "index_stories_on_is_moderated"
+      t.index ["short_id"], name: "unique_short_id", unique: true
+      t.index ["url"], name: "url", length: 191
+    end
+  end
+end

--- a/db/migrate/00000000000002_create_comments.rb
+++ b/db/migrate/00000000000002_create_comments.rb
@@ -1,0 +1,20 @@
+class CreateComments < ActiveRecord::Migration[4.2]
+  def change
+    create_table "comments", id: :bigint, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+      t.datetime "created_at", null: false
+      t.datetime "updated_at"
+      t.string "short_id", limit: 10, default: "", null: false
+      t.bigint "story_id", null: false, unsigned: true
+      t.bigint "user_id", null: false, unsigned: true
+      t.bigint "parent_comment_id", unsigned: true
+      t.bigint "thread_id", unsigned: true
+      t.text "comment", limit: 16777215, null: false
+      t.integer "upvotes", default: 0, null: false
+      t.integer "downvotes", default: 0, null: false
+      t.index ["parent_comment_id"], name: "comments_parent_comment_id_fk"
+      t.index ["short_id"], name: "short_id", unique: true
+      t.index ["story_id", "short_id"], name: "story_id_short_id"
+      t.index ["thread_id"], name: "thread_id"
+    end
+  end
+end

--- a/db/migrate/00000000000003_create_messages.rb
+++ b/db/migrate/00000000000003_create_messages.rb
@@ -1,0 +1,15 @@
+class CreateMessages < ActiveRecord::Migration[4.2]
+  def change
+    create_table "messages", id: :bigint, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+      t.datetime "created_at"
+      t.bigint "author_user_id", null: false, unsigned: true
+      t.bigint "recipient_user_id", null: false, unsigned: true
+      t.boolean "has_been_read", default: false
+      t.string "subject", limit: 100
+      t.text "body", limit: 16777215
+      t.string "random_hash", limit: 30
+      t.index ["recipient_user_id"], name: "messages_recipient_user_id_fk"
+      t.index ["random_hash"], name: "random_hash", unique: true
+    end
+  end
+end

--- a/db/migrate/00000000000004_create_keystores.rb
+++ b/db/migrate/00000000000004_create_keystores.rb
@@ -1,0 +1,9 @@
+class CreateKeystores < ActiveRecord::Migration[4.2]
+  def change
+    create_table "keystores", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+      t.string "key", limit: 50, default: "", null: false
+      t.bigint "value"
+      t.index ["key"], name: "key", unique: true
+    end
+  end
+end

--- a/db/migrate/00000000000005_create_tags.rb
+++ b/db/migrate/00000000000005_create_tags.rb
@@ -1,0 +1,9 @@
+class CreateTags < ActiveRecord::Migration[4.2]
+  def change
+    create_table "tags", id: :bigint, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+      t.string "tag", limit: 25, null: false
+      t.string "description", limit: 100
+      t.index ["tag"], name: "tag", unique: true
+    end
+  end
+end

--- a/db/migrate/00000000000006_create_votes.rb
+++ b/db/migrate/00000000000006_create_votes.rb
@@ -1,0 +1,14 @@
+class CreateVotes < ActiveRecord::Migration[4.2]
+  def change
+    create_table "votes", id: :bigint, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+      t.bigint "user_id", null: false, unsigned: true
+      t.bigint "story_id", null: false, unsigned: true
+      t.bigint "comment_id", unsigned: true
+      t.integer "vote", limit: 1, null: false
+      t.string "reason", limit: 1
+      t.index ["story_id"], name: "votes_story_id_fk"
+      t.index ["user_id", "comment_id"], name: "user_id_comment_id"
+      t.index ["user_id", "story_id"], name: "user_id_story_id"
+    end
+  end
+end

--- a/db/migrate/00000000000007_create_taggings.rb
+++ b/db/migrate/00000000000007_create_taggings.rb
@@ -1,0 +1,10 @@
+class CreateTaggings < ActiveRecord::Migration[4.2]
+  def change
+    create_table "taggings", id: :bigint, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+      t.bigint "story_id", null: false, unsigned: true
+      t.bigint "tag_id", null: false, unsigned: true
+      t.index ["story_id", "tag_id"], name: "story_id_tag_id", unique: true
+      t.index ["tag_id"], name: "taggings_tag_id_fk"
+    end
+  end
+end

--- a/db/migrate/20120701154453_create_invitations.rb
+++ b/db/migrate/20120701154453_create_invitations.rb
@@ -1,4 +1,4 @@
-class CreateInvitations < ActiveRecord::Migration
+class CreateInvitations < ActiveRecord::Migration[4.2]
   def change
     create_table :invitations do |t|
       t.integer :user_id

--- a/db/migrate/20120701160006_reply_notifications.rb
+++ b/db/migrate/20120701160006_reply_notifications.rb
@@ -1,4 +1,4 @@
-class ReplyNotifications < ActiveRecord::Migration
+class ReplyNotifications < ActiveRecord::Migration[4.2]
   def up
     add_column :users, :email_replies, :boolean, :default => false
     add_column :users, :pushover_replies, :boolean, :default => false

--- a/db/migrate/20120701181319_invitation_memo.rb
+++ b/db/migrate/20120701181319_invitation_memo.rb
@@ -1,4 +1,4 @@
-class InvitationMemo < ActiveRecord::Migration
+class InvitationMemo < ActiveRecord::Migration[4.2]
   def up
     add_column :invitations, :memo, :text
   end

--- a/db/migrate/20120703184957_integrated_story_hotness.rb
+++ b/db/migrate/20120703184957_integrated_story_hotness.rb
@@ -1,4 +1,4 @@
-class IntegratedStoryHotness < ActiveRecord::Migration
+class IntegratedStoryHotness < ActiveRecord::Migration[4.2]
   def up
     add_column :stories, :hotness, :decimal, :precision => 20, :scale => 10
     add_column :comments, :confidence, :decimal, :precision => 20, :scale => 19

--- a/db/migrate/20120704004020_fix_up_messages.rb
+++ b/db/migrate/20120704004020_fix_up_messages.rb
@@ -1,4 +1,4 @@
-class FixUpMessages < ActiveRecord::Migration
+class FixUpMessages < ActiveRecord::Migration[4.2]
   def up
     rename_column :messages, :random_hash, :short_id
 

--- a/db/migrate/20120704013019_pm_notification_options.rb
+++ b/db/migrate/20120704013019_pm_notification_options.rb
@@ -1,4 +1,4 @@
-class PmNotificationOptions < ActiveRecord::Migration
+class PmNotificationOptions < ActiveRecord::Migration[4.2]
   def up
     change_table :messages do |t|
       t.change :has_been_read, :boolean, :default => false

--- a/db/migrate/20120704025956_user_filter.rb
+++ b/db/migrate/20120704025956_user_filter.rb
@@ -1,4 +1,4 @@
-class UserFilter < ActiveRecord::Migration
+class UserFilter < ActiveRecord::Migration[4.2]
   def up
     create_table :tag_filters do |t|
       t.timestamps :null => false

--- a/db/migrate/20120705145520_move_markdown_into_sql.rb
+++ b/db/migrate/20120705145520_move_markdown_into_sql.rb
@@ -1,4 +1,4 @@
-class MoveMarkdownIntoSql < ActiveRecord::Migration
+class MoveMarkdownIntoSql < ActiveRecord::Migration[4.2]
   def up
     add_column :comments, :markeddown_comment, :text
     add_column :stories, :markeddown_description, :text

--- a/db/migrate/20120706221602_more_indexes.rb
+++ b/db/migrate/20120706221602_more_indexes.rb
@@ -1,4 +1,4 @@
-class MoreIndexes < ActiveRecord::Migration
+class MoreIndexes < ActiveRecord::Migration[4.2]
   def up
     add_index :stories, [ "is_expired", "is_moderated" ],
       :name => "is_idxes"

--- a/db/migrate/20120712174445_add_comment_deleted.rb
+++ b/db/migrate/20120712174445_add_comment_deleted.rb
@@ -1,4 +1,4 @@
-class AddCommentDeleted < ActiveRecord::Migration
+class AddCommentDeleted < ActiveRecord::Migration[4.2]
   def up
     add_column "comments", "is_deleted", :boolean, :default => false
     add_column "comments", "is_moderated", :boolean, :default => false

--- a/db/migrate/20120816203248_keystore_bigint.rb
+++ b/db/migrate/20120816203248_keystore_bigint.rb
@@ -1,4 +1,4 @@
-class KeystoreBigint < ActiveRecord::Migration
+class KeystoreBigint < ActiveRecord::Migration[4.2]
   def up
     change_column :keystores, :value, :integer, :limit => 8
   end

--- a/db/migrate/20120902143549_add_moderation_log.rb
+++ b/db/migrate/20120902143549_add_moderation_log.rb
@@ -1,4 +1,4 @@
-class AddModerationLog < ActiveRecord::Migration
+class AddModerationLog < ActiveRecord::Migration[4.2]
   def up
     add_column "users", "is_moderator", :boolean, :default => false
 

--- a/db/migrate/20120906183346_default_filtered_tags.rb
+++ b/db/migrate/20120906183346_default_filtered_tags.rb
@@ -1,4 +1,4 @@
-class DefaultFilteredTags < ActiveRecord::Migration
+class DefaultFilteredTags < ActiveRecord::Migration[4.2]
   def up
     add_column :tags, :filtered_by_default, :boolean, :default => false
   end

--- a/db/migrate/20120910172514_mention_notification_options.rb
+++ b/db/migrate/20120910172514_mention_notification_options.rb
@@ -1,4 +1,4 @@
-class MentionNotificationOptions < ActiveRecord::Migration
+class MentionNotificationOptions < ActiveRecord::Migration[4.2]
   def up
     add_column :users, :email_mentions, :boolean, :default => false
     add_column :users, :pushover_mentions, :boolean, :default => false

--- a/db/migrate/20120918152116_private_rss_feed.rb
+++ b/db/migrate/20120918152116_private_rss_feed.rb
@@ -1,4 +1,4 @@
-class PrivateRssFeed < ActiveRecord::Migration
+class PrivateRssFeed < ActiveRecord::Migration[4.2]
   def up
     add_column :users, :rss_token, :string
   end

--- a/db/migrate/20120919195401_private_tags.rb
+++ b/db/migrate/20120919195401_private_tags.rb
@@ -1,4 +1,4 @@
-class PrivateTags < ActiveRecord::Migration
+class PrivateTags < ActiveRecord::Migration[4.2]
   def up
     add_column :tags, :privileged, :boolean, :default => false
 

--- a/db/migrate/20121004153529_add_story_text.rb
+++ b/db/migrate/20121004153529_add_story_text.rb
@@ -1,4 +1,4 @@
-class AddStoryText < ActiveRecord::Migration
+class AddStoryText < ActiveRecord::Migration[4.2]
   def up
     add_column :stories, :story_cache, :text
   end

--- a/db/migrate/20121112165212_add_tag_media_types.rb
+++ b/db/migrate/20121112165212_add_tag_media_types.rb
@@ -1,4 +1,4 @@
-class AddTagMediaTypes < ActiveRecord::Migration
+class AddTagMediaTypes < ActiveRecord::Migration[4.2]
   def up
     add_column :tags, :is_media, :boolean, :default => false
 

--- a/db/migrate/20130526164230_change_tables_to_utf8mb4.rb
+++ b/db/migrate/20130526164230_change_tables_to_utf8mb4.rb
@@ -1,4 +1,4 @@
-class ChangeTablesToUtf8mb4 < ActiveRecord::Migration
+class ChangeTablesToUtf8mb4 < ActiveRecord::Migration[4.2]
   def up
     return if connection.adapter_name !~ /Mysql/
 

--- a/db/migrate/20130622021035_add_user_list_id.rb
+++ b/db/migrate/20130622021035_add_user_list_id.rb
@@ -1,4 +1,4 @@
-class AddUserListId < ActiveRecord::Migration
+class AddUserListId < ActiveRecord::Migration[4.2]
   def up
     add_column :users, :mailing_list_token, :string
     add_column :users, :mailing_list_enabled, :boolean, :default => false

--- a/db/migrate/20131018201413_add_invitation_requests.rb
+++ b/db/migrate/20131018201413_add_invitation_requests.rb
@@ -1,4 +1,4 @@
-class AddInvitationRequests < ActiveRecord::Migration
+class AddInvitationRequests < ActiveRecord::Migration[4.2]
   def up
     create_table :invitation_requests do |t|
       t.string :code

--- a/db/migrate/20131228175805_add_comment_by_email_flag.rb
+++ b/db/migrate/20131228175805_add_comment_by_email_flag.rb
@@ -1,4 +1,4 @@
-class AddCommentByEmailFlag < ActiveRecord::Migration
+class AddCommentByEmailFlag < ActiveRecord::Migration[4.2]
   def up
     add_column :comments, :is_from_email, :boolean, :default => false
   end

--- a/db/migrate/20140101202252_add_karma_to_users.rb
+++ b/db/migrate/20140101202252_add_karma_to_users.rb
@@ -1,4 +1,4 @@
-class AddKarmaToUsers < ActiveRecord::Migration
+class AddKarmaToUsers < ActiveRecord::Migration[4.2]
   def up
     add_column :users, :karma, :integer, :default => 0, :null => false
 

--- a/db/migrate/20140106205200_remove_tag_filtered_by_default.rb
+++ b/db/migrate/20140106205200_remove_tag_filtered_by_default.rb
@@ -1,4 +1,4 @@
-class RemoveTagFilteredByDefault < ActiveRecord::Migration
+class RemoveTagFilteredByDefault < ActiveRecord::Migration[4.2]
   def change
     remove_column :tags, :filtered_by_default
   end

--- a/db/migrate/20140109034338_move_comment_counts_to_story.rb
+++ b/db/migrate/20140109034338_move_comment_counts_to_story.rb
@@ -1,4 +1,4 @@
-class MoveCommentCountsToStory < ActiveRecord::Migration
+class MoveCommentCountsToStory < ActiveRecord::Migration[4.2]
   def up
     add_column :stories, :comments_count, :integer, :default => 0,
       :null => false

--- a/db/migrate/20140112192936_add_ban_reason.rb
+++ b/db/migrate/20140112192936_add_ban_reason.rb
@@ -1,4 +1,4 @@
-class AddBanReason < ActiveRecord::Migration
+class AddBanReason < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :banned_at, :datetime
     add_column :users, :banned_by_user_id, :integer

--- a/db/migrate/20140113153413_add_account_deletion.rb
+++ b/db/migrate/20140113153413_add_account_deletion.rb
@@ -1,4 +1,4 @@
-class AddAccountDeletion < ActiveRecord::Migration
+class AddAccountDeletion < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :deleted_at, :datetime
   end

--- a/db/migrate/20140121063641_pushover_sound.rb
+++ b/db/migrate/20140121063641_pushover_sound.rb
@@ -1,4 +1,4 @@
-class PushoverSound < ActiveRecord::Migration
+class PushoverSound < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :pushover_sound, :string
   end

--- a/db/migrate/20140219183804_change_mailing_list_enabled.rb
+++ b/db/migrate/20140219183804_change_mailing_list_enabled.rb
@@ -1,4 +1,4 @@
-class ChangeMailingListEnabled < ActiveRecord::Migration
+class ChangeMailingListEnabled < ActiveRecord::Migration[4.2]
   def change
     rename_column :users, :mailing_list_enabled, :mailing_list_mode
     change_column :users, :mailing_list_mode, :integer, :default => 0

--- a/db/migrate/20140221164400_inactive_tags.rb
+++ b/db/migrate/20140221164400_inactive_tags.rb
@@ -1,4 +1,4 @@
-class InactiveTags < ActiveRecord::Migration
+class InactiveTags < ActiveRecord::Migration[4.2]
   def change
     add_column :tags, :inactive, :boolean, :default => false
   end

--- a/db/migrate/20140408160306_add_story_merging.rb
+++ b/db/migrate/20140408160306_add_story_merging.rb
@@ -1,4 +1,4 @@
-class AddStoryMerging < ActiveRecord::Migration
+class AddStoryMerging < ActiveRecord::Migration[4.2]
   def change
     add_column :stories, :merged_story_id, :integer
     add_index "stories", [ "merged_story_id" ]

--- a/db/migrate/20140701153554_add_user_weblog_url.rb
+++ b/db/migrate/20140701153554_add_user_weblog_url.rb
@@ -1,4 +1,4 @@
-class AddUserWeblogUrl < ActiveRecord::Migration
+class AddUserWeblogUrl < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :weblog_feed_url, :string, :length => 500
   end

--- a/db/migrate/20140804005415_add_weblogs.rb
+++ b/db/migrate/20140804005415_add_weblogs.rb
@@ -1,4 +1,4 @@
-class AddWeblogs < ActiveRecord::Migration
+class AddWeblogs < ActiveRecord::Migration[4.2]
   def change
     create_table :weblogs do |t|
       t.timestamps

--- a/db/migrate/20140825225915_add_tag_hotness_mod.rb
+++ b/db/migrate/20140825225915_add_tag_hotness_mod.rb
@@ -1,4 +1,4 @@
-class AddTagHotnessMod < ActiveRecord::Migration
+class AddTagHotnessMod < ActiveRecord::Migration[4.2]
   def change
     add_column :tags, :hotness_mod, :integer, :default => 0
   end

--- a/db/migrate/20140901013149_drop_weblogs.rb
+++ b/db/migrate/20140901013149_drop_weblogs.rb
@@ -1,4 +1,4 @@
-class DropWeblogs < ActiveRecord::Migration
+class DropWeblogs < ActiveRecord::Migration[4.2]
   def change
     drop_table :weblogs
     remove_column :users, :weblog_feed_url

--- a/db/migrate/20141114184921_add_hats.rb
+++ b/db/migrate/20141114184921_add_hats.rb
@@ -1,4 +1,4 @@
-class AddHats < ActiveRecord::Migration
+class AddHats < ActiveRecord::Migration[4.2]
   def change
     create_table :hats do |t|
       t.timestamps

--- a/db/migrate/20150106195555_add_story_unavailable.rb
+++ b/db/migrate/20150106195555_add_story_unavailable.rb
@@ -1,4 +1,4 @@
-class AddStoryUnavailable < ActiveRecord::Migration
+class AddStoryUnavailable < ActiveRecord::Migration[4.2]
   def change
     add_column :stories, :unavailable_at, :datetime
   end

--- a/db/migrate/20150115172138_drop_extra_pushover_fields.rb
+++ b/db/migrate/20150115172138_drop_extra_pushover_fields.rb
@@ -1,4 +1,4 @@
-class DropExtraPushoverFields < ActiveRecord::Migration
+class DropExtraPushoverFields < ActiveRecord::Migration[4.2]
   # extra pushover data is now stored in the subscription, we don't need it
   #
   # user keys to subscription keys can be migrated by using

--- a/db/migrate/20150127180326_add_story_twitter_id.rb
+++ b/db/migrate/20150127180326_add_story_twitter_id.rb
@@ -1,4 +1,4 @@
-class AddStoryTwitterId < ActiveRecord::Migration
+class AddStoryTwitterId < ActiveRecord::Migration[4.2]
   def change
     add_column :stories, :twitter_id, :string, :limit => 20
     add_index :stories, [ :twitter_id ]

--- a/db/migrate/20150211170052_move_hidden_votes_to_hidden_story.rb
+++ b/db/migrate/20150211170052_move_hidden_votes_to_hidden_story.rb
@@ -1,4 +1,4 @@
-class MoveHiddenVotesToHiddenStory < ActiveRecord::Migration
+class MoveHiddenVotesToHiddenStory < ActiveRecord::Migration[4.2]
   def up
     create_table :hidden_stories do |t|
       t.integer :user_id

--- a/db/migrate/20150224035617_hotness_mod_to_float.rb
+++ b/db/migrate/20150224035617_hotness_mod_to_float.rb
@@ -1,4 +1,4 @@
-class HotnessModToFloat < ActiveRecord::Migration
+class HotnessModToFloat < ActiveRecord::Migration[4.2]
   def change
     change_column :tags, :hotness_mod, :float
   end

--- a/db/migrate/20150313040930_add_user_avatar_pref.rb
+++ b/db/migrate/20150313040930_add_user_avatar_pref.rb
@@ -1,4 +1,4 @@
-class AddUserAvatarPref < ActiveRecord::Migration
+class AddUserAvatarPref < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :show_avatars, :boolean, :default => false
   end

--- a/db/migrate/20150730215915_add_submitter_is_author.rb
+++ b/db/migrate/20150730215915_add_submitter_is_author.rb
@@ -1,4 +1,4 @@
-class AddSubmitterIsAuthor < ActiveRecord::Migration
+class AddSubmitterIsAuthor < ActiveRecord::Migration[4.2]
   def change
     add_column :stories, :user_is_author, :boolean, :default => false
   end

--- a/db/migrate/20150730225352_add_user_setting_show_preview.rb
+++ b/db/migrate/20150730225352_add_user_setting_show_preview.rb
@@ -1,4 +1,4 @@
-class AddUserSettingShowPreview < ActiveRecord::Migration
+class AddUserSettingShowPreview < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :show_story_previews, :boolean, :default => false
   end

--- a/db/migrate/20151015005101_add_suggested_taggings.rb
+++ b/db/migrate/20151015005101_add_suggested_taggings.rb
@@ -1,4 +1,4 @@
-class AddSuggestedTaggings < ActiveRecord::Migration
+class AddSuggestedTaggings < ActiveRecord::Migration[4.2]
   def change
     create_table :suggested_taggings do |t|
       t.integer :story_id

--- a/db/migrate/20151015011231_add_suggested_titles.rb
+++ b/db/migrate/20151015011231_add_suggested_titles.rb
@@ -1,4 +1,4 @@
-class AddSuggestedTitles < ActiveRecord::Migration
+class AddSuggestedTitles < ActiveRecord::Migration[4.2]
   def change
     create_table "suggested_titles" do |t|
       t.integer :story_id

--- a/db/migrate/20151015143959_moderations_from_group.rb
+++ b/db/migrate/20151015143959_moderations_from_group.rb
@@ -1,4 +1,4 @@
-class ModerationsFromGroup < ActiveRecord::Migration
+class ModerationsFromGroup < ActiveRecord::Migration[4.2]
   def change
     add_column :moderations, :is_from_suggestions, :boolean, :default => false
   end

--- a/db/migrate/20151207180050_add_user_setting_post_threads.rb
+++ b/db/migrate/20151207180050_add_user_setting_post_threads.rb
@@ -1,4 +1,4 @@
-class AddUserSettingPostThreads < ActiveRecord::Migration
+class AddUserSettingPostThreads < ActiveRecord::Migration[4.2]
   def change
     add_column "users", "show_submitted_story_threads", :boolean,
       :default => true

--- a/db/migrate/20160406160019_add_hat_requests.rb
+++ b/db/migrate/20160406160019_add_hat_requests.rb
@@ -1,4 +1,4 @@
-class AddHatRequests < ActiveRecord::Migration
+class AddHatRequests < ActiveRecord::Migration[4.2]
   def change
     create_table :hat_requests do |t|
       t.timestamps

--- a/db/migrate/20160515162433_add_disabled_invites_to_users.rb
+++ b/db/migrate/20160515162433_add_disabled_invites_to_users.rb
@@ -1,4 +1,4 @@
-class AddDisabledInvitesToUsers < ActiveRecord::Migration
+class AddDisabledInvitesToUsers < ActiveRecord::Migration[4.2]
   def change
       add_column :users, :disabled_invite_at, :datetime
       add_column :users, :disabled_invite_by_user_id, :integer

--- a/db/migrate/20160704022756_change_story_columns.rb
+++ b/db/migrate/20160704022756_change_story_columns.rb
@@ -1,4 +1,4 @@
-class ChangeStoryColumns < ActiveRecord::Migration
+class ChangeStoryColumns < ActiveRecord::Migration[4.2]
   def change
     change_column :stories, :is_moderated, :boolean, default: false, null: false
     change_column :stories, :is_expired, :boolean, default: false, null: false

--- a/db/migrate/20170119172852_move_user_settings.rb
+++ b/db/migrate/20170119172852_move_user_settings.rb
@@ -1,4 +1,4 @@
-class MoveUserSettings < ActiveRecord::Migration
+class MoveUserSettings < ActiveRecord::Migration[4.2]
   def up
     add_column :users, :settings, :text
 

--- a/db/migrate/20170119192703_add_dragons.rb
+++ b/db/migrate/20170119192703_add_dragons.rb
@@ -1,4 +1,4 @@
-class AddDragons < ActiveRecord::Migration
+class AddDragons < ActiveRecord::Migration[4.2]
   def change
     add_column :comments, :is_dragon, :boolean, :default => false
   end

--- a/db/migrate/20170225201811_delete_old_settings.rb
+++ b/db/migrate/20170225201811_delete_old_settings.rb
@@ -1,4 +1,4 @@
-class DeleteOldSettings < ActiveRecord::Migration
+class DeleteOldSettings < ActiveRecord::Migration[4.2]
   def change
     [
       :email_notifications,

--- a/db/migrate/20170413161450_add_indexes.rb
+++ b/db/migrate/20170413161450_add_indexes.rb
@@ -1,4 +1,4 @@
-class AddIndexes < ActiveRecord::Migration
+class AddIndexes < ActiveRecord::Migration[4.2]
   def change
     add_index :votes, [ :comment_id ]
     add_index :comments, [ :user_id ]

--- a/db/migrate/20170522144135_remove_comments_dragon.rb
+++ b/db/migrate/20170522144135_remove_comments_dragon.rb
@@ -1,4 +1,4 @@
-class RemoveCommentsDragon < ActiveRecord::Migration
+class RemoveCommentsDragon < ActiveRecord::Migration[4.2]
   def change
     remove_column :comments, :is_dragon
   end

--- a/db/migrate/20170607153224_add_stories_user_index.rb
+++ b/db/migrate/20170607153224_add_stories_user_index.rb
@@ -1,4 +1,4 @@
-class AddStoriesUserIndex < ActiveRecord::Migration
+class AddStoriesUserIndex < ActiveRecord::Migration[4.2]
   def change
     add_index "stories", [ "user_id" ]
   end

--- a/db/migrate/20170607170604_add_fulltext_indicies.rb
+++ b/db/migrate/20170607170604_add_fulltext_indicies.rb
@@ -1,4 +1,4 @@
-class AddFulltextIndicies < ActiveRecord::Migration
+class AddFulltextIndicies < ActiveRecord::Migration[4.2]
   def change
     add_index(:stories, :title, :type => :fulltext)
     add_index(:stories, :description, :type => :fulltext)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -23,8 +23,8 @@ ActiveRecord::Schema.define(version: 2018_10_05_192331) do
     t.text "comment", limit: 16777215, null: false
     t.integer "upvotes", default: 0, null: false
     t.integer "downvotes", default: 0, null: false
-    t.decimal "confidence", precision: 20, scale: 19, default: "0.0", null: false
-    t.text "markeddown_comment", limit: 16777215
+    t.decimal "confidence", precision: 20, scale: 19
+    t.text "markeddown_comment"
     t.boolean "is_deleted", default: false
     t.boolean "is_moderated", default: false
     t.boolean "is_from_email", default: false
@@ -40,30 +40,30 @@ ActiveRecord::Schema.define(version: 2018_10_05_192331) do
     t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
-  create_table "hat_requests", id: :bigint, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "hat_requests", id: :bigint, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
     t.bigint "user_id", null: false, unsigned: true
-    t.string "hat", collation: "utf8mb4_general_ci"
-    t.string "link", collation: "utf8mb4_general_ci"
-    t.text "comment", collation: "utf8mb4_general_ci"
+    t.string "hat"
+    t.string "link"
+    t.text "comment"
     t.index ["user_id"], name: "hat_requests_user_id_fk"
   end
 
-  create_table "hats", id: :bigint, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "hats", id: :bigint, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
     t.bigint "user_id", null: false, unsigned: true
     t.bigint "granted_by_user_id", null: false, unsigned: true
     t.string "hat", null: false
-    t.string "link", collation: "utf8mb4_general_ci"
+    t.string "link"
     t.boolean "modlog_use", default: false
     t.datetime "doffed_at"
     t.index ["granted_by_user_id"], name: "hats_granted_by_user_id_fk"
     t.index ["user_id"], name: "hats_user_id_fk"
   end
 
-  create_table "hidden_stories", id: :bigint, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "hidden_stories", id: :bigint, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.bigint "user_id", null: false, unsigned: true
     t.bigint "story_id", null: false, unsigned: true
     t.index ["story_id"], name: "hidden_stories_story_id_fk"
@@ -87,7 +87,7 @@ ActiveRecord::Schema.define(version: 2018_10_05_192331) do
     t.string "code"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.text "memo", limit: 16777215
+    t.text "memo"
     t.datetime "used_at"
     t.bigint "new_user_id", unsigned: true
     t.index ["new_user_id"], name: "invitations_new_user_id_fk"
@@ -134,8 +134,8 @@ ActiveRecord::Schema.define(version: 2018_10_05_192331) do
     t.bigint "story_id", unsigned: true
     t.bigint "comment_id", unsigned: true
     t.bigint "user_id", unsigned: true
-    t.text "action", limit: 16777215
-    t.text "reason", limit: 16777215
+    t.text "action"
+    t.text "reason"
     t.boolean "is_from_suggestions", default: false
     t.bigint "tag_id", unsigned: true
     t.index ["comment_id"], name: "moderations_comment_id_fk"
@@ -155,7 +155,7 @@ ActiveRecord::Schema.define(version: 2018_10_05_192331) do
     t.index ["user_id"], name: "index_read_ribbons_on_user_id"
   end
 
-  create_table "saved_stories", id: :bigint, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "saved_stories", id: :bigint, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false, unsigned: true
@@ -175,9 +175,9 @@ ActiveRecord::Schema.define(version: 2018_10_05_192331) do
     t.integer "upvotes", default: 0, null: false, unsigned: true
     t.integer "downvotes", default: 0, null: false, unsigned: true
     t.boolean "is_moderated", default: false, null: false
-    t.decimal "hotness", precision: 20, scale: 10, default: "0.0", null: false
-    t.text "markeddown_description", limit: 16777215
-    t.text "story_cache", limit: 16777215
+    t.decimal "hotness", precision: 20, scale: 10
+    t.text "markeddown_description"
+    t.text "story_cache"
     t.integer "comments_count", default: 0, null: false
     t.bigint "merged_story_id", unsigned: true
     t.datetime "unavailable_at"
@@ -198,7 +198,7 @@ ActiveRecord::Schema.define(version: 2018_10_05_192331) do
     t.index ["user_id"], name: "index_stories_on_user_id"
   end
 
-  create_table "suggested_taggings", id: :bigint, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "suggested_taggings", id: :bigint, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.bigint "story_id", null: false, unsigned: true
     t.bigint "tag_id", null: false, unsigned: true
     t.bigint "user_id", null: false, unsigned: true
@@ -207,15 +207,15 @@ ActiveRecord::Schema.define(version: 2018_10_05_192331) do
     t.index ["user_id"], name: "suggested_taggings_user_id_fk"
   end
 
-  create_table "suggested_titles", id: :bigint, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "suggested_titles", id: :bigint, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.bigint "story_id", null: false, unsigned: true
     t.bigint "user_id", null: false, unsigned: true
-    t.string "title", limit: 150, default: "", null: false, collation: "utf8mb4_general_ci"
+    t.string "title", limit: 150, null: false
     t.index ["story_id"], name: "suggested_titles_story_id_fk"
     t.index ["user_id"], name: "suggested_titles_user_id_fk"
   end
 
-  create_table "tag_filters", id: :bigint, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "tag_filters", id: :bigint, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false, unsigned: true
@@ -241,25 +241,25 @@ ActiveRecord::Schema.define(version: 2018_10_05_192331) do
     t.index ["tag"], name: "tag", unique: true
   end
 
-  create_table "users", id: :bigint, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "username", limit: 50, collation: "utf8mb4_general_ci"
-    t.string "email", limit: 100, collation: "utf8mb4_general_ci"
-    t.string "password_digest", limit: 75, collation: "utf8mb4_general_ci"
+  create_table "users", id: :bigint, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.string "username", limit: 50
+    t.string "email", limit: 100
+    t.string "password_digest", limit: 75
     t.datetime "created_at"
     t.boolean "is_admin", default: false
-    t.string "password_reset_token", limit: 75, collation: "utf8mb4_general_ci"
-    t.string "session_token", limit: 75, default: "", null: false, collation: "utf8mb4_general_ci"
-    t.text "about", limit: 16777215, collation: "utf8mb4_general_ci"
+    t.string "password_reset_token", limit: 75
+    t.string "session_token", limit: 75, default: "", null: false
+    t.text "about", limit: 16777215
     t.bigint "invited_by_user_id", unsigned: true
     t.boolean "is_moderator", default: false
     t.boolean "pushover_mentions", default: false
-    t.string "rss_token", limit: 75, collation: "utf8mb4_general_ci"
-    t.string "mailing_list_token", limit: 75, collation: "utf8mb4_general_ci"
+    t.string "rss_token"
+    t.string "mailing_list_token"
     t.integer "mailing_list_mode", default: 0
     t.integer "karma", default: 0, null: false
     t.datetime "banned_at"
     t.bigint "banned_by_user_id", unsigned: true
-    t.string "banned_reason", limit: 200, collation: "utf8mb4_general_ci"
+    t.string "banned_reason", limit: 200
     t.datetime "deleted_at"
     t.datetime "disabled_invite_at"
     t.bigint "disabled_invite_by_user_id", unsigned: true
@@ -268,10 +268,8 @@ ActiveRecord::Schema.define(version: 2018_10_05_192331) do
     t.index ["banned_by_user_id"], name: "users_banned_by_user_id_fk"
     t.index ["disabled_invite_by_user_id"], name: "users_disabled_invite_by_user_id_fk"
     t.index ["invited_by_user_id"], name: "users_invited_by_user_id_fk"
-    t.index ["mailing_list_mode"], name: "mailing_list_enabled"
-    t.index ["mailing_list_token"], name: "mailing_list_token", unique: true
+    t.index ["mailing_list_mode"], name: "index_users_on_mailing_list_mode"
     t.index ["password_reset_token"], name: "password_reset_token", unique: true
-    t.index ["rss_token"], name: "rss_token", unique: true
     t.index ["session_token"], name: "session_hash", unique: true
     t.index ["username"], name: "username", unique: true
   end
@@ -307,6 +305,7 @@ ActiveRecord::Schema.define(version: 2018_10_05_192331) do
   add_foreign_key "moderations", "comments", name: "moderations_comment_id_fk"
   add_foreign_key "moderations", "stories", name: "moderations_story_id_fk"
   add_foreign_key "moderations", "tags", name: "moderations_tag_id_fk"
+  add_foreign_key "moderations", "users", column: "moderator_user_id", name: "moderations_moderator_user_id_fk"
   add_foreign_key "read_ribbons", "stories", name: "read_ribbons_story_id_fk"
   add_foreign_key "read_ribbons", "users", name: "read_ribbons_user_id_fk"
   add_foreign_key "saved_stories", "stories", name: "saved_stories_story_id_fk"


### PR DESCRIPTION
After cloning the project and trying to run it (my first time with Ruby/Rails) I had troubles with migrations. It turns out, there were some migrations missing and also there's a change in how ActiveRecord migrations are declared.
This commits try to fix this so migrate can be used.

Feel free to reject this PR if this is a wrong approach on Rails. 