### PR TITLE
switch 'cached' link back to the Internet Archive

### DIFF
--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -278,7 +278,8 @@ class Story < ApplicationRecord
   end
 
   def archive_url
-    "https://archive.is/#{CGI.escape(self.url)}"
+    datecode = (self.created_at || Time.current).utc.strftime("%Y%m%d%H%M%S")
+    "https://web.archive.org/web/#{datecode}/#{self.url}"
   end
 
   def as_json(options = {})

--- a/extras/story_cacher.rb
+++ b/extras/story_cacher.rb
@@ -40,12 +40,14 @@ class StoryCacher
       Rails.logger.error "error fetching #{db_url}: #{e.message}"
     end
 
+    ia_url = "https://web.archive.org/save/#{story.url}"
+
     begin
       s = Sponge.new
       s.timeout = 45
-      s.fetch(story.archive_url)
+      s.fetch(ia_url)
     rescue => e
-      Rails.logger.error "error caching #{db_url}: #{e.message}"
+      Rails.logger.error "error caching #{ia_url}: #{e.message}"
     end
 
     nil


### PR DESCRIPTION
Feedback welcome, commit message below. I'll post this to the lobsters thread as well. I haven't been able to test this out yet, but the CI seems happy with it (famous last words?). 

-----

As discussed in
https://lobste.rs/s/yadlxj/pointing_cached_at_internet_archive, point
the 'cached' link for a story to the Internet Archive's Wayback Machine.
The closest date to the submitted date will be selected, the newest one
if that is unavailable.
Also fixes the error message for failed archival (the URL pointed to
diffbot.com)

<!--
Issues and PRs are typically reviewed Wednesday and some Thursday mornings.
-->
