### PR TITLE
Q-encode characters as multiple encoded words

### DIFF
--- a/script/mail_new_activity.rb
+++ b/script/mail_new_activity.rb
@@ -9,15 +9,25 @@ Rails.application.require_environment!
 
 class String
   def quoted_printable(encoded_word = false)
-    s = [self].pack("M")
+    string = [self].pack("M")
 
-    if encoded_word
-      s.split(/\r?\n/).map {|l|
-        "=?UTF-8?Q?" + l.gsub(/=*$/, "").gsub('?', '=3F').tr(" ", "_") << "?="
-      }.join("\n\t")
-    else
-      s
-    end
+    return string unless encoded_word
+
+    q_encode_word = ->(w) { "=?UTF-8?Q?#{w}?=" }
+
+    string \
+      # Undo linebreaks from #pack("M") because we'll be adding characters
+      .gsub("=\n", "") \
+      # Question marks are delimiters in q-encoding so must be escaped
+      .gsub("?", "=3F") \
+      # Spaces are insignificant in q-encoding so must be escaped
+      .gsub(' ', ' _') \
+      # Take each space-separated word, then q-encode
+      .split(' ').map(&q_encode_word) \
+      # Recombine words then word wrap at 75 characters
+      .join(" ").word_wrap(75) \
+      # Compose final string, folding headers per rfc 2822 section 2.2.3
+      .lines.join("\t")
   end
 
   # like ActionView::Helpers::TextHelper but preserve > and indentation when

--- a/script/mail_new_activity.rb
+++ b/script/mail_new_activity.rb
@@ -21,7 +21,7 @@ class String
       # Question marks are delimiters in q-encoding so must be escaped
       .gsub("?", "=3F") \
       # Spaces are insignificant in q-encoding so must be escaped
-      .gsub(' ', ' _') \
+      .gsub(/\s+/, ' _') \
       # Take each space-separated word, then q-encode
       .split(' ').map(&q_encode_word) \
       # Recombine words then word wrap at 75 characters

--- a/spec/scripts/mail_new_activity_spec.rb
+++ b/spec/scripts/mail_new_activity_spec.rb
@@ -1,7 +1,41 @@
 require_relative '../../script/mail_new_activity'
 
 describe 'EmailSender' do
-  it "encodes text as quoted printable" do
-    expect("Why Use Pointers?".quoted_printable(true)).to eq("=?UTF-8?Q?Why_Use_Pointers=3F?=")
+  context "encoded words" do
+    it "encodes text as quoted printable" do
+      expect("Why  Use Pointers?".quoted_printable(true))
+        .to eq("=?UTF-8?Q?Why?= =?UTF-8?Q?_?= =?UTF-8?Q?_Use?= =?UTF-8?Q?_Pointers=3F?=")
+    end
+
+    # https://tools.ietf.org/html/rfc2047#section-2
+    # An 'encoded-word' may not be more than 75 characters long, including
+    # 'charset', 'encoding', 'encoded-text', and delimiters.  If it is
+    # desirable to encode more text than will fit in an 'encoded-word' of
+    # 75 characters, multiple 'encoded-word's (separated by CRLF SPACE) may
+    # be used.
+    it 'does not allow lines longer than 75 characters' do
+      string = ("foö " * 30).quoted_printable(true)
+      string.lines.each {|line| expect(line.length).to be <= 75 }
+    end
+
+    it 'does not break on multibyte encoded characters' do
+      q_encoded = (1..30).map { 'ö' * 5 }.join(' ').quoted_printable(true)
+
+      without_space, *remainder = q_encoded.split("\n\t")
+
+      expect(without_space).to eq "=?UTF-8?Q?=C3=B6=C3=B6=C3=B6=C3=B6=C3=B6?="
+      expect(remainder).to all eq "=?UTF-8?Q?_=C3=B6=C3=B6=C3=B6=C3=B6=C3=B6?="
+    end
+
+    it 'handles really long words' do
+      # it does not, in fact, handle long words because it would have to
+      # potentially split in the middle of multibyte characters unless we
+      # parsed the glyphs somehow
+      long_string = 'àéîöuū' * 25
+      q_encoded = long_string.quoted_printable(true)
+      expect(q_encoded.length).to be > long_string.length
+
+      q_encoded.lines.each {|line| expect(line.length).to be <= 75 }
+    end
   end
 end

--- a/spec/scripts/mail_new_activity_spec.rb
+++ b/spec/scripts/mail_new_activity_spec.rb
@@ -29,15 +29,19 @@ describe 'EmailSender' do
       expect(remainder).to all eq "=?UTF-8?Q?_=C3=B6=C3=B6=C3=B6=C3=B6=C3=B6?="
     end
 
-    it 'handles really long words' do
+    xit 'handles really long words' do
       # it does not, in fact, handle long words because it would have to
       # potentially split in the middle of multibyte characters unless we
-      # parsed the glyphs somehow
+      # parsed the glyphs somehow. Current actual behavior is that it
+      # simply does not line break at all.
       long_string = 'àéîöuū' * 25
       q_encoded = long_string.quoted_printable(true)
       expect(q_encoded.length).to be > long_string.length
 
       q_encoded.lines.each {|line| expect(line.length).to be <= 75 }
+      # Failure/Error:  expect(line.length).to be <= 75
+      #   expected: <= 75
+      #   got: 787
     end
   end
 end

--- a/spec/scripts/mail_new_activity_spec.rb
+++ b/spec/scripts/mail_new_activity_spec.rb
@@ -3,8 +3,10 @@ require_relative '../../script/mail_new_activity'
 describe 'EmailSender' do
   context "encoded words" do
     it "encodes text as quoted printable" do
+      # Note two spaces after "Why" - following conventions in many other sites
+      # additional spacing will be removed
       expect("Why  Use Pointers?".quoted_printable(true))
-        .to eq("=?UTF-8?Q?Why?= =?UTF-8?Q?_?= =?UTF-8?Q?_Use?= =?UTF-8?Q?_Pointers=3F?=")
+        .to eq("=?UTF-8?Q?Why?= =?UTF-8?Q?_Use?= =?UTF-8?Q?_Pointers=3F?=")
     end
 
     # https://tools.ietf.org/html/rfc2047#section-2


### PR DESCRIPTION
Unless we parse the text and figure out where the glyph boundaries are, we might end up splitting a glyph between bytes. Considering that was the original complaint in #328, I'm not sure what to do. Granted, the failing case I'm working with - a _really_ long word with multibyte characters - is probably unlikely, but still technically a possibility.

There's a failing test: `it 'handles really long words'` that covers this.

~~Submitting to publish the research / work I've done so far, but not particularly happy with it.~~

Resolves #328