### PR TITLE
fix #599: skip robocop on server start in production env

### DIFF
--- a/extras/prohibit_safe_navigation.rb
+++ b/extras/prohibit_safe_navigation.rb
@@ -1,3 +1,6 @@
+require 'rails'
+return if Rails.env.production?
+
 module RuboCop
   module Cop
     module Style


### PR DESCRIPTION
fixes #599 

Rails tries to use robocop in production env where robocop gem isn't available.

add a conditional to prevent using robocop in production.