### PR TITLE
switch dark mode themes to openusercss

### DIFF
--- a/app/views/home/about.html.erb
+++ b/app/views/home/about.html.erb
@@ -283,10 +283,10 @@
     If you prefer to read Lobsters on a dark background instead of a light one, there are a few options. You could install the
     <a href="https://darkreader.org/">Dark Reader extension</a>;
     or an extension to add your own CSS to sites like <a href="https://add0n.com/stylus.html">Stylus</a> or <a href="https://github.com/openstyles/stylus/wiki/Usercss">UserCSS</a> (<a href="https://en.wikipedia.org/wiki/Stylish#Privacy_issues">never Stylish</a>). Themes:
-    <a href="https://userstyles.org/styles/136068/neo-dark-lobsters">1</a>
-    <a href="https://userstyles.org/styles/139281/dark-solarized-lobster">2</a>
-    <a href="https://userstyles.org/styles/115042/dark-lobsters">3</a>
-    <a href="https://userstyles.org/styles/99290/lobste-rs-dark">4</a>.
+    <a href="https://openusercss.org/theme/5cc5ad28ad27da0c0016cf3c">1</a>
+    <a href="https://openusercss.org/theme/5cc5ab1ead27da0c0016cf3a">2</a>
+    <a href="https://openusercss.org/theme/5cc5aeb3ad27da0c0016cf3d">3</a>
+    <a href="https://openusercss.org/theme/5cc5ac10ad27da0c0016cf3b">4</a>.
     Discussion:
     <a href="https://github.com/lobsters/lobsters/issues/404">1</a>
     <a href="https://github.com/lobsters/lobsters/issues/637">2</a>


### PR DESCRIPTION
Migrated the original styles from https://userstyles.org to https://openusercss.org

Background information:
- Stylish and userstyles.org switched ownership(https://www.ghacks.net/2016/10/09/stylish-and-userstyles-org-have-a-new-owner/)
- Stylish is known to have privacy issues (https://en.wikipedia.org/wiki/Stylish#Privacy_issues)
- To avoid Stylish installation recommendation by userstyles.org, I migrated the themes to https://openusercss.org

The themes contain references to the original author, URL and licensing. The [Dark Lobsters](https://openusercss.org/theme/5cc5aeb3ad27da0c0016cf3d) theme had to be modified, as it was not working (white body background).

This is related to pull request https://github.com/lobsters/lobsters/pull/666