### PR TITLE
Fix replies missing after unhiding story

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -310,6 +310,7 @@ class StoriesController < ApplicationController
     end
 
     HiddenStory.where(:user_id => @user.id, :story_id => story.id).delete_all
+    ReadRibbon.unhide_replies_for(story.id, @user.id)
 
     render :plain => "ok"
   end

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -299,7 +299,6 @@ class StoriesController < ApplicationController
     end
 
     HiddenStory.hide_story_for_user(story.id, @user.id)
-    ReadRibbon.hide_replies_for(story.id, @user.id)
 
     render :plain => "ok"
   end
@@ -310,7 +309,6 @@ class StoriesController < ApplicationController
     end
 
     HiddenStory.unhide_story_for_user(story.id, @user.id)
-    ReadRibbon.unhide_replies_for(story.id, @user.id)
 
     render :plain => "ok"
   end

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -309,7 +309,7 @@ class StoriesController < ApplicationController
       return render :plain => "can't find story", :status => 400
     end
 
-    HiddenStory.where(:user_id => @user.id, :story_id => story.id).delete_all
+    HiddenStory.unhide_story_for_user(story.id, @user.id)
     ReadRibbon.unhide_replies_for(story.id, @user.id)
 
     render :plain => "ok"

--- a/app/models/hidden_story.rb
+++ b/app/models/hidden_story.rb
@@ -8,4 +8,9 @@ class HiddenStory < ApplicationRecord
     HiddenStory.where(:user_id => user_id, :story_id =>
       story_id).first_or_initialize.save!
   end
+
+  def self.unhide_story_for_user(story_id, user_id)
+    HiddenStory.where(:user_id => user_id, :story_id =>
+      story_id).delete_all
+  end
 end

--- a/app/models/hidden_story.rb
+++ b/app/models/hidden_story.rb
@@ -7,10 +7,12 @@ class HiddenStory < ApplicationRecord
   def self.hide_story_for_user(story_id, user_id)
     HiddenStory.where(:user_id => user_id, :story_id =>
       story_id).first_or_initialize.save!
+    ReadRibbon.hide_replies_for(story_id, user_id)
   end
 
   def self.unhide_story_for_user(story_id, user_id)
     HiddenStory.where(:user_id => user_id, :story_id =>
       story_id).delete_all
+    ReadRibbon.unhide_replies_for(story_id, user_id)
   end
 end

--- a/app/models/read_ribbon.rb
+++ b/app/models/read_ribbon.rb
@@ -10,4 +10,10 @@ class ReadRibbon < ApplicationRecord
     ribbon.is_following = false
     ribbon.save!
   end
+
+  def self.unhide_replies_for(story_id, user_id)
+    ribbon = find_or_create_by(user_id: user_id, story_id: story_id)
+    ribbon.is_following = true
+    ribbon.save!
+  end
 end

--- a/app/models/read_ribbon.rb
+++ b/app/models/read_ribbon.rb
@@ -6,14 +6,16 @@ class ReadRibbon < ApplicationRecord
   # StoriesController uses .touch and RepliesController uses update_all
 
   def self.hide_replies_for(story_id, user_id)
-    ribbon = find_or_create_by(user_id: user_id, story_id: story_id)
-    ribbon.is_following = false
-    ribbon.save!
+    if (ribbon = find_by(user_id: user_id, story_id: story_id))
+      ribbon.is_following = false
+      ribbon.save!
+    end
   end
 
   def self.unhide_replies_for(story_id, user_id)
-    ribbon = find_or_create_by(user_id: user_id, story_id: story_id)
-    ribbon.is_following = true
-    ribbon.save!
+    if (ribbon = find_by(user_id: user_id, story_id: story_id))
+      ribbon.is_following = true
+      ribbon.save!
+    end
   end
 end


### PR DESCRIPTION
This PR aims at fixing #675.

As said in the issue, ReadRibbon for a given story is marked as "is_following = false" when hiding the story, making replies not displayed in the "Replies" section. But when unhiding a story we don't mark it back as "is_following = true", hence the problem.

The PR also has 2 small refactor commits that are neutral from a behavior point of vue but make the code a bit more coherent.

HiddenStory and ReadRibbon related behaviors were not tested previously. We may want to add a test, it might be a bit tautological but let me know, I can give it a try.

Of course feel free to tell me what to improve in this proposal!