### PR TITLE
Add "Unkind" option

### DIFF
--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -9,6 +9,7 @@ class Vote < ApplicationRecord
     "M" => "Me-too",
     "T" => "Troll",
     "S" => "Spam",
+    "U" => "Unkind",
     "" => "Cancel",
   }.freeze
 


### PR DESCRIPTION
Add a new option "Unkind" when down-voting comments.

As brought up here: https://lobste.rs/s/xnjo8g/add_downvote_reason_unkind

As mentioned in https://lobste.rs/s/xnjo8g/add_downvote_reason_unkind#c_0lzrxb, this is maybe related to https://github.com/lobsters/lobsters/issues/376?

Does the phrasing need to be 100% figured out before any merging? The intent - which seems generally clear - seems important, and if it's being stored as a single character then we can easily adjust language as necessary later?

Note: I used "me-too" as a search term to see if there are any specific tests for this, and the me-too case didn't seem to have any. So, no tests here but happy to add some if people have ideas for what is testable here!

Also, I'm wondering if this requires consideration here?

https://github.com/lobsters/lobsters/blob/d2963d4b80b47ac9f34bda65154a37cdde0a2174/app/controllers/mod_controller.rb#L33