### PR TITLE
update scout apm gem source to https

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem "sitemap_generator" # for better search engine indexing
 
 gem "ruumba"
 
-gem "scout_apm", :git => 'git://github.com/scoutapp/scout_apm_ruby.git', :ref => '574b0a6'
+gem "scout_apm", :git => 'https://github.com/scoutapp/scout_apm_ruby.git', :ref => '574b0a6'
 
 group :test, :development do
   gem 'bullet'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/scoutapp/scout_apm_ruby.git
+  remote: https://github.com/scoutapp/scout_apm_ruby.git
   revision: 574b0a6cf9ee774b5c09e60825f0f6131ea9f005
   ref: 574b0a6
   specs:


### PR DESCRIPTION
when running bundle I kept getting the following error:

```
The git source `git://github.com/scoutapp/scout_apm_ruby.git` uses the `git` protocol, which transmits data without encryption. Disable this warning with `bundle config git.allow_insecure true`, or switch to the `https` protocol to keep your data secure.
```
