### PR TITLE
Update Scout gem to the latest version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem "ruumba" # tests views
 gem "sitemap_generator" # for better search engine indexing
 gem 'transaction_retry' # mitigate https://github.com/lobsters/lobsters-ansible/issues/39
 
-gem "scout_apm", :git => 'https://github.com/scoutapp/scout_apm_ruby.git', :ref => '574b0a6'
+gem "scout_apm"
 
 group :test, :development do
   gem 'bullet'

--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem "ruumba" # tests views
 gem "sitemap_generator" # for better search engine indexing
 gem 'transaction_retry' # mitigate https://github.com/lobsters/lobsters-ansible/issues/39
 
-gem "scout_apm"
+gem "scout_apm", "2.6.2"
 
 group :test, :development do
   gem 'bullet'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -274,7 +274,7 @@ DEPENDENCIES
   ruumba
   scenic
   scenic-mysql_adapter
-  scout_apm
+  scout_apm (= 2.6.2)
   sitemap_generator
   transaction_retry
   uglifier (>= 1.3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: https://github.com/scoutapp/scout_apm_ruby.git
-  revision: 574b0a6cf9ee774b5c09e60825f0f6131ea9f005
-  ref: 574b0a6
-  specs:
-    scout_apm (2.4.24)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -212,6 +205,8 @@ GEM
     scenic-mysql_adapter (1.0.1)
       mysql2
       scenic (>= 1.4.0)
+    scout_apm (2.6.2)
+      parser
     sitemap_generator (6.0.2)
       builder (~> 3.0)
     sprockets (3.7.2)
@@ -279,7 +274,7 @@ DEPENDENCIES
   ruumba
   scenic
   scenic-mysql_adapter
-  scout_apm!
+  scout_apm
   sitemap_generator
   transaction_retry
   uglifier (>= 1.3.0)


### PR DESCRIPTION
Update the Scout APM gem to the latest version so that the Timeline view can be utilised.

https://docs.scoutapm.com/?_ga=2.117993099.324453617.1571089242-2135995770.1562204706#updating-to-the-newest-version