### PR TITLE
#525 multi tag feed

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -193,7 +193,8 @@ class HomeController < ApplicationController
   def tagged
     tag_params = params[:tag].split(',')
     @tags = Tag.where(tag: tag_params)
-    @tags.first!
+
+    raise ActiveRecord::RecordNotFound unless @tags.length == tag_params.length
 
     @stories, @show_more = get_from_cache(tags: tag_params.sort.join(',')) do
       paginate stories.tagged(@tags)

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -191,13 +191,13 @@ class HomeController < ApplicationController
   end
 
   def tagged
-    tag_params = params[:tag].split('+')
+    tag_params = params[:tag].split(',')
     @tags = Tag.where(tag: tag_params)
     @tags.first!
 
-    @stories, @show_more = get_from_cache(tags: tag_params.sort.join('+')) {
+    @stories, @show_more = get_from_cache(tags: tag_params.sort.join(',')) do
       paginate stories.tagged(@tags)
-    }
+    end
 
     @heading = params[:tag]
     @title = @tags.map do |tag|

--- a/app/models/story_repository.rb
+++ b/app/models/story_repository.rb
@@ -30,11 +30,11 @@ class StoryRepository
     Story.base.saved_by(@user).filter_tags(@params[:exclude_tags] || []).order(:hotness)
   end
 
-  def tagged(tag)
+  def tagged(tags)
     tagged = Story.base.positive_ranked.where(
       Story.arel_table[:id].in(
         Tagging.arel_table.where(
-          Tagging.arel_table[:tag_id].eq(tag.id)
+          Tagging.arel_table[:tag_id].in(tags.map(&:id))
         ).project(
           Tagging.arel_table[:story_id]
         )

--- a/app/models/story_repository.rb
+++ b/app/models/story_repository.rb
@@ -31,15 +31,8 @@ class StoryRepository
   end
 
   def tagged(tags)
-    tagged = Story.base.positive_ranked.where(
-      Story.arel_table[:id].in(
-        Tagging.arel_table.where(
-          Tagging.arel_table[:tag_id].in(tags.map(&:id))
-        ).project(
-          Tagging.arel_table[:story_id]
-        )
-      )
-    )
+    tagged = Story.base.positive_ranked.joins(:taggings).where(taggings: { tag_id: tags.map(&:id) })
+
     tagged.order(created_at: :desc)
   end
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -13,7 +13,8 @@ class Tag < ApplicationRecord
   attr_accessor :edit_user_id, :stories_count
   attr_writer :filtered_count
 
-  validates :tag, length: { maximum: 25 }, presence: true, uniqueness: true
+  validates :tag, length: { maximum: 25 }, presence: true,
+                  uniqueness: true, format: { without: /,/ }
   validates :description, length: { maximum: 100 }
   validates :hotness_mod, inclusion: { in: -10..10 }
 

--- a/app/views/home/about.html.erb
+++ b/app/views/home/about.html.erb
@@ -23,7 +23,8 @@
   <p>
   When links/stories are submitted, they must be tagged by the submitter from a list of predefined <a href="/tags">tags</a>.
   Users can choose to <a href="/filters">filter</a> out or
-  subscribe to all submissions with particular tags (<a href="https://lobste.rs/t/programming.rss">example</a>).
+  subscribe to all submissions with particular tags (example: <a href="https://lobste.rs/t/programming.rss">programming.rss</a>)
+  or combinations of tags (example: <a href="https://lobste.rs/t/programming,audio.rss">programming,audio.rss</a>).
   All users see all stories by default.
   The tagging system works this way for three reasons:
   </p>
@@ -227,7 +228,7 @@
   </p></li>
 
   <li><p>
-  <strong><a href="/rss">Per-tag and site-wide RSS feeds</a></strong> are
+  <strong><a href="/rss">Per-tag, multi-tag and site-wide RSS feeds</a></strong> are
   available to the public and logged-in users have private RSS feeds that
   filter out each user's <a href="/filters">filtered tags</a>.
   </p></li>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -3,12 +3,14 @@
     <em>The <a href="/newest">newest</a> stories that have not yet reached the front page.</em>
   </div>
 <% end %>
-<% if @tag %>
+<% if @tags.present? %>
   <div class="box" id="leader">
     Stories <a href="/tags">tagged</a> as
-    <%= tag_link(@tag) %>
-    &ndash;
-    <%= @tag.description %>
+    <% @tags.each do |tag| %>
+      <%= tag_link(@tag) %>
+      &ndash;
+      <%= tag.description %>
+    <% end %>
   </div>
 <% end %>
 

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -14,7 +14,7 @@
       <% end %>
     <% end %>
 
-    <%= render(partial: 'tags/multi_tag_tip', locals: { tags: @tags + Tag.limit(1) }) if @tags.count == 1 %>
+    <%= render(partial: 'tags/multi_tag_tip') if @tags.count == 1 %>
   </div>
 <% end %>
 

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -7,9 +7,11 @@
   <div class="box" id="leader">
     Stories <a href="/tags">tagged</a> as
     <% @tags.each do |tag| %>
-      <%= tag_link(@tag) %>
-      &ndash;
-      <%= tag.description %>
+      <%= tag_link(tag) %>
+
+      <% if tag.description.present? %>
+        &ndash; <%= tag.description %>
+      <% end %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -13,6 +13,8 @@
         &ndash; <%= tag.description %>
       <% end %>
     <% end %>
+
+    <%= render(partial: 'tags/multi_tag_tip', locals: { tags: @tags + Tag.limit(1) }) if @tags.count == 1 %>
   </div>
 <% end %>
 

--- a/app/views/tags/_multi_tag_tip.html.erb
+++ b/app/views/tags/_multi_tag_tip.html.erb
@@ -1,0 +1,5 @@
+<p class="sublegend">
+  Tip: combine tag feeds by delimiting them with commas:
+  <% tags = tags.pluck(:tag)[0..1].join(',') %>
+  <a href="/t/<%= tags %>"><code><%= Rails.application.domain %>/t/<%= tags %></code></a>
+</p >

--- a/app/views/tags/_multi_tag_tip.html.erb
+++ b/app/views/tags/_multi_tag_tip.html.erb
@@ -1,5 +1,3 @@
 <p class="sublegend">
-  Tip: combine tag feeds by delimiting them with commas:
-  <% tags = tags.pluck(:tag)[0..1].join(',') %>
-  <a href="/t/<%= tags %>"><code><%= Rails.application.domain %>/t/<%= tags %></code></a>
+  Tip: read stories across multiple tags with <code>/t/tag1,tag2</code>
 </p >

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -1,6 +1,8 @@
 <div class="box wide">
   <div class="legend">
     Tags
+
+    <%= render partial: 'tags/multi_tag_tip', locals: { tags: @tags } %>
   </div>
 
   <% is_admin = @user.try(:is_admin?) %>

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -2,7 +2,7 @@
   <div class="legend">
     Tags
 
-    <%= render partial: 'tags/multi_tag_tip', locals: { tags: @tags } %>
+    <%= render partial: 'tags/multi_tag_tip' %>
   </div>
 
   <% is_admin = @user.try(:is_admin?) %>

--- a/spec/features/homepage_spec.rb
+++ b/spec/features/homepage_spec.rb
@@ -19,4 +19,37 @@ RSpec.feature "Reading Homepage", type: feature do
       expect(page).to have_content(story.title)
     end
   end
+
+  feature "browsing stories by tag" do
+    let(:tag_a) { Tag.create(tag: 'A1').tag }
+    let(:tag_b) { Tag.create(tag: 'B2').tag }
+    let!(:ab_story) { create(:story, tags_a: [tag_a, tag_b]) }
+    let!(:a_story) { create(:story, tags_a: [tag_a]) }
+    let!(:b_story) { create(:story, tags_a: [tag_b]) }
+
+    scenario "viewing one tag at a time" do
+      visit "/t/#{tag_a}"
+
+      expect(page).to have_content(ab_story.title)
+      expect(page).to have_content(a_story.title)
+
+      visit "/t/#{tag_b}"
+
+      expect(page).to have_content(ab_story.title)
+      expect(page).to have_content(b_story.title)
+    end
+
+    scenario "viewing two tags" do
+      tags = [tag_a, tag_b].join(",")
+      visit "/t/#{tags}"
+
+      expect(page).to have_content(ab_story.title)
+      expect(page).to have_content(a_story.title)
+      expect(page).to have_content(b_story.title)
+    end
+
+    scenario "no tags raises error" do
+      expect { visit "/t/definitelynosuchtaghere" }.to raise_error
+    end
+  end
 end

--- a/spec/features/homepage_spec.rb
+++ b/spec/features/homepage_spec.rb
@@ -48,8 +48,18 @@ RSpec.feature "Reading Homepage", type: feature do
       expect(page).to have_content(b_story.title)
     end
 
-    scenario "no tags raises error" do
-      expect { visit "/t/definitelynosuchtaghere" }.to raise_error
+    context "errors" do
+      scenario "non-existent tag raises error" do
+        expect { visit "/t/definitelynosuchtaghere" }.to raise_error
+      end
+
+      scenario "non-existent tag with existing tag raises an error" do
+        expect { visit "/t/#{tag_a},definitelynosuchtaghere"}.to raise_error
+      end
+
+      scenario "non-unique existing tags raises an error" do
+        expect { visit "/t/#{tag_a},#{tag_a}"}.to raise_error
+      end
     end
   end
 end

--- a/spec/features/homepage_spec.rb
+++ b/spec/features/homepage_spec.rb
@@ -54,11 +54,11 @@ RSpec.feature "Reading Homepage", type: feature do
       end
 
       scenario "non-existent tag with existing tag raises an error" do
-        expect { visit "/t/#{tag_a},definitelynosuchtaghere"}.to raise_error
+        expect { visit "/t/#{tag_a},definitelynosuchtaghere" }.to raise_error
       end
 
       scenario "non-unique existing tags raises an error" do
-        expect { visit "/t/#{tag_a},#{tag_a}"}.to raise_error
+        expect { visit "/t/#{tag_a},#{tag_a}" }.to raise_error
       end
     end
   end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -30,6 +30,10 @@ describe Tag do
     it 'does not allow a tag with a description too long to be saved' do
       expect(Tag.create(tag: 'tag_name', description: 'test_desc' * 20)).not_to be_valid
     end
+
+    it 'does not allow a tag with a comma to be saved' do
+      expect(Tag.create(tag: 'tag,name')).not_to be_valid
+    end
   end
 
   context 'logs modification in moderation log' do


### PR DESCRIPTION
Closes #525 (multi-tag based feed issue)
Builds off of and closes #542 (@sohaibbhatti's PR)

Design decisions:
- Use commas `,` to separate tags in the route parameters
- Validate that tags cannot have commas in them
- Use @sohaibbhatti's active record code snippet *
- Use `&ndash; <%= tag.description %>` only if tag description present

\* Regarding @sohaibbhatti's ActiveRecord code snippet, I was concerned that it might not produce the same output, but I ran an `EXPLAIN` on the MySQL queries that each command output (using `#to_sql`) and it came up with identical plans, so I think it's a fairly safe drop in replacement (more details [here](https://gist.github.com/briankung/83e636096d507b470b1f4120a05847cd))

All in all, not too much to do thanks to @sohaibbhatti's handiwork, unfortunate I can't get a hold of him for thanks or questions!