### PR TITLE
make `rails test` run `rails spec` instead

### DIFF
--- a/test/placeholder_test.rb
+++ b/test/placeholder_test.rb
@@ -1,3 +1,0 @@
-class PlaceholderTest < ActiveSupport::TestCase
-  test("placeholder") { raise "Run `rails spec`. https://github.com/lobsters/lobsters/issues/585" }
-end

--- a/test/test_as_spec.rb
+++ b/test/test_as_spec.rb
@@ -1,0 +1,2 @@
+require 'rspec/core'
+RSpec::Core::Runner.run(['spec'])


### PR DESCRIPTION
fix #585 

make `rails test` run `rails spec` instead