### PR TITLE
Refocus lobsters more on links than comments

### DIFF
--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -311,7 +311,7 @@ class Story < ApplicationRecord
     i_cpoint = self.tags_a.include?('ask') ? 0 : -0.0625
     cpoints = self.merged_comments
       .select(:downvotes)
-      .map {|c| c.downvotes == 0 ? i_cpoint : -0.25}
+      .map {|c| c.downvotes == 0 ? i_cpoint : -0.25 }
       .inject(&:+).to_f
 
     # mix in any stories this one cannibalized

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -317,7 +317,7 @@ class Story < ApplicationRecord
     # mix in any stories this one cannibalized
     cpoints += self.merged_stories.map(&:score).inject(&:+).to_f
 
-    # cap the merged-article boost
+    # cap the merged-story boost
     if cpoints > self.upvotes
       cpoints = self.upvotes
     end

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -304,14 +304,14 @@ class Story < ApplicationRecord
     # stories submitted by the author
     base = self.tags.sum(:hotness_mod) + (self.user_is_author? && self.url.present? ? 0.25 : 0.0)
 
-    # if a story has a large number of comments, it's probably a dumpster fire and needs to be put out
-    # receiving four downvoted comments, or sixteen comments that receive no downvote, is equivalent to one flag
-    #
+    # if a story has a large number of comments, it's probably a dumpster fire
+    # receiving four downvoted comments, or sixteen comments that receive no downvote,
+    # is equivalent to one flag
     # ask posts don't count, because those are supposed to generate comments
     i_cpoint = self.tags_a.include?('ask') ? 0 : -0.0625
     cpoints = self.merged_comments
       .select(:downvotes)
-      .map { |c| c.downvotes == 0 ? i_cpoint : -0.25 }
+      .map {|c| c.downvotes == 0 ? i_cpoint : -0.25}
       .inject(&:+).to_f
 
     # mix in any stories this one cannibalized


### PR DESCRIPTION
I'd rather do something like this than [lock invites](https://lobste.rs/s/sfzmwr/proposal_set_everyone_s_invite_count_zero). Specifically, notice a few problems with how [the thread that prompted that discussion went](https://lobste.rs/s/egbgwb/introducing_conjure_palantir_s):

* The original post received 21 upvotes, and the first comment on it, which the author posted in an attempt to tell people to avoid the software, received 95. This doubles the article's score (since you're already capping it).
* Lobsters counts upvoted comments positively with the linked page, but actually, that poster probably would have wanted that link to be hidden.
* Because downvoting is so much harder than upvoting, people upvote comments they strongly agree with and ignore comments they disagree with, which, again, counts in favor of the link.

Lobsters then, essentially, optimizes for controversy (mostly because you copied Reddit in design, and Reddit is also optimized to generate controversy). Don't do that.