### PR TITLE
Lobsters + Scout & Nate Berkopec Performance Collab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ config/database.yml
 config/initializers/secret_token.rb
 config/*.sphinx.conf
 config/unicorn.conf.rb
+config/scout_apm.yml

--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem "sitemap_generator" # for better search engine indexing
 
 gem "ruumba"
 
-gem "scout_apm"
+gem "scout_apm", :git => 'git://github.com/scoutapp/scout_apm_ruby.git', :ref => '574b0a6'
 
 group :test, :development do
   gem 'bullet'

--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,8 @@ gem "sitemap_generator" # for better search engine indexing
 
 gem "ruumba"
 
+gem "scout_apm"
+
 group :test, :development do
   gem 'bullet'
   gem 'capybara'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,6 +204,7 @@ GEM
     scenic-mysql_adapter (1.0.1)
       mysql2
       scenic (>= 1.4.0)
+    scout_apm (2.4.24)
     sitemap_generator (6.0.1)
       builder (~> 3.0)
     sprockets (3.7.2)
@@ -266,6 +267,7 @@ DEPENDENCIES
   ruumba
   scenic
   scenic-mysql_adapter
+  scout_apm
   sitemap_generator
   sqlite3
   uglifier (>= 1.3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: git://github.com/scoutapp/scout_apm_ruby.git
+  revision: 574b0a6cf9ee774b5c09e60825f0f6131ea9f005
+  ref: 574b0a6
+  specs:
+    scout_apm (2.4.24)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -204,7 +211,6 @@ GEM
     scenic-mysql_adapter (1.0.1)
       mysql2
       scenic (>= 1.4.0)
-    scout_apm (2.4.24)
     sitemap_generator (6.0.1)
       builder (~> 3.0)
     sprockets (3.7.2)
@@ -267,7 +273,7 @@ DEPENDENCIES
   ruumba
   scenic
   scenic-mysql_adapter
-  scout_apm
+  scout_apm!
   sitemap_generator
   sqlite3
   uglifier (>= 1.3.0)


### PR DESCRIPTION
This is a follow-up on the collaboration between Lobsters and Scout + Nate Berkopec. 

Lobste.rs discussion thread here:
https://lobste.rs/s/5hshvd/proposal_lobste_rs_performance_analysis

In this PR, we've added Scout to the gemfile (referenced by git hash) and config/scout_apm.yml to .gitignore. 

The config file includes the organization's Scout key, so is not included here (e-mailing directly to @pushcx). It also includes the privacy features we've enabled as discussed in the Lobste.rs thread linked above, specifically the disabling of IP collection and query parameters.