### PR TITLE
Fix invalid URI on script/send_new_webmentions

### DIFF
--- a/script/send_new_webmentions
+++ b/script/send_new_webmentions
@@ -5,6 +5,7 @@ ENV["RAILS_ENV"] ||= "production"
 APP_PATH = File.expand_path('../../config/application', __FILE__)
 require File.expand_path('../../config/boot', __FILE__)
 require APP_PATH
+require 'webrick'
 Rails.application.require_environment!
 
 LAST_STORY_KEY = "webmentions:last_story_id".freeze
@@ -77,7 +78,7 @@ if __FILE__ == $PROGRAM_NAME
 
     sp = Sponge.new
     sp.timeout = 10
-    response = sp.fetch(s.url, :get, nil, nil, {
+    response = sp.fetch(WEBrick::HTTPUtils.escape(s.url), :get, nil, nil, {
       "User-agent" => "#{Rails.application.domain} webmention endpoint lookup",
     }, 3)
     next unless response


### PR DESCRIPTION
Fix #586.

I've managed to reproduce it on the console:

```
2.3.3 :027 > a
 => "https://www.redhat.com/en/about/press-releases/ibm-acquire-red-hat-completely-changing-cloud-landscape-and-becoming-world’s-1-hybrid-cloud-provider" 
2.3.3 :028 > Sponge.new.fetch(a)
URI::InvalidURIError: URI must be ascii only "https://www.redhat.com/en/about/press-releases/ibm-acquire-red-hat-completely-changing-cloud-landscape-and-becoming-world\u{2019}s-1-hybrid-cloud-provider"
	from (irb):28
2.3.3 :029 > Sponge.new.fetch(WEBrick::HTTPUtils.escape(a))
 => #<Net::HTTPOK 200 OK readbody=true> 
```

<!--
Issues and PRs are typically reviewed Wednesday and some Thursday mornings.
-->
