### PR TITLE
Better colours for error boxes

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1157,8 +1157,7 @@ div.errorExplanation a {
 }
 div.flash-error p a,
 div.flash-notice p a,
-div.flash-success p a,
-div.errorExplanation a {
+div.flash-success p a {
 	color: #ffffff;
 }
 div.flash-error p,
@@ -1177,10 +1176,10 @@ div.errorExplanation div {
 }
 div.flash-error,
 div.errorExplanation {
-	background-color: #c43c35;
+	background-color: #fdcfcc;
 	background-repeat: repeat-x;
 	background-image: linear-gradient(top, #ee5f5b, #c43c35);
-	text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
+	text-shadow: none;
 	border-color: #c43c35 #c43c35 #882a25;
 	border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
 }


### PR DESCRIPTION
The boxes are hard to read due to the black text on dark red background
colour (contrast ratio: 4.04).

This replaces the background colour with a light red one (ratio: 14.97)
for better readability.

Alternatively, could also muck about with the text colour, but this
looked better IMHO and it was easier to get a good contract ratio
(changing the text to #fff is more readable, but contrast ratio is only
5.19).

<!--
Issues and PRs are typically reviewed Wednesday and some Thursday mornings.
-->
