### PR TITLE
Forces encoding to utf-8 when fetching url titles [Resolves #648]

### DIFF
--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -920,9 +920,8 @@ class Story < ApplicationRecord
       begin
         s = Sponge.new
         s.timeout = 3
-        @fetched_content = s.fetch(self.url, :get, nil, nil, {
-          "User-agent" => "#{Rails.application.domain} for #{self.fetching_ip}",
-        }, 3).body.force_encoding('utf-8')
+        user_agent = { "User-agent" => "#{Rails.application.domain} for #{fetching_ip}" }
+        @fetched_content = s.fetch(url, :get, nil, nil, user_agent, 3).body.force_encoding('utf-8')
       rescue
         return @fetched_attributes
       end

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -922,7 +922,7 @@ class Story < ApplicationRecord
         s.timeout = 3
         @fetched_content = s.fetch(self.url, :get, nil, nil, {
           "User-agent" => "#{Rails.application.domain} for #{self.fetching_ip}",
-        }, 3).body.encode!(invalid: :replace, undef: :replace, replace: '')
+        }, 3).body.force_encoding('utf-8')
       rescue
         return @fetched_attributes
       end


### PR DESCRIPTION
~~I found it moderately difficult to write a test case for this, since it seems like all the tests I wrote seemed to assume UTF-8 encoding and passed the \xe2\x80\x99 apostrophe through just fine.~~ Regression test added.

Manual testing confirms that it works for the URL in #648 (https://www.codewithjason.com/sometimes-better-tests-hit-real-api/)

I can't locate Abdullah Samman, the last person to touch this line in 0e198cb9bf39211c22e5293d846e3e6be348e4f1, on GitHub, or I'd tag them as a reviewer.

~~Set to draft PR awaiting feedback on testing! I could spend a bit longer working on getting a test case written or we could just merge it.~~