### PR TITLE
fix #590: encode fetched content to utf8

### DIFF
--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -904,7 +904,7 @@ class Story < ApplicationRecord
         s.timeout = 3
         @fetched_content = s.fetch(self.url, :get, nil, nil, {
           "User-agent" => "#{Rails.application.domain} for #{self.fetching_ip}",
-        }, 3).body
+        }, 3).body.encode!(invalid: :replace, undef: :replace, replace: '')
       rescue
         return @fetched_attributes
       end


### PR DESCRIPTION
encode fetched_content response body from `ASCII-8BIT` to `UTF-8`