### PR TITLE
CI: Get Bundler 2 first

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ env:
   global:
     - DATABASE_URL=mysql2://root:@localhost/lobsters_dev
     - RAILS_ENV=test
+before_install:
+  - gem install bundler
 before_script:
   - ./bin/rails db:create
   - ./bin/rails db:schema:load


### PR DESCRIPTION
This PR is about trying to **make the build pass:**

Before this change: it says "the Gemfile.lock _demands_ Bundler 2+" and quits. Example: https://travis-ci.org/lobsters/lobsters/builds/505896930

After this change: builds green.