### PR TITLE
fix: don't try to match empty title

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -259,7 +259,7 @@ var _Lobsters = Class.extend({
 
   checkStoryTitle: function() {
     var title = $("#story_title").val();
-    if (title === undefined) {
+    if (title === undefined || title === '') {
       return;
     }
     var m;


### PR DESCRIPTION
When visiting https://lobste.rs/stories/new there is a JS console error

```
TypeError: e.match(...) is null
```

this happens because it tries to match stories title even when the title is empty. This is a simple fix to not try to match against empty titles