### PR TITLE
Notes mysql2 gem installation workaround for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ There's an external project [docker-lobsters](https://github.com/jamesbrink/dock
     ```sh
     lobsters$ bundle
     ```
+    
+    * If when installing the `mysql2` gem on macOS, you see 
+      `ld: library not found for -l-lpthread` in the output, see 
+      [this solution](https://stackoverflow.com/a/44790834/204052) for a fix.
 
 * Create a MySQL (other DBs supported by ActiveRecord may work, only MySQL and
 MariaDB have been tested) database, username, and password and put them in a


### PR DESCRIPTION
There is apparently a bug in the `mysql_config` script included in `mysql-connector-c` that the mysql2 gem uses to build the native extensions. This theoretically would trip up anyone using macOS 10.12+ without having MySQL or MariaDB running locally.
