### PR TITLE
enforce content security policy

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -22,4 +22,4 @@ end
 # Report CSP violations to a specified URI
 # For further information see the following documentation:
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only
-Rails.application.config.content_security_policy_report_only = true
+Rails.application.config.content_security_policy_report_only = false

--- a/spec/requests/content_security_policy_spec.rb
+++ b/spec/requests/content_security_policy_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+describe 'content security policy' do
+  it 'sets the correct headers' do
+    get '/'
+
+    directives = [
+      "default-src 'none'",
+      "img-src * data:",
+      "script-src 'self' 'unsafe-inline'",
+      "style-src 'self' 'unsafe-inline'",
+      "form-action 'self'",
+      "report-uri /csp-violation-report"
+    ].join('; ')
+
+    expect(response.headers['Content-Security-Policy']).to eq(directives)
+  end
+end

--- a/spec/requests/content_security_policy_spec.rb
+++ b/spec/requests/content_security_policy_spec.rb
@@ -10,7 +10,7 @@ describe 'content security policy' do
       "script-src 'self' 'unsafe-inline'",
       "style-src 'self' 'unsafe-inline'",
       "form-action 'self'",
-      "report-uri /csp-violation-report"
+      "report-uri /csp-violation-report",
     ].join('; ')
 
     expect(response.headers['Content-Security-Policy']).to eq(directives)


### PR DESCRIPTION
Now that enough time has passed since https://github.com/lobsters/lobsters/pull/698 we should enable the enforcement of the content security policy.

I also added a requests (as discussed in https://github.com/lobsters/lobsters/issues/704) test for csp so that the headers get their own tests.