### PR TITLE
Add validations into models(#745)

### DIFF
--- a/app/models/keystore.rb
+++ b/app/models/keystore.rb
@@ -1,7 +1,9 @@
 class Keystore < ApplicationRecord
+  MAX_KEY_LENGTH = 50
+
   self.primary_key = "key"
 
-  validates :key, presence: true, length: { maximum: 50 }
+  validates :key, presence: true, length: { maximum: MAX_KEY_LENGTH }
 
   def self.get(key)
     self.find_by(:key => key)
@@ -94,7 +96,8 @@ class Keystore < ApplicationRecord
   end
 
   def self.validate_input_key(key)
-    exception = ActiveRecord::ValueTooLong.new('50 characters is the maximum allowed for key')
-    raise exception if key.length > 50
+    exception = ActiveRecord::ValueTooLong.new("#{MAX_KEY_LENGTH}" \
+      " characters is the maximum allowed for key")
+    raise exception if key.length > MAX_KEY_LENGTH
   end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -15,6 +15,7 @@ class Message < ApplicationRecord
 
   validates :subject, length: { :in => 1..100 }
   validates :body, length: { :maximum => (64 * 1024) }
+  validates :short_id, length: { maximum: 30 }
   validate :hat do
     next if hat.blank?
     if author.blank? || author.wearable_hats.exclude?(hat)

--- a/app/models/mod_note.rb
+++ b/app/models/mod_note.rb
@@ -8,7 +8,7 @@ class ModNote < ApplicationRecord
   scope :recent, -> { where('created_at >= ?', 1.week.ago).order('created_at desc') }
   scope :for, ->(user) { includes(:moderator).where('user_id = ?', user).order('created_at desc') }
 
-  validates :note, presence: true
+  validates :note, :markeddown_note, presence: true, length: { maximum: 65_535 }
 
   delegate :username, to: :user
 

--- a/app/models/moderation.rb
+++ b/app/models/moderation.rb
@@ -20,6 +20,8 @@ class Moderation < ApplicationRecord
       comments.user_id = ?", user, user, user)
   }
 
+  validates :action, :reason, length: { maximum: 16_777_215 }
+
   after_create :send_message_to_moderated
 
   def send_message_to_moderated

--- a/db/migrate/20191008123620_add_foreign_key_for_messages_and_comments.rb
+++ b/db/migrate/20191008123620_add_foreign_key_for_messages_and_comments.rb
@@ -1,0 +1,13 @@
+class AddForeignKeyForMessagesAndComments < ActiveRecord::Migration[5.2]
+  def change
+    reversible do |dir|
+      dir.up do
+        execute "ALTER TABLE messages ADD FOREIGN KEY (author_user_id) REFERENCES users(id);"
+      end
+
+      dir.down do
+        remove_foreign_key :messages, :users
+      end
+    end
+  end
+end

--- a/db/migrate/20191010172004_add_index_for_moderations_associated_model.rb
+++ b/db/migrate/20191010172004_add_index_for_moderations_associated_model.rb
@@ -1,0 +1,5 @@
+class AddIndexForModerationsAssociatedModel < ActiveRecord::Migration[5.2]
+  def change
+    add_index :moderations, :user_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -111,6 +111,7 @@ ActiveRecord::Schema.define(version: 2019_10_29_021735) do
     t.boolean "deleted_by_author", default: false
     t.boolean "deleted_by_recipient", default: false
     t.bigint "hat_id", unsigned: true
+    t.index ["author_user_id"], name: "author_user_id"
     t.index ["hat_id"], name: "index_messages_on_hat_id"
     t.index ["recipient_user_id"], name: "messages_recipient_user_id_fk"
     t.index ["short_id"], name: "random_hash", unique: true
@@ -143,6 +144,7 @@ ActiveRecord::Schema.define(version: 2019_10_29_021735) do
     t.index ["moderator_user_id"], name: "moderations_moderator_user_id_fk"
     t.index ["story_id"], name: "moderations_story_id_fk"
     t.index ["tag_id"], name: "moderations_tag_id_fk"
+    t.index ["user_id"], name: "index_moderations_on_user_id"
   end
 
   create_table "read_ribbons", id: :bigint, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
@@ -302,6 +304,7 @@ ActiveRecord::Schema.define(version: 2019_10_29_021735) do
   add_foreign_key "invitations", "users", column: "new_user_id", name: "invitations_new_user_id_fk"
   add_foreign_key "invitations", "users", name: "invitations_user_id_fk"
   add_foreign_key "messages", "hats", name: "messages_hat_id_fk"
+  add_foreign_key "messages", "users", column: "author_user_id", name: "messages_ibfk_1"
   add_foreign_key "messages", "users", column: "recipient_user_id", name: "messages_recipient_user_id_fk"
   add_foreign_key "mod_notes", "users", column: "moderator_user_id", name: "mod_notes_moderator_user_id_fk"
   add_foreign_key "mod_notes", "users", name: "mod_notes_user_id_fk"

--- a/spec/models/keystore_spec.rb
+++ b/spec/models/keystore_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+describe Keystore do
+  let(:valid_key) { 'a' * 50 }
+  let(:invalid_key) { 'a' * 51 }
+  let(:value) { rand(100) }
+
+  describe "should not raise any errors when" do
+    it "send valid arguments to service class interfaces #put" do
+      expect { Keystore.put(valid_key, value) }.not_to raise_error
+    end
+
+    it "send valid arguments to service class interfaces #incremented_value_for" do
+      expect { Keystore.incremented_value_for(valid_key, value) }.not_to raise_error
+    end
+  end
+
+  describe "should raise error when" do
+    it "send invalid arguments to service class interfaces #put" do
+      expect { Keystore.put(invalid_key, value) }
+        .to raise_error("50 characters is the maximum allowed for key")
+    end
+
+    it "send invalid arguments to service class interfaces #incremented_value_for" do
+      expect { Keystore.incremented_value_for(invalid_key, value) }
+        .to raise_error("50 characters is the maximum allowed for key")
+    end
+  end
+end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -6,6 +6,12 @@ describe Message do
     expect(m.short_id).to match(/^\A[a-zA-Z0-9]{1,10}\z/)
   end
 
+  it "validates the length of short_id" do
+    m_valid_short_id = create(:message)
+    m_valid_short_id.short_id = 'a' * 50
+    expect(m_valid_short_id).not_to be_valid
+  end
+
   describe "hat" do
     it "can't be worn if user doesn't have that hat" do
       message = build(:message, hat: create(:hat))

--- a/spec/models/mod_note_spec.rb
+++ b/spec/models/mod_note_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+describe ModNote do
+  let(:user) { create(:user) }
+  let(:moderator) { create(:user, :moderator) }
+
+  it "validates the length of note" do
+    mod_note = ModNote.new(user: user,
+                           moderator: moderator,
+                           note: 'a' * 65_536,
+                           markeddown_note: 'a')
+    expect(mod_note).not_to be_valid
+    expect(mod_note.errors.messages.dig(:note))
+      .to eq(["is too long (maximum is 65535 characters)"])
+  end
+
+  it "validates the length of markeddown_note" do
+    mod_note = ModNote.new(user: user,
+                           moderator: moderator,
+                           note: 'a',
+                           markeddown_note: 'a' * 65_536)
+    expect(mod_note).not_to be_valid
+    expect(mod_note.errors.messages.dig(:markeddown_note))
+      .to eq(["is too long (maximum is 65535 characters)"])
+  end
+
+  it "validates the presence of note" do
+    mod_note = ModNote.new(user: user,
+                           moderator: moderator,
+                           note: nil,
+                           markeddown_note: 'a')
+    expect(mod_note).not_to be_valid
+    expect(mod_note.errors.messages.dig(:note))
+      .to eq(["can't be blank"])
+  end
+
+  it "validates the presence of markeddown_note" do
+    mod_note = ModNote.new(user: user,
+                           moderator: moderator,
+                           note: 'a',
+                           markeddown_note: nil)
+    expect(mod_note).not_to be_valid
+    expect(mod_note.errors.messages.dig(:markeddown_note))
+      .to eq(["can't be blank"])
+  end
+end

--- a/spec/models/moderation_spec.rb
+++ b/spec/models/moderation_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+describe Moderation do
+  let(:value) { 'a' * 16_777_216 }
+
+  it "validates the length of action" do
+    moderation = Moderation.new(action: value, reason: nil)
+    expect(moderation).not_to be_valid
+    expect(moderation.errors.messages.dig(:action))
+      .to eq(["is too long (maximum is 16777215 characters)"])
+  end
+
+  it "validates the length of reason" do
+    moderation = Moderation.new(action: nil, reason: value)
+    expect(moderation).not_to be_valid
+    expect(moderation.errors.messages.dig(:reason))
+      .to eq(["is too long (maximum is 16777215 characters)"])
+  end
+end


### PR DESCRIPTION
- [x]  fail Keystore key column has limit in the database but do not have length validator
- [x]  fail Message short_id column has limit in the database but do not have length validator
- [x]  fail ModNote note column has limit in the database but do not have length validator
- [x]  fail ModNote markeddown_note column is required in the database but do not have presence validator
- [x]  fail ModNote markeddown_note column has limit in the database but do not have length validator
- [x]  fail Moderation action column has limit in the database but do not have length validator
- [x]  fail Moderation reason column has limit in the database but do not have length validator

===================================================
- [x]  fail Message author model should have proper foreign key in the database
- [x]  fail User sent_messages associated model should have proper index in the database
- [x]  fail User moderations associated model should have proper index in the database

===================================================
Also can be marked as done, as i told [before](https://github.com/lobsters/lobsters/issues/745#issuecomment-539024662):

- [x] fail User lower(username) model should have proper unique index in the database
- [x]  fail User lower(email) model should have proper unique index in the database