### PR TITLE
comment_deletor/comment_undeletor: add missing event parameter to callback

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -491,7 +491,7 @@ $(document).ready(function() {
     });
   });
 
-  $(document).on("click", "a.comment_deletor", function() {
+  $(document).on("click", "a.comment_deletor", function(event) {
     event.preventDefault();
     if (confirm("Are you sure you want to delete this comment?")) {
       var li = $(this).closest(".comment");
@@ -501,7 +501,7 @@ $(document).ready(function() {
       });
     }
   });
-  $(document).on("click", "a.comment_undeletor", function() {
+  $(document).on("click", "a.comment_undeletor", function(event) {
     event.preventDefault();
     if (confirm("Are you sure you want to undelete this comment?")) {
       var li = $(this).closest(".comment");


### PR DESCRIPTION
comment_deletor/comment_undeletor: add missing event parameter to callback

This appears to be a C&P error introduced in
003d47ce221a4bc988b122804a8b7888e007c5f3 due to copying similar code
around here and forgetting to also modify the function parameters:

https://github.com/lobsters/lobsters/blob/003d47ce221a4bc988b122804a8b7888e007c5f3/app/assets/javascripts/application.js.erb#L545
