### PR TITLE
Fix failing test data cleanup due to foreign key constraint

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,7 @@ require 'rspec/rails'
 # in spec/support/ and its subdirectories.
 Dir[Rails.root.join("spec/support/**/*.rb")].each {|f| require f }
 
+Moderation.destroy_all
 Tag.destroy_all
 Tag.create!([{ tag: "tag1" }, { tag: "tag2" }])
 


### PR DESCRIPTION
Before this change, running `Tag.destroy_all` would fail due to existing
`Moderation` records with a foreign key on some of those tags with the
following message:

```
Mysql2::Error:
  Cannot delete or update a parent row: a foreign key constraint fails
  (`lobsters_test`.`moderations`, CONSTRAINT `moderations_tag_id_fk`
  FOREIGN KEY (`tag_id`) REFERENCES `tags` (`id`))
```

Thus, one had to manually cleanup some test data before re-running the test suite.
