### PR TITLE
return 404 for search when requested format is not html

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -2,7 +2,6 @@ class SearchController < ApplicationController
   def index
     respond_to do |format|
       format.html { render_search }
-      format.all { render status: :not_found, plain: '404 not found' }
     end
   end
 

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,5 +1,14 @@
 class SearchController < ApplicationController
   def index
+    respond_to do |format|
+      format.html { render_search }
+      format.all { render status: :not_found, plain: '404 not found' }
+    end
+  end
+
+private
+
+  def render_search
     @title = "Search"
     @cur_url = "/search"
 
@@ -23,10 +32,6 @@ class SearchController < ApplicationController
       end
     end
 
-    respond_to :html
-  end
-
-  rescue_from ActionController::UnknownFormat do
-    render status: :not_found, plain: '404 not found'
+    render action: :index
   end
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -23,6 +23,10 @@ class SearchController < ApplicationController
       end
     end
 
-    render :action => "index"
+    respond_to :html
+  end
+
+  rescue_from ActionController::UnknownFormat do
+    render status: :not_found, plain: '404 not found'
   end
 end

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -2,16 +2,20 @@ require 'rails_helper'
 
 describe SearchController do
   describe '#index' do
-    it 'response okish for html requests' do
-      get :index
+    context 'when requesting html view' do
+      it 'responses with oki' do
+        get :index
 
-      expect(response).to have_http_status(:ok)
+        expect(response).to have_http_status(:ok)
+      end
     end
 
-    it 'responses with a 404 for rss requests' do
-      get :index, format: :rss
+    context 'when requested with another format' do
+      it 'responses with a 404' do
+        get :index, format: :rss
 
-      expect(response).to have_http_status(:not_found)
+        expect(response).to have_http_status(:not_found)
+      end
     end
   end
 end

--- a/spec/controllers/search_controller_spec.rb
+++ b/spec/controllers/search_controller_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+describe SearchController do
+  describe '#index' do
+    it 'response okish for html requests' do
+      get :index
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'responses with a 404 for rss requests' do
+      get :index, format: :rss
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end


### PR DESCRIPTION
this solves https://github.com/lobsters/lobsters/issues/746 and returns a 404 when the search is requested with a different format than html

room for improvement: don't execute the search when the requested format is not html. This would may require another method to keep the code cleaner and IDK if it's worth the effort