### PR TITLE
Add JSON MIME to StoriesController#check_url_dupe

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -339,8 +339,17 @@ class StoriesController < ApplicationController
     @story = Story.new(story_params)
     @story.check_already_posted
 
-    return render :partial => "stories/form_errors", :layout => false,
-      :content_type => "text/html", :locals => { :story => @story }
+    respond_to do |format|
+      format.html {
+        return render :partial => "stories/form_errors", :layout => false,
+          :content_type => "text/html", :locals => { :story => @story }
+      }
+      format.json {
+        similar_stories = @story.similar_stories.map(&:as_json)
+
+        render :json => @story.as_json.merge(similar_stories: similar_stories)
+      }
+    end
   end
 
 private

--- a/spec/controllers/stories_controller_spec.rb
+++ b/spec/controllers/stories_controller_spec.rb
@@ -7,6 +7,58 @@ describe StoriesController do
     stub_login_as user
   end
 
+  describe "#check_url_dupe" do
+    let(:story) { create(:story, user: user) }
+
+    context "json" do
+      it "returns similar story matching URL" do
+        post :check_url_dupe,
+             format: :json,
+             params: { story: { title: "some other title", url: story.url } }
+
+        expect(response).to be_successful
+
+        json = JSON.parse(response.body)
+
+        expect(json.fetch("title")).to eq "some other title"
+        expect(json.fetch("similar_stories").count).to eq(1)
+
+        similar_story = json.fetch("similar_stories").first
+        expect(similar_story.fetch("title")).to eq story.title
+        expect(similar_story.fetch("short_id")).to eq story.short_id
+        expect(similar_story.fetch("url")).to eq story.url
+        expect(similar_story.fetch("comments_url")).to eq story.comments_url
+        expect(similar_story.fetch("comment_count")).to eq story.comments_count
+      end
+
+      it "returns no matches if previously submitted URL is only partial match" do
+        post :check_url_dupe,
+             format: :json,
+             params: { story: { title: "some other title", url: story.url[0...-1] } }
+
+        expect(response).to be_successful
+
+        json = JSON.parse(response.body)
+
+        expect(json.fetch("title")).to eq "some other title"
+        expect(json.fetch("similar_stories").count).to eq(0)
+      end
+
+      it "returns no matches if no matching URL" do
+        post :check_url_dupe,
+             format: :json,
+             params: { story: { title: "some other title", url: "invalid_url" } }
+
+        expect(response).to be_successful
+
+        json = JSON.parse(response.body)
+
+        expect(json.fetch("title")).to eq "some other title"
+        expect(json.fetch("similar_stories").count).to eq(0)
+      end
+    end
+  end
+
   describe "#delete" do
     let(:story) { create(:story, user: user) }
 


### PR DESCRIPTION
Replacement for https://github.com/lobsters/lobsters/pull/555

Adds JSON support to the `check_url_dupe` endpoint allowing searches for discussions about previously submitted URLs.