### PR TITLE
Allow users to see merged stories they submitted

### DIFF
--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -29,6 +29,7 @@ class Story < ApplicationRecord
   scope :base, -> { includes(:tags).unmerged.not_deleted }
   scope :deleted, -> { where(is_expired: true) }
   scope :not_deleted, -> { where(is_expired: false) }
+  scope :merged, -> { where(merged_story_id: nil) }
   scope :unmerged, -> { where(:merged_story_id => nil) }
   scope :positive_ranked, -> { where("#{Story.score_sql} >= 0") }
   scope :low_scoring, ->(max = 5) { where("#{Story.score_sql} < ?", max) }

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -29,7 +29,6 @@ class Story < ApplicationRecord
   scope :base, -> { includes(:tags).unmerged.not_deleted }
   scope :deleted, -> { where(is_expired: true) }
   scope :not_deleted, -> { where(is_expired: false) }
-  scope :merged, -> { where(merged_story_id: nil) }
   scope :unmerged, -> { where(:merged_story_id => nil) }
   scope :positive_ranked, -> { where("#{Story.score_sql} >= 0") }
   scope :low_scoring, ->(max = 5) { where("#{Story.score_sql} < ?", max) }

--- a/app/models/story_repository.rb
+++ b/app/models/story_repository.rb
@@ -20,12 +20,11 @@ class StoryRepository
 
   def newest_by_user(user)
     if @user == user
-      stories =
-        Story.includes(:tags).not_deleted.where(user_id: user.id).left_joins(:merged_into_story)
-      stories_not_merged = stories.where(merged_into_story: nil)
-      visible_merged_stories = stories.where.not(merged_into_stories_stories: { user_id: user.id })
+      stories = Story.includes(:tags).not_deleted.left_joins(:merged_stories)
+      unmerged = stories.unmerged.where(user_id: user.id)
+      merged_into_others = stories.merged.where(merged_stories_stories: { user_id: user.id })
 
-      stories_not_merged.or(visible_merged_stories).order(id: :desc)
+      unmerged.or(merged_into_others).order(id: :desc)
     else
       Story.base.where(user_id: user.id).order("stories.id DESC")
     end

--- a/app/models/story_repository.rb
+++ b/app/models/story_repository.rb
@@ -20,7 +20,8 @@ class StoryRepository
 
   def newest_by_user(user)
     if @user == user
-      stories = Story.includes(:tags).not_deleted.where(user_id: user.id).left_joins(:merged_into_story)
+      stories =
+        Story.includes(:tags).not_deleted.where(user_id: user.id).left_joins(:merged_into_story)
       stories_not_merged = stories.where(merged_into_story: nil)
       visible_merged_stories = stories.where.not(merged_into_stories_stories: { user_id: user.id })
 

--- a/app/models/story_repository.rb
+++ b/app/models/story_repository.rb
@@ -22,7 +22,7 @@ class StoryRepository
     if @user == user
       stories = Story.includes(:tags).not_deleted.left_joins(:merged_stories)
       unmerged = stories.unmerged.where(user_id: user.id)
-      merged_into_others = stories.merged.where(merged_stories_stories: { user_id: user.id })
+      merged_into_others = stories.where(merged_stories_stories: { user_id: user.id })
 
       unmerged.or(merged_into_others).order(id: :desc)
     else

--- a/app/models/story_repository.rb
+++ b/app/models/story_repository.rb
@@ -19,7 +19,15 @@ class StoryRepository
   end
 
   def newest_by_user(user)
-    Story.base.where(user_id: user.id).order(id: :desc)
+    if @user == user
+      stories = Story.includes(:tags).not_deleted.where(user_id: user.id).left_joins(:merged_into_story)
+      stories_not_merged = stories.where(merged_into_story: nil)
+      visible_merged_stories = stories.where.not(merged_into_stories_stories: { user_id: user.id })
+
+      stories_not_merged.or(visible_merged_stories).order(id: :desc)
+    else
+      Story.base.where(user_id: user.id).order("stories.id DESC")
+    end
   end
 
   def newest_including_deleted_by_user(user)

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -15,10 +15,8 @@
 <% end %>
 
 <ol class="stories list <%= @cur_url == "/hidden" ? "show_hidden" : "" %>">
-  <% @stories.each do |story| %>
-    <% story_to_display = story.merged_into_story.present? ? story.merged_into_story : story %>
-    <%= render "stories/listdetail", story: story_to_display, single_story: @for_user == @user&.username %>
-  <% end %>
+  <%= render partial: "stories/listdetail", collection: @stories, as: :story,
+             locals: { single_story: @for_user == @user&.username } %>
 </ol>
 
 <div class="morelink">

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -15,8 +15,10 @@
 <% end %>
 
 <ol class="stories list <%= @cur_url == "/hidden" ? "show_hidden" : "" %>">
-  <%= render :partial => "stories/listdetail", :collection => @stories,
-    :as => :story %>
+  <% @stories.each do |story| %>
+    <% story_to_display = story.merged_into_story.present? ? story.merged_into_story : story %>
+    <%= render "stories/listdetail", story: story_to_display, single_story: @for_user == @user&.username %>
+  <% end %>
 </ol>
 
 <div class="morelink">

--- a/spec/models/story_repository_spec.rb
+++ b/spec/models/story_repository_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+describe StoryRepository do
+  let(:viewing_user) { create(:user) }
+  let(:repo) { StoryRepository.new(viewing_user) }
+
+  describe ".newest_by_user" do
+    context "when user is viewing their own stories" do
+      before do
+        create(:story, user: viewing_user, title: "A story not merged")
+        create(:story, user: viewing_user, title: "A merged story", merged_into_story: create(:story))
+        create(:story, user: viewing_user, title: "A merged story by the same user",
+          merged_into_story: create(:story, user: viewing_user)
+        )
+      end
+
+      it "sees their stories" do
+        stories = repo.newest_by_user(viewing_user)
+
+        expect(stories.map(&:title)).to include("A story not merged")
+      end
+
+      it "sees stories merged into another story" do
+        stories = repo.newest_by_user(viewing_user)
+
+        expect(stories.map(&:title)).to include("A merged story")
+      end
+
+      it "does not see stories merged into a story they submitted" do
+        stories = repo.newest_by_user(viewing_user)
+
+        expect(stories.map(&:title)).to_not include("A merged story by the same user")
+      end
+    end
+  end
+end

--- a/spec/models/story_repository_spec.rb
+++ b/spec/models/story_repository_spec.rb
@@ -1,37 +1,35 @@
 require "rails_helper"
 
 describe StoryRepository do
-  let(:viewing_user) { create(:user) }
-  let(:repo) { StoryRepository.new(viewing_user) }
+  let(:submitter) { create(:user) }
+  let(:repo) { StoryRepository.new(submitter) }
 
   describe ".newest_by_user" do
     context "when user is viewing their own stories" do
       before do
-        create(:story, user: viewing_user, title: "A story not merged")
-        create(:story, user: viewing_user, title: "A merged story",
+        create(:story, user: submitter, title: "A story not merged")
+        create(:story, user: submitter, title: "A merged story",
                merged_into_story: create(:story, title: "Story merged into"))
-        create(:story, user: viewing_user, title: "A merged story by the same user",
-               merged_into_story: create(:story, user: viewing_user))
+        create(:story, user: submitter, title: "A merged story by the same user",
+               merged_into_story: create(:story, user: submitter))
       end
 
       it "sees their stories" do
-        stories = repo.newest_by_user(viewing_user)
-
-        expect(stories.map(&:title)).to include("A story not merged")
+        expect(story_titles_from(submitter)).to include("A story not merged")
       end
 
       it "sees stories that their story was merged into" do
-        stories = repo.newest_by_user(viewing_user)
-
-        expect(stories.map(&:title)).to_not include("A merged story")
-        expect(stories.map(&:title)).to include("Story merged into")
+        expect(story_titles_from(submitter)).to_not include("A merged story")
+        expect(story_titles_from(submitter)).to include("Story merged into")
       end
 
       it "does not see stories merged into a story they submitted" do
-        stories = repo.newest_by_user(viewing_user)
-
-        expect(stories.map(&:title)).to_not include("A merged story by the same user")
+        expect(story_titles_from(submitter)).to_not include("A merged story by the same user")
       end
     end
+  end
+
+  def story_titles_from(user)
+    repo.newest_by_user(user).map(&:title)
   end
 end

--- a/spec/models/story_repository_spec.rb
+++ b/spec/models/story_repository_spec.rb
@@ -9,7 +9,7 @@ describe StoryRepository do
       before do
         create(:story, user: viewing_user, title: "A story not merged")
         create(:story, user: viewing_user, title: "A merged story",
-               merged_into_story: create(:story))
+               merged_into_story: create(:story, title: "Story merged into"))
         create(:story, user: viewing_user, title: "A merged story by the same user",
                merged_into_story: create(:story, user: viewing_user))
       end
@@ -20,10 +20,11 @@ describe StoryRepository do
         expect(stories.map(&:title)).to include("A story not merged")
       end
 
-      it "sees stories merged into another story" do
+      it "sees stories that their story was merged into" do
         stories = repo.newest_by_user(viewing_user)
 
-        expect(stories.map(&:title)).to include("A merged story")
+        expect(stories.map(&:title)).to_not include("A merged story")
+        expect(stories.map(&:title)).to include("Story merged into")
       end
 
       it "does not see stories merged into a story they submitted" do

--- a/spec/models/story_repository_spec.rb
+++ b/spec/models/story_repository_spec.rb
@@ -8,10 +8,10 @@ describe StoryRepository do
     context "when user is viewing their own stories" do
       before do
         create(:story, user: viewing_user, title: "A story not merged")
-        create(:story, user: viewing_user, title: "A merged story", merged_into_story: create(:story))
+        create(:story, user: viewing_user, title: "A merged story",
+               merged_into_story: create(:story))
         create(:story, user: viewing_user, title: "A merged story by the same user",
-          merged_into_story: create(:story, user: viewing_user)
-        )
+               merged_into_story: create(:story, user: viewing_user))
       end
 
       it "sees their stories" do


### PR DESCRIPTION
Fixes #423 - Users can now see their own stories that were merged into another story.

The logic for finding all those stories was slightly more complicated, so I pushed it into the `StoryRepository` so that it would be easier to test.

For the view, I reused the existing partial (`stories/listdetail` is used in many places). When the submitter is viewing their own stories, a merged story looks the same as if they were seeing the story view.

I am pretty sure this will conflict with my other PR #563, so once one is merged, I can update the other.