### PR TITLE
Move closing `a` element

### DIFF
--- a/app/views/stories/_listdetail.html.erb
+++ b/app/views/stories/_listdetail.html.erb
@@ -168,11 +168,10 @@ class="story <%= story.vote && story.vote[:vote] == 1 ? "upvoted" : "" %>
             |
             <a href="<%= story.comments_path %>">
             <% if story.comments_count == 0 %>
-              no comments
+              no comments</a>
             <% else %>
               <%= story.comments_count %> <%= 'comment'.pluralize(story.comments_count) %></a>
             <% end %>
-            </a>
           </span>
         <% end %>
 


### PR DESCRIPTION
This patch avoids a double-closing `a` element.
It patch aligns _listdetail.html.erb with _similar.html.erb, where the closing `a` element is in each if-branch. Compare with https://github.com/lobsters/lobsters/blob/3ed2b8e5af0ce3d7d13c0e88104cacc045f3ed10/app/views/stories/_similar.html.erb#L16,L18

<!--
Issues and PRs are typically reviewed Wednesday and some Thursday mornings.
-->
