### PR TITLE
Add the text "(new)" for new comments

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -181,11 +181,13 @@ module ApplicationHelper
     end
 
     span_class = ''
+    title = time.strftime("%F %T %z")
 
     if options[:mark_unread]
       span_class += 'comment_unread'
+      title += ' (new)'
     end
 
-    raw(content_tag(:span, ago, title: time.strftime("%F %T %z"), class: span_class))
+    raw(content_tag(:span, ago, title: title, class: span_class))
   end
 end


### PR DESCRIPTION
The use case for this is that especially on stories with longer
comments; it's kind of hard to see new comments right now: you need to
visually scan the entire page.

With this change, I can search the page for `(new)` and quickly find
them.