### PR TITLE
Add validation for invitation and invitation request

### DIFF
--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -11,6 +11,8 @@ class Invitation < ApplicationRecord
     end
   end
 
+  validates :code, :email, :memo, length: { maximum: 255 }
+
   before_validation :create_code, :on => :create
 
   def create_code

--- a/app/models/invitation_request.rb
+++ b/app/models/invitation_request.rb
@@ -1,7 +1,15 @@
 class InvitationRequest < ApplicationRecord
-  validates :name, :presence => true
-  validates :email, :format => { :with => /\A[^@ ]+@[^@ ]+\.[^@ ]+\Z/ }, :presence => true
-  validates :memo, :format => { :with => /https?:\/\// }
+  validates :name,
+            :presence => true,
+            :length => { maximum: 255 }
+  validates :email,
+            :format => { :with => /\A[^@ ]+@[^@ ]+\.[^@ ]+\Z/ },
+            :presence => true,
+            :length => { maximum: 255 }
+  validates :memo,
+            :format => { :with => /https?:\/\// },
+            :length => { maximum: 255 }
+  validates :code, :ip_address, :length => { maximum: 255 }
 
   before_validation :create_code
   after_create :send_email

--- a/spec/factories/invitation.rb
+++ b/spec/factories/invitation.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :invitation do
+    sequence(:email) {|n| "user-#{n}@example.com" }
+    memo { 'some text for memo' }
+  end
+end

--- a/spec/factories/invitation_request.rb
+++ b/spec/factories/invitation_request.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :invitation_request do
+    name { 'pete smith' }
+    sequence(:email) {|n| "user-#{n}@example.com" }
+    memo { 'some text for memo' }
+    ip_address { '1.1.1.1' }
+  end
+end

--- a/spec/models/invitation_request_spec.rb
+++ b/spec/models/invitation_request_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+describe InvitationRequest do
+  it "has a limit on the email field" do
+    invitation_request = build(:invitation_request, email: "a" * 256)
+    expect(invitation_request).to_not be_valid
+  end
+
+  it "has a limit on the code field" do
+    invitation_request = build(:invitation_request)
+    invitation_request.code = "a" * 256
+    expect(invitation_request).to_not be_valid
+  end
+
+  it "has a limit on the memo field" do
+    invitation_request = build(:invitation_request, memo: "a" * 256)
+    expect(invitation_request).to_not be_valid
+  end
+
+  it "has a limit on the name field" do
+    invitation_request = build(:invitation_request, name: "a" * 256)
+    expect(invitation_request).to_not be_valid
+  end
+
+  it "has a limit on the ip_address field" do
+    invitation_request = build(:invitation_request, ip_address: "a" * 256)
+    expect(invitation_request).to_not be_valid
+  end
+end

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe Invitation do
+  it "has a limit on the email field" do
+    invitation = build(:invitation, email: "a" * 256)
+    expect(invitation).to_not be_valid
+  end
+
+  it "has a limit on the code field" do
+    invitation = build(:invitation)
+    invitation.code = "a" * 256
+    expect(invitation).to_not be_valid
+  end
+
+  it "has a limit on the memo field" do
+    invitation = build(:invitation, memo: "a" * 256)
+    expect(invitation).to_not be_valid
+  end
+end


### PR DESCRIPTION
This adds validation and tests for the `Invitation` and `InvitationRequest` models to fix some parts of #745 