### PR TITLE
Make /recent leader text more accurate

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,6 +1,6 @@
 <% if @cur_url == "/recent" %>
   <div class="box" id="leader">
-    <em>The <a href="/newest">newest</a> stories that have not yet reached the front page.</em>
+    <em>The <a href="/newest">newest</a> stories.</em>
   </div>
 <% end %>
 <% if @tag %>


### PR DESCRIPTION
The old text implied that this page contains only those stories which
have not reached the front page. In fact, it contains all recent
stories in order of submission, regardless of whether they are or are
not on the front page.

<!--
Issues and PRs are typically reviewed Wednesday and some Thursday mornings.
-->
