### PR TITLE
Fix error refreshing stories count

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -342,7 +342,7 @@ class User < ApplicationRecord
   end
 
   def refresh_counts!
-    Keystore.put("user:#{self.id}:stories_submitted", self.stories.not_deleted.count)
+    Keystore.put("user:#{self.id}:stories_submitted", self.stories.count)
     Keystore.put("user:#{self.id}:comments_posted", self.comments.active.count)
     Keystore.put("user:#{self.id}:comments_deleted", self.comments.deleted.count)
   end


### PR DESCRIPTION
Resolves https://github.com/lobsters/lobsters/issues/771

When a user is inactive, [`User#refresh_counst!`](https://github.com/lobsters/lobsters/blob/791b21f60a2e952cabe5187559c8fb7724b7b8aa/app/models/user.rb#L344) is called. This method updates `user:#{self.id}:stories_submitted` with the value from `self.stories.not_deleted.count`.

When a user deletes a story and then deactivates the account, the value for `user:#{self.id}:stories_submitted` will be the number of stories submitted minus the number of stories deleted.

When the info of the user is displayed, [`stories_displayed`](https://github.com/lobsters/lobsters/blob/master/app/helpers/users_helper.rb#L7) already takes into account the stories that have been deleted.

So if a user submits 1 story and then removes it, `User#refresh_counst!` will update the value of `user:#{self.id}:stories_submitted` to `1 - 1`, this is, 0.

But then, when displaying the info, `User#stories_deleted_count` will be substracted to `User#stories_submitted_count`, so the deleted story will be substracted again, displaying the value of -1.

I am not familiar enough with the code to claim that this is the best fix for this issue nor it does not have any side effects in other parts of the codebase. Let me know if my approach is correct, and point me in the right direction if it is not.
