### PR TITLE
set action_view.form_with_generates_remote_forms to default (true)

### DIFF
--- a/app/views/comments/_commentbox.html.erb
+++ b/app/views/comments/_commentbox.html.erb
@@ -1,6 +1,6 @@
 <div class="comment comment_form_container"
 data-shortid="<%= comment.short_id if comment.persisted? %>">
-<%= form_with url: comment, :id => "edit_comment_#{comment.short_id}" do |f| %>
+<%= form_with url: comment, id: "edit_comment_#{comment.short_id}", local: true do |f| %>
   <% if comment.errors.any? %>
     <%= errors_for comment %>
   <% end %>

--- a/app/views/filters/index.html.erb
+++ b/app/views/filters/index.html.erb
@@ -16,7 +16,7 @@
     </p>
   <% end %>
 
-  <%= form_with url: "/filters", :method => :post do |f| %>
+  <%= form_with url: '/filters', method: :post, local: true do |f| %>
     <table class="data zebra" cellspacing=0 width="75%">
     <tr>
       <th width="7%">Hide</th>

--- a/app/views/hats/build_request.html.erb
+++ b/app/views/hats/build_request.html.erb
@@ -27,7 +27,7 @@
   Old messages will still show it, but you won't be able to use it again.
   </p>
 
-  <%= form_with model: @hat_request, :url => create_hat_request_path do |f| %>
+  <%= form_with model: @hat_request, url: create_hat_request_path, local: true do |f| %>
     <p>
     <%= f.label :hat, "Hat:" %>
     <%= f.text_field :hat, :size => 20,

--- a/app/views/hats/requests_index.html.erb
+++ b/app/views/hats/requests_index.html.erb
@@ -11,8 +11,7 @@
         <hr>
       <% end %>
 
-      <%= form_with model: hr, :url => approve_hat_request_url(:id => hr),
-      :method => :post do |f| %>
+      <%= form_with model: hr, url: approve_hat_request_url(id: hr), method: :post, local: true do |f| %>
         <p>
         <div class="boxline">
           <%= f.label :user_id, "User:", :class => "required" %>
@@ -48,8 +47,7 @@
       <p>
       or
       </p>
-      <%= form_with model: hr, :url => reject_hat_request_url(:id => hr),
-      :method => :post do |f| %>
+      <%= form_with model: hr, url: reject_hat_request_url(id: hr), method: :post, local: true do |f| %>
         <div class="boxline">
           <%= f.label :link, "Reason:", :class => "required" %>
           <%= f.text_area :rejection_comment, :rows => 4 %>

--- a/app/views/invitations/build.html.erb
+++ b/app/views/invitations/build.html.erb
@@ -16,8 +16,7 @@
   shown to any other users (except moderators).
   </p>
 
-  <%= form_with model: @invitation_request,
-  :url => create_invitation_by_request_path do |f| %>
+  <%= form_with model: @invitation_request, url: create_invitation_by_request_path, local: true do |f| %>
     <p>
     <%= f.label :name, "Name (not username):" %>
     <%= f.text_field :name, :size => 30 %>

--- a/app/views/invitations/index.html.erb
+++ b/app/views/invitations/index.html.erb
@@ -26,12 +26,12 @@
           <em><%= ir.email %></em>
         <% end %></td>
       <td><%= raw ir.markeddown_memo %></td>
-      <td><%= form_with url: send_invitation_for_request_path do |f| %>
+      <td><%= form_with url: send_invitation_for_request_path, local: true do |f| %>
           <%= f.hidden_field "code", :value => ir.code %>
         <%= f.submit "Send Invitation", :data => { :confirm => "Are " <<
         "you sure you want to invite this person and remove this request?" } %>
       <% end %></td>
-      <td><%= form_with url: delete_invitation_request_path do |f| %>
+      <td><%= form_with url: delete_invitation_request_path, local: true do |f| %>
           <%= f.hidden_field "code", :value => ir.code %>
         <%= f.submit "Delete", :data => { :confirm => "Are you sure " <<
           "you want to delete this request?" } %>

--- a/app/views/keybase_proofs/new.html.erb
+++ b/app/views/keybase_proofs/new.html.erb
@@ -12,7 +12,7 @@
   <%= image_tag @kb_avatar, width: 100 %>
   </p>
 
-  <%= form_with(url: keybase_proofs_url, scope: :keybase_proof) do |f| %>
+  <%= form_with url: keybase_proofs_url, scope: :keybase_proof, local: true do |f| %>
     Is this you on Keybase? <b><i><%= @kb_username %></b></i>
     <%= f.hidden_field "kb_username", value: @kb_username %>
     <%= f.hidden_field "kb_signature", value: @kb_signature %>

--- a/app/views/login/forgot_password.html.erb
+++ b/app/views/login/forgot_password.html.erb
@@ -8,7 +8,7 @@
   below and instructions will be e-mailed to you.
   </p>
 
-  <%= form_with url: reset_password_path do |f| %>
+  <%= form_with url: reset_password_path, local: true do |f| %>
     <%= f.label :email, "E-mail or Username:" %>
     <%= f.text_field :email, :size => 30 %>
     <br />

--- a/app/views/login/index.html.erb
+++ b/app/views/login/index.html.erb
@@ -10,7 +10,7 @@
     The site is currently in read-only mode for maintenance.
     </p>
   <% else %>
-    <%= form_with url: login_path do |form| %>
+    <%= form_with url: login_path, local: true do |form| %>
     <p>
       <%= form.label :email, "E-mail or Username:" %>
       <%= form.text_field :email, :size => 30, :autofocus => "autofocus" %>

--- a/app/views/login/set_new_password.html.erb
+++ b/app/views/login/set_new_password.html.erb
@@ -3,7 +3,7 @@
     Set New Password
   </div>
 
-  <%= form_with url: set_new_password_path, :autocomplete => "off" do |f| %>
+  <%= form_with url: set_new_password_path, autocomplete: 'off', local: true do |f| %>
     <%= error_messages_for(@reset_user) %>
 
     <%= f.hidden_field "token", :value => params[:token] %>

--- a/app/views/login/twofa.html.erb
+++ b/app/views/login/twofa.html.erb
@@ -3,7 +3,7 @@
     Login - Two Factor Authentication
   </div>
 
-  <%= form_with url: twofa_login_url do |f| %>
+  <%= form_with url: twofa_login_url, local: true do |f| %>
     <p>
     Enter the current TOTP code from your TOTP application:
     </p>

--- a/app/views/messages/_form.html.erb
+++ b/app/views/messages/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: @new_message, url: new_message, :method => :post do |f| %>
+<%= form_with model: @new_message, url: new_message, method: :post, local: true do |f| %>
   <%= error_messages_for @new_message %>
 
   <% if replying %>

--- a/app/views/messages/index.html.erb
+++ b/app/views/messages/index.html.erb
@@ -23,7 +23,7 @@
   </div>
 
   <% if @messages.any? %>
-    <%= form_with url: batch_delete_messages_path do |f| %>
+    <%= form_with url: batch_delete_messages_path, local: true do |f| %>
       <table class="data zebra" width="100%" cellspacing=0>
       <tr>
         <th width="3%"><%= check_box_tag "delete_all",

--- a/app/views/messages/show.html.erb
+++ b/app/views/messages/show.html.erb
@@ -33,20 +33,20 @@
 
   <div class="boxline">
     <div style="float: left;">
-      <%= form_with url:  message_path(@message.short_id), :method => :delete do |f| %>
+      <%= form_with url: message_path(@message.short_id), method: :delete, local: true do |f| %>
         <%= f.submit "Delete Message" %>
       <% end %>
     </div>
 
     <div style="float: left; padding-left: 1em;">
-      <%= form_with url: message_keep_as_new_path(@message.short_id), :method => :post do |f| %>
+      <%= form_with url: message_keep_as_new_path(@message.short_id), method: :post, local: true do |f| %>
         <%= f.submit "Keep As New" %>
       <% end %>
     </div>
 
     <% if @user.is_moderator? %>
       <div style="float: left; padding-left: 1em;">
-        <%= form_with url: message_mod_note_path(@message.short_id), :method => :post do |f| %>
+        <%= form_with url: message_mod_note_path(@message.short_id), method: :post, local: true do |f| %>
           <%= f.submit "ModNote" %>
         <% end %>
       </div>

--- a/app/views/mod_notes/index.html.erb
+++ b/app/views/mod_notes/index.html.erb
@@ -1,6 +1,6 @@
 <%= render partial: 'mod/nav' %>
 
-<%= form_with url: mod_notes_path, method: :get do |f| %>
+<%= form_with url: mod_notes_path, method: :get, local: true do |f| %>
   <div class="boxline">
     <label class="normal" for="username">Username:</label>
     <input type="text" name="username" value="<%= @username %>">

--- a/app/views/moderations/index.html.erb
+++ b/app/views/moderations/index.html.erb
@@ -3,7 +3,7 @@
     Moderation Log
   </div>
 
-  <%= form_with url: moderations_path, :method => :get do |f| %>
+  <%= form_with url: moderations_path, method: :get, local: true do |f| %>
     <label class="normal" for="moderator">Moderator:</label>
     <%= f.select 'moderator', options_for_select(@moderators, @moderator) %>
     <% @what.each do |type, checked| %>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -3,7 +3,7 @@
     Search
   </div>
 
-  <%= form_with url: "/search", :method => :get do |f| %>
+  <%= form_with url: '/search', method: :get, local: true do |f| %>
     <div class="boxline">
         <%= f.text_field "q", { :value => @search.q, :size => 40 }.
         merge(@search.q.present? ? {} : { :autofocus => "autofocus" }) %>

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -10,8 +10,7 @@
     Account Settings (<a href="/u/<%= @user.username %>">View Profile</a>)
   </div>
 
-  <%= form_with :model => @edit_user, :url => settings_path, :method => :post,
-  :id => "edit_user" do |f| %>
+  <%= form_with model: @edit_user, url: settings_path, method: :post, id: 'edit_user', local: true do |f| %>
     <%= error_messages_for f.object %>
 
     <div class="boxline">
@@ -317,8 +316,7 @@
   <br>
 
   <div class="deletion">
-      <%= form_with :model => @edit_user, :url => delete_account_path, :method => :post,
-            :id => "delete_user" do |f| %>
+      <%= form_with model: @edit_user, url: delete_account_path, method: :post, id: 'delete_user', local: true do |f| %>
       <div class="legend">
         Delete Account
       </div>

--- a/app/views/settings/twofa.html.erb
+++ b/app/views/settings/twofa.html.erb
@@ -6,7 +6,7 @@
     <%= @title %>
   </div>
 
-  <%= form_with :model => @user, :url => twofa_auth_url, :method => :post do |f| %>
+  <%= form_with model: @user, url: twofa_auth_url, method: :post, local: true do |f| %>
     <p>
     <% if @user.has_2fa? %>
       To turn off two-factor authentication for your account, enter your

--- a/app/views/settings/twofa_verify.html.erb
+++ b/app/views/settings/twofa_verify.html.erb
@@ -6,7 +6,7 @@
     <%= @title %>
   </div>
 
-  <%= form_with url: twofa_update_url do |f| %>
+  <%= form_with url: twofa_update_url, local: true do |f| %>
     <p>
     To enable Two-Factor Authentication on your account using your new TOTP
     secret, enter the six-digit code from your TOTP application:

--- a/app/views/signup/invited.html.erb
+++ b/app/views/signup/invited.html.erb
@@ -3,7 +3,7 @@
     Create an Account
   </div>
 
-  <%= form_with model: @new_user, :url => signup_path do |f| %>
+  <%= form_with model: @new_user, url: signup_path, local: true do |f| %>
     <p>
     To create a new account, enter your e-mail address and a password.
     Your e-mail address will never be shown to users and will only be used

--- a/app/views/stories/_form_errors.html.erb
+++ b/app/views/stories/_form_errors.html.erb
@@ -17,7 +17,7 @@
       <% if defined?(f) %>
         <%= f.hidden_field :seen_previous %>
       <% else %>
-        <%= form_with model: story do |f| %>
+        <%= form_with model: story, local: true do |f| %>
           <%= f.hidden_field :seen_previous %>
         <% end %>
       <% end %>

--- a/app/views/stories/edit.html.erb
+++ b/app/views/stories/edit.html.erb
@@ -3,8 +3,7 @@
     Edit Story
   </div>
 
-  <%= form_with model: @story, :url => story_path(@story.short_id),
-  :method => :put, :id => "edit_story" do |f| %>
+  <%= form_with model: @story, url: story_path(@story.short_id), method: :put, id: 'edit_story', local: true do |f| %>
     <%= render :partial => "stories/form", :locals => { :story => @story,
       :f => f } %>
 

--- a/app/views/stories/new.html.erb
+++ b/app/views/stories/new.html.erb
@@ -4,7 +4,7 @@
   </div>
 
   <div id="story_holder">
-    <%= form_with model: @story do |f| %>
+    <%= form_with model: @story, local: true do |f| %>
       <%= render :partial => "stories/form", :locals => { :story => @story, :f => f } %>
 
       <p></p>

--- a/app/views/stories/suggest.html.erb
+++ b/app/views/stories/suggest.html.erb
@@ -3,8 +3,7 @@
     Suggest Story Changes
   </div>
 
-  <%= form_with model: @story, :url => story_suggest_path(@story.short_id),
-  :method => :post, :html => { :id => "edit_story" } do |f| %>
+  <%= form_with model: @story, url: story_suggest_path(@story.short_id), method: :post, html: { id: 'edit_story' }, local: true do |f| %>
     <%= render :partial => "stories/form", :locals => { :story => @story,
       :f => f, :suggesting => true } %>
 

--- a/app/views/tags/_form.html.erb
+++ b/app/views/tags/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: @tag, url: @tag.persisted? ? update_tag_path : tags_path, method: :post do |f| %>
+<%= form_with model: @tag, url: @tag.persisted? ? update_tag_path : tags_path, method: :post, local: true do |f| %>
   <div class="boxline">
     <%= f.label :tag, 'Name:', class: 'required' %>
     <%= f.text_field :tag  %>

--- a/app/views/users/_invitationform.html.erb
+++ b/app/views/users/_invitationform.html.erb
@@ -5,7 +5,7 @@ if they cause problems.  Please use your discretion when inviting persons you
 don't personally know.
 </p>
 
-<%= form_with url: invitations_path, :method => :post do |f| %>
+<%= form_with url: invitations_path, method: :post, local: true do |f| %>
   <% if defined?(return_home) && return_home %>
     <%= f.hidden_field :return_home, value: 1 %>
   <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -191,7 +191,7 @@
     <%= render partial: 'mod_notes/table', locals: {
       mod_notes: ModNote.for(@showing_user).limit(10),
     } %>
-    <%= form_with model: @mod_note, method: :post do |f| %>
+    <%= form_with model: @mod_note, method: :post, local: true do |f| %>
       <%= error_messages_for @mod_note %>
       <%= f.hidden_field :username %>
       <div class="boxline">
@@ -236,7 +236,7 @@
       </table>
 
       <% if @showing_user.is_banned? || @showing_user.banned_from_inviting? %>
-        <%= form_with url: user_unban_path, :method => :post do |f| %>
+        <%= form_with url: user_unban_path, method: :post, local: true do |f| %>
           <p>
             <% if @showing_user.is_banned? %>
               <%= f.submit "Unban" %>
@@ -253,7 +253,7 @@
           Banning or disabling invites for a user will send an e-mail to the user with the reason below,
           with your e-mail address as the Reply-To so the user can respond.
         </p>
-        <%= form_with url: user_ban_path, :method => :post do |f| %>
+        <%= form_with url: user_ban_path, method: :post, local: true do |f| %>
           <div class="boxline">
             <%= f.label :reason, "Reason:", :class => "required" %>
             <%= f.text_field :reason, :size => 40 %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,8 +26,6 @@ module Lobsters
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
 
-    config.action_view.form_with_generates_remote_forms = false
-
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading


### PR DESCRIPTION
Now that https://github.com/lobsters/lobsters/issues/527 has been closed, we can use the default value for `action_view.form_with_generates_remote_forms` which is true, and conforms to the defaults of rails. This should remove surprises for people browsing the code.

I also took the time to make the style more consistent.

This also opens up the opportunity for someone to experiment with turning 1 form into a remote form without having to convert them all.