### PR TITLE
Fix bug preventing the inactive-user user to reset their password

### DIFF
--- a/app/controllers/login_controller.rb
+++ b/app/controllers/login_controller.rb
@@ -116,7 +116,7 @@ class LoginController < ApplicationController
     end
 
     if @found_user.is_wiped?
-      flash.now[:error] = "It's not possible to reest your password " <<
+      flash.now[:error] = "It's not possible to reset your password " <<
                           "because your account was deleted before the site changed admins " <<
                           "and your email address was wiped for privacy."
       return forgot_password

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -110,7 +110,7 @@ class User < ApplicationRecord
   end
 
   BANNED_USERNAMES = ["admin", "administrator", "contact", "fraud", "guest",
-    "help", "hostmaster", "inactive-user", "lobster", "lobsters", "mailer-daemon", "moderator",
+    "help", "hostmaster", "lobster", "lobsters", "mailer-daemon", "moderator",
     "moderators", "nobody", "postmaster", "root", "security", "support",
     "sysop", "webmaster", "enable", "new", "signup",].freeze
 


### PR DESCRIPTION
Fix bug preventing the inactive-user user account from being created by *rake db:seed* as well as preventing the inactive-user user to reset their password.
