### PR TITLE
Fix #571 handle new comment

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -385,11 +385,12 @@ var _Lobsters = Class.extend({
 var Lobsters = new _Lobsters();
 
 $(document).ready(function() {
-  $(".comment a.downvoter").click(function() {
+  var $olcomments = $("ol.comments");
+  $olcomments.on("click", ".comment a.downvoter", function() {
     Lobsters.downvoteComment(this);
     return false;
   });
-  $(".comment a.upvoter").click(function() {
+  $olcomments.on("click", ".comment a.upvoter", function() {
     Lobsters.upvoteComment(this);
     return false;
   });


### PR DESCRIPTION
Bind click event to comments OL container instead of existing elements.
Otherwise when creating the new comment it won't have the event attached
to it.
