### PR TITLE
use released scout_apm gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem "sitemap_generator" # for better search engine indexing
 
 gem "ruumba"
 
-gem "scout_apm", :git => 'https://github.com/scoutapp/scout_apm_ruby.git', :ref => '574b0a6'
+gem "scout_apm"
 
 group :test, :development do
   gem 'bullet'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: https://github.com/scoutapp/scout_apm_ruby.git
-  revision: 574b0a6cf9ee774b5c09e60825f0f6131ea9f005
-  ref: 574b0a6
-  specs:
-    scout_apm (2.4.24)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -212,6 +205,7 @@ GEM
     scenic-mysql_adapter (1.0.1)
       mysql2
       scenic (>= 1.4.0)
+    scout_apm (2.5.1)
     sitemap_generator (6.0.2)
       builder (~> 3.0)
     sprockets (3.7.2)
@@ -274,7 +268,7 @@ DEPENDENCIES
   ruumba
   scenic
   scenic-mysql_adapter
-  scout_apm!
+  scout_apm
   sitemap_generator
   uglifier (>= 1.3.0)
   unicorn


### PR DESCRIPTION
Not sure why the git version was used in the first place, but there has been a new release that includes the commit that it was pinned to.