### PR TITLE
Drop erroneous hash member to fix editing comments

### DIFF
--- a/app/views/comments/_commentbox.html.erb
+++ b/app/views/comments/_commentbox.html.erb
@@ -12,7 +12,7 @@ data-shortid="<%= comment.short_id if comment.persisted? %>">
   <% end %>
 
   <div style="width: 100%;">
-      <%= f.text_area "comment", :body => comment.comment, :rows => 5,
+      <%= f.text_area "comment", comment.comment, :rows => 5,
       :disabled => !@user,
       :placeholder => (@user ? "" : "You must be logged in to leave a comment.")
       %>


### PR DESCRIPTION
This caused the content of `comment.comment` to go into a `body` HTML attribute instead of the body of the textarea. This restores the functionality prior to 089f3475.

Fixes #624
