### PR TITLE
Fixes moderation logs for newly created Tags [Resolves #650]

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -59,8 +59,8 @@ class Tag < ApplicationRecord
 
   def log_modifications
     Moderation.create do |m|
-      if self.new_record?
-        m.action = 'Created new tag ' + self.changes.map {|f, c| "with #{f} '#{c[1]}'" }.join(', ')
+      if self.id_previously_changed?
+        m.action = 'Created new tag ' + self.attributes.map {|f, c| "with #{f} '#{c}'" }.join(', ')
       else
         m.action = "Updating tag #{self.tag}, " + self.saved_changes
           .map {|f, c| "changed #{f} from '#{c[0]}' to '#{c[1]}'" } .join(', ')

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -37,17 +37,19 @@ describe Tag do
 
     it 'logs on create' do
       expect { Tag.create(tag: 'tag_name', edit_user_id: edit_user.id) }
-        .to(change { Moderation.count })
-      mod = Moderation.order(id: :desc).first
+        .to change { Moderation.count }.by(1)
+      mod = Moderation.last
       expect(mod.action).to include 'tag_name'
+      expect(mod.action).to start_with 'Created new tag'
       expect(mod.moderator_user_id).to be edit_user.id
     end
 
     it 'logs on update' do
       expect { Tag.first.update(tag: 'new_tag_name', edit_user_id: edit_user.id) }
-        .to(change { Moderation.count })
-      mod = Moderation.order(id: :desc).first
+        .to change { Moderation.count }.by(1)
+      mod = Moderation.last
       expect(mod.action).to include 'new_tag_name'
+      expect(mod.action).to start_with 'Updating'
       expect(mod.moderator_user_id).to be edit_user.id
     end
   end


### PR DESCRIPTION
Turns out `#new_record?` is only `true` before the save, which is not true in an `after_save` callback. I also made the unit tests a bit more specific.

Resolves #650 