### PR TITLE
Fix comment spec's order dependence

### DIFF
--- a/spec/features/comment_spec.rb
+++ b/spec/features/comment_spec.rb
@@ -76,11 +76,17 @@ RSpec.feature "Commenting" do
 
     feature "Merging story comments" do
       scenario "upvote merged story comments" do
-        comment = create(:comment, user_id: user.id, story_id: story.id, created_at: 90.days.ago)
+        comment = create(
+          :comment,
+          user_id: user.id,
+          story_id: story.id,
+          created_at: 90.days.ago,
+          comment: "Cool story.",
+        )
 
         stub_login_as user1
         visit "/s/#{story.short_id}"
-        expect(page.find(:css, ".comment .comment_text")).to have_content('comment text 5')
+        expect(page.find(:css, ".comment .comment_text")).to have_content('Cool story.')
         expect(comment.upvotes).to eq(1)
         page.driver.post "/comments/#{comment.short_id}/upvote"
         comment.reload


### PR DESCRIPTION
When the comment spec is run, on of the tests asserts that the
comment's text is a certain string. However that string was not
matching some of the time and causing the test to fail.

The reason is the comment factory has a sequence included in it. It
makes each successive comment look like this:

* "comment text 1"
* "comment text 2"
* "comment text 3"
* etc.

The test file was checking for the string: "comment text 5". When the
whole test file is run in isolation the failing test created a comment
and happened to be the 5th comment created. This let the test pass.

However if the test was run in isolation it would fail (comment text 1)
or when the test suite was run as a whole it would also fail (comment
text 11).

Now, instead of relying on a sequence to set the comment text, I've set
the comment text explicitly because it is part of the thing we are
testing. Now the test can be run in any order or with any number of
other tests and will pass.
