### PR TITLE
Properly redirect json requests for a merged story's show page

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -119,8 +119,15 @@ class StoriesController < ApplicationController
     # @story was already loaded by track_story_reads for logged-in users
     @story ||= Story.where(short_id: params[:id]).first!
     if @story.merged_into_story
-      flash[:success] = "\"#{@story.title}\" has been merged into this story."
-      return redirect_to @story.merged_into_story.comments_path
+      respond_to do |format|
+        format.html {
+          flash[:success] = "\"#{@story.title}\" has been merged into this story."
+          return redirect_to @story.merged_into_story.comments_path
+        }
+        format.json {
+          return redirect_to(story_path @story.merged_into_story, format: :json)
+        }
+      end
     end
 
     if !@story.can_be_seen_by_user?(@user)

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -125,7 +125,7 @@ class StoriesController < ApplicationController
           return redirect_to @story.merged_into_story.comments_path
         }
         format.json {
-          return redirect_to(story_path @story.merged_into_story, format: :json)
+          return redirect_to(story_path(@story.merged_into_story, format: :json))
         }
       end
     end

--- a/spec/controllers/stories_controller_spec.rb
+++ b/spec/controllers/stories_controller_spec.rb
@@ -129,4 +129,18 @@ describe StoriesController do
       expect(s.merged_into_story).to be_nil
     end
   end
+
+  describe "show" do
+    context "json" do
+      context "for a story that merged into another story" do
+        let(:merged_into_story) { create(:story) }
+        let(:story) { create(:story, merged_into_story: merged_into_story) }
+
+        it "redirects to the merged story's json" do
+          get :show, params: { id: story.short_id, format: :json }
+          expect(response).to redirect_to action: :show, id: merged_into_story.short_id, format: :json
+        end
+      end
+    end
+  end
 end

--- a/spec/controllers/stories_controller_spec.rb
+++ b/spec/controllers/stories_controller_spec.rb
@@ -83,6 +83,7 @@ describe StoriesController do
 
   describe "#undelete" do
     before { stub_login_as user }
+
     let(:deleted_story) { create(:story, :deleted, user: user) }
 
     it "decrements the user's count of deleted stories" do
@@ -138,7 +139,9 @@ describe StoriesController do
 
         it "redirects to the merged story's json" do
           get :show, params: { id: story.short_id, format: :json }
-          expect(response).to redirect_to action: :show, id: merged_into_story.short_id, format: :json
+          expect(response).to redirect_to(action: :show,
+                                          id: merged_into_story.short_id,
+                                          format: :json)
         end
       end
     end

--- a/spec/features/read_story_spec.rb
+++ b/spec/features/read_story_spec.rb
@@ -34,7 +34,7 @@ RSpec.feature "Reading Stories", type: :feature do
 
     it "redirects links" do
       visit merged.comments_path
-      expect(page.current_path).to eq(story.comments_path)
+      expect(page).to have_current_path(story.comments_path)
     end
 
     it "shows merged story at the top" do


### PR DESCRIPTION
Attempt to fix #706.

Using the example from the bug report, a request to `https://lobste.rs/s/2ftw37.json` will now return a 302 to `https://lobste.rs/stories/sfo06b.json`