### PR TITLE
Remove jQuery from application.js.erb

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -4,6 +4,34 @@
 
 "use strict";
 
+// Polyfill Element.matches()
+// https://developer.mozilla.org/en-US/docs/Web/API/Element/matches#polyfill
+if (!Element.prototype.matches) {
+  Element.prototype.matches = Element.prototype.msMatchesSelector || 
+                              Element.prototype.webkitMatchesSelector;
+}
+
+// Polyfill Element.closest()
+// https://developer.mozilla.org/en-US/docs/Web/API/Element/closest#polyfill
+if (!Element.prototype.closest) {
+  Element.prototype.closest = function(s) {
+    var el = this;
+    if (!document.documentElement.contains(el)) return null;
+    do {
+      if (el.matches(s)) return el;
+      el = el.parentElement || el.parentNode;
+    } while (el !== null && el.nodeType === 1);
+    return null;
+  };
+}
+
+function post(url, data) {
+  var request = new XMLHttpRequest();
+  request.open('POST', url, true);
+  request.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded; charset=UTF-8');
+  request.send(data);
+}
+
 var _Lobsters = Class.extend({
   curUser: null,
 
@@ -43,21 +71,19 @@ var _Lobsters = Class.extend({
     if (!Lobsters.curUser)
       return Lobsters.bounceToLogin();
 
-    var li = $(saverEl).closest(".story, .comment");
+    var li = saverEl.closest(".story, .comment");
     var act;
 
-    if (li.hasClass("saved")) {
+    if (li.classList.contains("saved")) {
       act = "unsave";
-      li.removeClass("saved");
+      li.classList.remove("saved");
       saverEl.innerHTML = "save";
-    }
-    else {
+    } else {
       act = "save";
-      li.addClass("saved");
+      li.classList.add("saved");
       saverEl.innerHTML = "unsave";
     }
-
-    $.post("/stories/" + li.attr("data-shortid") + "/" + act);
+    post("/stories/" + li.attr("data-shortid") + "/" + act);
   },
 
   upvoteComment: function(voterEl) {

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -45,6 +45,10 @@ function removeEl(el) {
   return el.parentNode.removeChild(el);
 }
 
+function replaceEl(oldEl, newEl) {
+  return oldEl.parentNode.replaceChild(newEl, oldEl);
+}
+
 var _Lobsters = Class.extend({
   curUser: null,
 
@@ -290,14 +294,19 @@ var _Lobsters = Class.extend({
   },
 
   previewComment: function(form) {
-    var params = $(form).serializeArray();
-    params.push({"name": "preview", "value": "true"});
-    params.push({"name": "show_tree_lines", "value": "true"});
-    $.post($(form).attr("action"), params, function(data) {
-      var da = $.parseHTML(data);
-      var ta = $(da).find("textarea");
-      $(form).closest(".comment").replaceWith(da);
-      autosize(ta);
+    var data = Rails.serializeElement(form, param({
+      preview: true,
+      show_tree_lines: true
+    }));
+    Rails.ajax({
+      type: "POST",
+      url: form.getAttribute("action"),
+      data: data,
+      success: function(da) {
+        var ta = da.querySelector("textarea");
+        replaceEl(form.closest(".comment"), da.body.children[0]);
+        autosize(ta);
+      },
     });
   },
 
@@ -607,7 +616,7 @@ $(document).ready(function() {
   });
 
   $(document).on("click", "button.comment-preview", function() {
-    Lobsters.previewComment($(this).parents("form").first());
+    Lobsters.previewComment($(this).parents("form").first()[0]);
   });
 
   $(document).on("click", "button.story-preview", function() {

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -51,21 +51,20 @@ var _Lobsters = Class.extend({
     if (!Lobsters.curUser)
       return Lobsters.bounceToLogin();
 
-    var li = $(hiderEl).closest(".story, .comment");
+    var li = hiderEl.closest(".story, .comment");
     var act;
 
-    if (li.hasClass("hidden")) {
+    if (li.classList.contains("hidden")) {
       act = "unhide";
-      li.removeClass("hidden");
+      li.classList.remove("hidden");
       hiderEl.innerHTML = "hide";
-    }
-    else {
+    } else {
       act = "hide";
-      li.addClass("hidden");
+      li.classList.add("hidden");
       hiderEl.innerHTML = "unhide";
     }
 
-    $.post("/stories/" + li.attr("data-shortid") + "/" + act);
+    post("/stories/" + li.getAttribute("data-shortid") + "/" + act);
   },
   saveStory: function(saverEl) {
     if (!Lobsters.curUser)
@@ -83,7 +82,7 @@ var _Lobsters = Class.extend({
       li.classList.add("saved");
       saverEl.innerHTML = "unsave";
     }
-    post("/stories/" + li.attr("data-shortid") + "/" + act);
+    post("/stories/" + li.getAttribute("data-shortid") + "/" + act);
   },
 
   upvoteComment: function(voterEl) {

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -41,6 +41,10 @@ function param(object) {
   return encodedString;
 }
 
+function removeEl(el) {
+  return el.parentNode.removeChild(el);
+}
+
 var _Lobsters = Class.extend({
   curUser: null,
 
@@ -112,69 +116,73 @@ var _Lobsters = Class.extend({
     if (!Lobsters.curUser)
       return Lobsters.bounceToLogin();
 
-    var li = $(voterEl).closest(".story, .comment");
-    if (li.hasClass("downvoted")) {
+    var li = voterEl.closest(".story, .comment");
+    if (li.classList.contains("downvoted")) {
       /* already upvoted, neutralize */
       Lobsters.vote(thingType, voterEl, -1, null);
       return;
     }
 
-    if ($("#downvote_why"))
-      $("#downvote_why").remove();
-    if ($("#downvote_why_shadow"))
-      $("#downvote_why_shadow").remove();
+    if (document.getElementById("downvote_why")) {
+      removeEl(document.getElementById("downvote_why"));
+    }
+    if (document.getElementById("downvote_why_shadow")) {
+      removeEl(document.getElementById("downvote_why_shadow"));
+    }
 
-    var sh = $("<div id=\"downvote_why_shadow\"></div>");
-    $(voterEl).after(sh);
-    sh.click(function() {
-      $("#downvote_why_shadow").remove();
-      $("#downvote_why").remove();
+    var sh = document.createElement("div");
+    sh.id = "downvote_why_shadow";
+    voterEl.insertAdjacentElement("afterend", sh);
+
+    sh.addEventListener('click', function() {
+      removeEl(document.getElementById("downvote_why_shadow"));
+      removeEl(document.getElementById("downvote_why"));
     });
 
-    var d = $("<div id=\"downvote_why\"></div>");
+    var d = document.createElement("div");
+    d.id = "downvote_why";
 
     var reasons;
-    if (thingType == "comment")
+    if (thingType === "comment") {
       reasons = Lobsters.commentDownvoteReasons;
-    else
+    } else {
       reasons = Lobsters.storyFlagReasons;
+    }
 
-    $.each(reasons, function(k, v) {
-      var a = $("<a href=\"#\"" + (k == "" ? " class=\"cancelreason\"" : "") +
-        ">" + v + "</a>");
+    Object.keys(reasons).forEach(function(k) {
+      var v = reasons[k];
+      var a = document.createElement("a");
+      a.setAttribute("href", "#");
+      a.textContent = v;
+      if (k === "") {
+        a.classList.add("cancelreason");
+      }
 
-      a.click(function() {
-        $("#downvote_why").remove();
-        $("#downvote_why_shadow").remove();
+      a.addEventListener("click", function(e) {
+        removeEl(document.getElementById("downvote_why"));
+        removeEl(document.getElementById("downvote_why_shadow"));
 
-        if (k != "")
+        if (k != "") {
           onChooseWhy(k);
+        }
 
-        return false;
+        e.preventDefault();
       });
 
-      d.append(a);
+      d.appendChild(a);
     });
 
-    console.log(voterEl, d);
-    if (thingType == "story") {
-      $(voterEl).closest("li").after(d);
-      d.position({
-        my: "left top",
-        at: "left bottom",
-        offset: "-2 -2",
-        of: $(voterEl),
-        collision: "none",
-      });
-      d.css("left", $(voterEl).position().left);
+    if (thingType === "story") {
+      d.style.top = voterEl.offsetTop + voterEl.offsetHeight - 2 + "px";
+      d.style.left = voterEl.offsetLeft - 2 + "px";
+      voterEl.closest("li").insertAdjacentElement('afterend', d);
     } else {
       // place downvote menu outside of the comment to avoid inheriting opacity
-      var voterPos = $(voterEl).position();
-      d.appendTo($(voterEl).closest(".comments_subtree"));
-      d.css({
-        left: voterPos.left,
-        top: voterPos.top + $(voterEl).outerHeight()
-      });
+      var voterPosLeft = voterEl.offsetLeft;
+      var voterPosTop = voterEl.offsetTop;
+      voterEl.closest(".comments_subtree").appendChild(d);
+      d.style.left = voterPosLeft;
+      d.style.top = voterPosTop + voterEl.offsetHeight;
     }
   },
 

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -1,3 +1,4 @@
+//= require rails-ujs
 //= require jquery
 //= require jquery_ujs
 //= require_tree .
@@ -25,11 +26,6 @@ if (!Element.prototype.closest) {
   };
 }
 
-function post(url, data) {
-  var request = new XMLHttpRequest();
-  request.open('POST', url, true);
-  request.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded; charset=UTF-8');
-  request.send(data);
 }
 
 var _Lobsters = Class.extend({
@@ -64,7 +60,10 @@ var _Lobsters = Class.extend({
       hiderEl.innerHTML = "unhide";
     }
 
-    post("/stories/" + li.getAttribute("data-shortid") + "/" + act);
+    Rails.ajax({
+      type: "POST",
+      url: "/stories/" + li.getAttribute("data-shortid") + "/" + act,
+    });
   },
   saveStory: function(saverEl) {
     if (!Lobsters.curUser)
@@ -82,7 +81,11 @@ var _Lobsters = Class.extend({
       li.classList.add("saved");
       saverEl.innerHTML = "unsave";
     }
-    post("/stories/" + li.getAttribute("data-shortid") + "/" + act);
+
+    Rails.ajax({
+      type: "POST",
+      url: "/stories/" + li.getAttribute("data-shortid") + "/" + act,
+    });
   },
 
   upvoteComment: function(voterEl) {

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -26,6 +26,19 @@ if (!Element.prototype.closest) {
   };
 }
 
+// Parameter encodes an object to replicate jQuery.post's behavior for it's
+// second argument.
+function param(object) {
+  var encodedString = '';
+  for (var prop in object) {
+    if (object.hasOwnProperty(prop) && object[prop] != undefined) {
+      if (encodedString.length > 0) {
+        encodedString += '&';
+      }
+      encodedString += encodeURI(prop + '=' + object[prop]);
+    }
+  }
+  return encodedString;
 }
 
 var _Lobsters = Class.extend({
@@ -169,8 +182,8 @@ var _Lobsters = Class.extend({
     if (!Lobsters.curUser)
       return Lobsters.bounceToLogin();
 
-    var li = $(voterEl).closest(".story, .comment");
-    var scoreDiv = li.find("div.score").get(0);
+    var li = voterEl.closest(".story, .comment");
+    var scoreDiv = li.querySelector("div.score");
     var showScore = true;
     var score = parseInt(scoreDiv.innerHTML);
     if (isNaN(score)) {
@@ -179,55 +192,66 @@ var _Lobsters = Class.extend({
     }
     var action = "";
 
-    if (li.hasClass("upvoted") && point > 0) {
+    if (li.classList.contains("upvoted") && point > 0) {
       /* already upvoted, neutralize */
-      li.removeClass("upvoted");
+      li.classList.remove("upvoted");
       score--;
       action = "unvote";
-    }
-    else if (li.hasClass("downvoted") && point < 0) {
+    } else if (li.classList.contains("downvoted") && point < 0) {
       /* already downvoted, neutralize */
-      li.removeClass("downvoted");
+      li.classList.remove("downvoted");
       score++;
       action = "unvote";
-    }
-    else if (point > 0) {
-      if (li.hasClass("downvoted"))
+    } else if (point > 0) {
+      if (li.classList.contains("downvoted")) {
         /* flip flop */
         score++;
+      }
 
-      li.removeClass("downvoted").addClass("upvoted");
+      li.classList.remove("downvoted");
+      li.classList.add("upvoted");
       score++;
       action = "upvote";
-    }
-    else if (point < 0) {
-      if (li.hasClass("upvoted"))
+    } else if (point < 0) {
+      if (li.classList.contains("upvoted"))
         /* flip flop */
         score--;
 
-      li.removeClass("upvoted").addClass("downvoted");
+      li.classList.remove("upvoted");
+      li.classList.add("downvoted");
       score--;
       action = "downvote";
     }
 
-    if (showScore)
+    if (showScore) {
       scoreDiv.innerHTML = score;
+    }
 
     if (action == "upvote" || action == "unvote") {
-      li.find(".reason").html("");
+      var reasonEl = li.querySelector(".reason");
+      if (reasonEl) {
+        reasonEl.innerHTML = "";
+      }
 
-      if (action == "unvote" && thingType == "story" && point < 0)
-        li.find(".flagger").text("flag");
+      if (action == "unvote" && thingType == "story" && point < 0) {
+        li.querySelector(".flagger").innerText = 'flag';
+      }
+    } else if (action == "downvote" && thingType == "comment") {
+      li.querySelector(".reason").innerHTML = "| " +
+        Lobsters.commentDownvoteReasons[reason].toLowerCase();
+    } else if (action == "downvote" && thingType == "story") {
+      li.querySelector(".flagger").innerText = "unflag";
     }
-    else if (action == "downvote" && thingType == "comment")
-      li.find(".reason").html("| " +
-        Lobsters.commentDownvoteReasons[reason].toLowerCase());
-    else if (action == "downvote" && thingType == "story")
-      li.find(".flagger").text("unflag");
 
-    $.post("/" + (thingType == "story" ? "stories" : thingType + "s") + "/" +
-      li.attr("data-shortid") + "/" +
-      action, { reason: reason });
+    Rails.ajax({
+      type: "POST",
+      url: (
+        "/" + (thingType == "story" ? "stories" : thingType + "s") + "/" +
+        li.getAttribute("data-shortid") + "/" +
+        action
+      ),
+      data: param({ reason: reason }),
+    })
   },
 
   postComment: function(form) {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,6 +22,7 @@
   <% end %>
   <title><%= @title.present? ? "#{@title} | " : "" %><%=
     Rails.application.name %></title>
+  <%= csrf_meta_tags %>
   <%= stylesheet_link_tag "application", :media => "all" %>
   <% if @user %>
     <%= javascript_include_tag "application" %>
@@ -29,7 +30,6 @@
       Lobsters.curUser = '<%= @user.id %>';
     </script>
   <% end %>
-  <%= csrf_meta_tags %>
   <% if @rss_link %>
     <link rel="alternate" type="application/rss+xml"
       title="<%= @rss_link[:title] %>" href="<%= @rss_link[:href] %>" />


### PR DESCRIPTION
Why is addressed in #554. My approach here is to make this a slightly larger PR broken into individual atomic commits. Adding test plans for each commit considering that the JS codebase isn't particularly well tested. If this becomes too big (or I abandon it) I'll just cut the scope of the PR to whatever I get done.

TODO:

- [ ] Remove explicit jQuery references from `application.js.erb`
- [ ] Remove `jquery_class.js`
- [ ] Replace `select2.js`