### PR TITLE
bugfix: actually raise on too many code collisions

### DIFF
--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -14,16 +14,11 @@ class Invitation < ApplicationRecord
   before_validation :create_code, :on => :create
 
   def create_code
-    (1...10).each do |tries|
-      if tries == 10
-        raise "too many hash collisions"
-      end
-
+    10.times do
       self.code = Utils.random_str(15)
-      unless Invitation.exists?(:code => self.code)
-        break
-      end
+      return unless Invitation.exists?(:code => self.code)
     end
+    raise "too many hash collisions"
   end
 
   def send_email

--- a/app/models/invitation_request.rb
+++ b/app/models/invitation_request.rb
@@ -11,16 +11,11 @@ class InvitationRequest < ApplicationRecord
   end
 
   def create_code
-    (1...10).each do |tries|
-      if tries == 10
-        raise "too many hash collisions"
-      end
-
+    10.times do
       self.code = Utils.random_str(15)
-      unless InvitationRequest.exists?(:code => self.code)
-        break
-      end
+      return unless InvitationRequest.exists?(:code => self.code)
     end
+    raise "too many hash collisions"
   end
 
   def markeddown_memo


### PR DESCRIPTION
Creating codes for invitations and invitation requests should raise on
the 10th attempt.

The "too many hash collisions" exception is never raised because the 10th try never happens. Using the inclusive range operator, instead of the exclusive one, makes it work.

Aside: the code columns for these models are missing a unique index. Is it worth adding or are too few concurrent creates for invitations and invitation requests for that to matter?