### PR TITLE
Add tag regex

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -286,8 +286,8 @@ var _Lobsters = Class.extend({
       return tagAcc;
     },[]);
     $('#regex_suggested_tags').html(
-      suggestedTags.length === 0 ? '' :
-      "Suggested tags: " + suggestedTags.join(' ')
+      (suggestedTags.length === 0) ? ('') :
+      ("Suggested tags: " + suggestedTags.join(' '))
     );
   },
 

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -276,6 +276,19 @@ var _Lobsters = Class.extend({
     ) {
       $('.title-reminder').slideDown();
     }
+
+    // add tag suggestions if possible
+    var suggestedTags = $('#story_tags_a > option').reduce(function(tagAcc,$tag){
+      var tagRegex = $($tag).data("suggestionRegex") || '';
+      if (tagRegex.length > 0 && title.match(new RegExp(tagRegex))){
+        tagAcc.push($tag.value);
+      }
+      return tagAcc;
+    },[]);
+    $('#regex_suggested_tags').html(
+      suggestedTags.length === 0 ? '' :
+      "Suggested tags: " + suggestedTags.join(' ')
+    );
   },
 
   runSelect2: function() {

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -51,6 +51,7 @@ private
     params.require(:tag).permit(
       :tag,
       :description,
+      :suggestion_regex,
       :privileged,
       :inactive,
       :hotness_mod,

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -10,7 +10,7 @@ class Tag < ApplicationRecord
 
   after_save :log_modifications
 
-  attr_accessor :edit_user_id, :stories_count, :suggestion_regex
+  attr_accessor :edit_user_id, :stories_count
   attr_writer :filtered_count
 
   validates :tag, length: { maximum: 25 }, presence: true,

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -10,7 +10,7 @@ class Tag < ApplicationRecord
 
   after_save :log_modifications
 
-  attr_accessor :edit_user_id, :stories_count
+  attr_accessor :edit_user_id, :stories_count, :suggestion_regex
   attr_writer :filtered_count
 
   validates :tag, length: { maximum: 25 }, presence: true,

--- a/app/views/stories/_form.html.erb
+++ b/app/views/stories/_form.html.erb
@@ -50,7 +50,7 @@
           (t.filtered_count == 1 ? "" : "s") << " filtering</em>"
       end
 
-      [ "#{t.tag} - #{t.description}", t.tag, { "data-html" => raw(html) } ]},
+      [ "#{t.tag} - #{t.description}", t.tag, { "data-html" => raw(html), "data-suggestionRegex" => raw(t.suggestion_regex || "") } ]},
     f.object.tags_a), {}, { :multiple => true } %>
   </div>
 

--- a/app/views/stories/_form.html.erb
+++ b/app/views/stories/_form.html.erb
@@ -52,6 +52,9 @@
 
       [ "#{t.tag} - #{t.description}", t.tag, { "data-html" => raw(html), "data-suggestionRegex" => raw(t.suggestion_regex || "") } ]},
     f.object.tags_a), {}, { :multiple => true } %>
+
+    <div id="regex_suggested_tags">
+    </div>
   </div>
 
   <% if f.object.id && !defined?(suggesting) && f.object.suggested_tagging_times.any? %>

--- a/app/views/tags/_form.html.erb
+++ b/app/views/tags/_form.html.erb
@@ -10,6 +10,11 @@
   </div>
 
   <div class="boxline">
+    <%= f.label :suggestion_regex, 'Suggestion regex:' %>
+    <%= f.text_field :suggestion_regex %>
+  </div>
+
+  <div class="boxline">
     <%= f.label :privileged, 'Privileged:' %>
     <%= f.check_box :privileged %>
   </div>

--- a/db/migrate/20190916000000_add_tag_regex.rb
+++ b/db/migrate/20190916000000_add_tag_regex.rb
@@ -1,0 +1,5 @@
+class AddTagRegex < ActiveRecord::Migration[5.2]
+    def change
+      add_column :tags, :suggestion_regex, :string, :default => ""
+    end
+  end


### PR DESCRIPTION
<!--
Issues and PRs are typically reviewed Wednesday and some Thursday mornings.
-->

## Description

This is a quick attempt at putting in a regex-based tag suggestion system for Lobsters.

## Motivation

If a user submits a story whose title is "Announcing Linux 5.3!", we should be able to guess that the tags relevant may be `release` and `linux`. Similarly, a submission of "Foobar for Python and Go" is pretty obviously likely to be about `python` and `go`. 

We can nudge users in the correct direction by providing feedback *before* they make mislabeled submissions. I think this can be done with a simple regex-based approach without having to do ML or stats or anything.

## Implementation

It works by adding a "suggestion_regex" field to the tag model, and then changing the story submission form to have a `regex_suggested_tags` div that is normally empty but, after a run of the `checkStoryTitle()` function, will be populated with a list of tags whose regexes matched on the title.

Any regex of zero length is considered as "do not try to suggest this tag automagically".

## Future improvements

* Adding more robust protection against malicious tag regexes. No limit in size is currently present, and no attempt is made on the server-side that the submitted regex is valid for JS. No attempt is made to prevent input of, say, a regex that is just whitespace.
* Adding a way of testing the regex in the tag edtior.
* Changing the tag suggestions to be clickable (this would almost certainly be a big help).
* Preventing display of tags that have already been selected.
* Tests. Always tests.


~

I'm throwing this up for @hmadison to kick the tires on, and we can proceed from there.