### PR TITLE
Turn SSL certificate verification on for critical services

### DIFF
--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -915,6 +915,9 @@ class Story < ApplicationRecord
       begin
         s = Sponge.new
         s.timeout = 3
+        # User submitted URLs may have an incorrect https certificate, but we
+        # don't want to fail the retrieval for this. Security risk is minimal.
+        s.ssl_verify = false
         user_agent = { "User-agent" => "#{Rails.application.domain} for #{fetching_ip}" }
         @fetched_content = s.fetch(url, :get, nil, nil, user_agent, 3).body.force_encoding('utf-8')
       rescue

--- a/extras/sponge.rb
+++ b/extras/sponge.rb
@@ -40,7 +40,7 @@ class Sponge
   MAX_TIME = 60
   MAX_DNS_TIME = 5
 
-  attr_accessor :debug, :last_res, :timeout
+  attr_accessor :debug, :last_res, :timeout, :ssl_verify
 
   # rfc3330
   BAD_NETS = [
@@ -60,12 +60,14 @@ class Sponge
   # old api
   def self.fetch(url, headers = {}, limit = 10)
     s = Sponge.new
+    s.ssl_verify = false # backward compatibility
     s.fetch(url, "get", nil, nil, headers, limit)
   end
 
   def initialize
     @cookies = {}
     @timeout = MAX_TIME
+    @ssl_verify = OpenSSL::SSL::VERIFY_PEER
   end
 
   def set_cookie(host, name, val)
@@ -156,7 +158,7 @@ class Sponge
       host.use_ssl = true
       host.address = uri.host
       host.custom_conn_address = ip.to_s
-      host.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      host.verify_mode = self.ssl_verify ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE
     end
 
     send_headers = headers.dup

--- a/script/send_new_webmentions
+++ b/script/send_new_webmentions
@@ -58,6 +58,9 @@ end
 def send_webmention(source, target, endpoint)
   sp = Sponge.new
   sp.timeout = 10
+  # Don't check SSL certificate here for backward compatibility, security risk
+  # is minimal.
+  sp.ssl_verify = false
   sp.fetch(endpoint.to_s, :post, {
     "source" => URI.encode_www_form_component(source),
     "target" => URI.encode_www_form_component(target),


### PR DESCRIPTION
The `Sponge` class used to skip SSL certificate verification entirely
for all HTTPS calls for all HTTPS calls, which makes Lobsters
vulnerable to some MITM attacks that are easily exploited on private or
corporate LANs. We still want to skip certificate verification when
there's no specific security risk, but we do want to validate
certificates when communicating with well-known APIs, such as
Archive.is, GitHub, Gravatar and PushHover. Note that some APIs are
accessed outside of Sponge, such as Twitter's one.

Turning this verification on will flat out break requests to those
websites in case their certificate expired or is incorrect. This may
trigger a 500 for the users of Lobsters, which is what we want. Note
that for Gravatar the 500 would be limited to avatar serving, and
wouldn't impact the main page of Lobsters.

This PR is supposed to fix concerns detailed in #434. The review should be trivial, but feel free to ask and I'll do my best to answer or improve this proposal.