### PR TITLE
make Homepage spec more reliable

### DIFF
--- a/spec/features/homepage_spec.rb
+++ b/spec/features/homepage_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
 RSpec.feature "Reading Homepage", type: feature do
-  let!(:story) { create(:story) }
+  let!(:story) { create(:story, title: "10 tips for lobstering") }
 
   feature "when logged out" do
     scenario "reading a story" do
       visit "/"
-      expect(page).to have_content(story.title)
+      expect(page).to have_content("10 tips for lobstering")
     end
   end
 
@@ -16,7 +16,7 @@ RSpec.feature "Reading Homepage", type: feature do
 
     scenario "reading a story" do
       visit "/"
-      expect(page).to have_content(story.title)
+      expect(page).to have_content("10 tips for lobstering")
     end
   end
 end


### PR DESCRIPTION
I'm not sure why this was failing, but for whatever reason I would run
the whole test suite and it would fail once in every ~2-4 runs. It kept
looking for a story title that wasn't on the homepage. I switched the
test to look for a title that I had created manually and that seems to
have made it much more reliable. After 20+ whole-suite runs I got no
failures.
