### PR TITLE
Fix commentbox text_area

### DIFF
--- a/app/views/comments/_commentbox.html.erb
+++ b/app/views/comments/_commentbox.html.erb
@@ -6,13 +6,14 @@ data-shortid="<%= comment.short_id if comment.persisted? %>">
   <% end %>
 
   <%= f.hidden_field "story_id", value: comment.story.short_id %>
+  <%= f.hidden_field "_method", value: "#{comment.new_record?? 'post' : 'patch'}" %>
 
   <% if comment.parent_comment %>
     <%= f.hidden_field "parent_comment_short_id", value: comment.parent_comment.short_id %>
   <% end %>
 
   <div style="width: 100%;">
-      <%= f.text_area "comment", :body => comment.comment, :rows => 5,
+      <%= f.text_area "comment", :value => comment.comment, :rows => 5,
       :disabled => !@user,
       :placeholder => (@user ? "" : "You must be logged in to leave a comment.")
       %>

--- a/app/views/comments/_commentbox.html.erb
+++ b/app/views/comments/_commentbox.html.erb
@@ -1,20 +1,18 @@
 <div class="comment comment_form_container"
 data-shortid="<%= comment.short_id if comment.persisted? %>">
-<%= form_for comment,
-:html => { :id => "edit_comment_#{comment.short_id}" } do |f| %>
+<%= form_with url: comment, :id => "edit_comment_#{comment.short_id}" do |f| %>
   <% if comment.errors.any? %>
     <%= errors_for comment %>
   <% end %>
 
-  <%= hidden_field_tag "story_id", comment.story.short_id %>
+  <%= f.hidden_field "story_id", value: comment.story.short_id %>
 
   <% if comment.parent_comment %>
-    <%= hidden_field_tag "parent_comment_short_id",
-      comment.parent_comment.short_id %>
+    <%= f.hidden_field "parent_comment_short_id", value: comment.parent_comment.short_id %>
   <% end %>
 
   <div style="width: 100%;">
-    <%= text_area_tag "comment", comment.comment, :rows => 5,
+      <%= f.text_area "comment", :body => comment.comment, :rows => 5,
       :disabled => !@user,
       :placeholder => (@user ? "" : "You must be logged in to leave a comment.")
       %>
@@ -32,21 +30,21 @@ data-shortid="<%= comment.short_id if comment.persisted? %>">
         </div>
       <% end %>
 
-      <%= submit_tag "#{comment.new_record?? "Post" : "Update"}",
+      <%= f.submit "#{comment.new_record?? "Post" : "Update"}",
         :class => "comment-post", :disabled => !@user %>
       &nbsp;
-      <%= button_tag "Preview", :class => "comment-preview",
+      <%= f.button "Preview", :class => "comment-preview",
         :type => "button", :disabled => !@user %>
       <% if comment.persisted? || comment.parent_comment_id %>
         &nbsp;
-        <%= button_tag "Cancel", :class => "comment-cancel",
+        <%= f.button "Cancel", :class => "comment-cancel",
           :type => "button" %>
       <% end %>
 
       <% if @user && @user.wearable_hats.any? %>
         <div style="display: inline-block; margin-left: 1em;">
         Put on hat:
-        <%= select_tag "hat_id",
+        <%= f.select "hat_id",
           options_from_collection_for_select(@user.wearable_hats, "id", "hat",
           comment.hat_id), :include_blank => true %>
         </div>


### PR DESCRIPTION
This caused the content of `comment.comment` to go into a `body` HTML attribute instead of the body of the textarea. This restores the functionality prior to 089f3475.

Closes #624 #625 
