### PR TITLE
Switch to database cleaner approach for cleaning up test data

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ gem "sitemap_generator" # for better search engine indexing
 group :test, :development do
   gem 'bullet'
   gem 'capybara'
+  gem 'database_cleaner'
   gem 'good_migrations'
   gem "listen"
   gem "rspec-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,7 @@ GEM
       ruby-enum (~> 0.5)
     concurrent-ruby (1.0.5)
     crass (1.0.4)
+    database_cleaner (1.7.0)
     diff-lcs (1.3)
     dynamic_form (1.1.4)
     erubi (1.7.1)
@@ -236,6 +237,7 @@ DEPENDENCIES
   byebug
   capybara
   commonmarker (~> 0.14)
+  database_cleaner
   dynamic_form
   exception_notification
   factory_bot_rails
@@ -264,4 +266,4 @@ DEPENDENCIES
   unicorn
 
 BUNDLED WITH
-   1.16.2
+   1.16.5

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,13 +7,6 @@ require 'rspec/rails'
 # in spec/support/ and its subdirectories.
 Dir[Rails.root.join("spec/support/**/*.rb")].each {|f| require f }
 
-Moderation.destroy_all
-Tag.destroy_all
-Tag.create!([{ tag: "tag1" }, { tag: "tag2" }])
-Vote.destroy_all
-Story.destroy_all
-User.destroy_all
-
 RSpec.configure do |config|
   # ## Mock Framework
   #
@@ -30,6 +23,29 @@ RSpec.configure do |config|
   # examples within a transaction, remove the following line or assign false
   # instead of true.
   config.use_transactional_fixtures = true
+
+  config.before(:suite) do
+    DatabaseCleaner.strategy = :transaction
+    DatabaseCleaner.clean_with :truncation
+
+    Tag.create!([{ tag: "tag1" }, { tag: "tag2" }])
+  end
+
+  config.before(:example) do
+    DatabaseCleaner.start
+  end
+
+  config.after(:example) do
+    DatabaseCleaner.clean
+  end
+
+  config.before(:example, :js) do
+    DatabaseCleaner.strategy = :truncation
+  end
+
+  config.before(:example, :truncate) do
+    DatabaseCleaner.strategy = :truncation
+  end
 
   # If true, the base class of anonymous controllers will be inferred
   # automatically. This will be the default behavior in future versions of


### PR DESCRIPTION
While the previous approach of hand-rolling test data cleanup + setup works
it’s prone to become insufficient with regards to future test scenarios. Recent
commits 6a6da094 and later 4620a922 highlight the issue.

Using the database cleaner gem provides a cleaner (pun intended) approach to
setup a clean room environment before and after each specific test.

Annotating specs with with `:js` or `:truncate` will switch from a transaction
based cleanup strategy to a truncation based one to enable feature/request specs
for which a web server is spun up in separate process by RSpec, in other words
the process executing the spec is not the same as the process handling the
request so RSpec/DatabaseCleaner wouldn’t know when to rollback the transaction.

The overall downside of this approach might be that RSpec takes a few more seconds 
to run all specs.
