### PR TITLE
Improve database consistency by setting a length limit

### DIFF
--- a/db/migrate/20191118015357_add_invitation_request_length_limit.rb
+++ b/db/migrate/20191118015357_add_invitation_request_length_limit.rb
@@ -1,0 +1,9 @@
+class AddInvitationRequestLengthLimit < ActiveRecord::Migration[5.2]
+  def change
+    change_column :invitation_requests, :name,       :string, limit: 255
+    change_column :invitation_requests, :email,      :string, limit: 255
+    change_column :invitation_requests, :code,       :string, limit: 255
+    change_column :invitation_requests, :ip_address, :string, limit: 255
+    change_column :invitation_requests, :memo,       :text,   limit: 255
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_29_021735) do
+ActiveRecord::Schema.define(version: 2019_11_18_015357) do
 
   create_table "comments", id: :bigint, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.datetime "created_at", null: false
@@ -75,7 +75,7 @@ ActiveRecord::Schema.define(version: 2019_10_29_021735) do
     t.boolean "is_verified", default: false
     t.string "email", null: false
     t.string "name", null: false
-    t.text "memo"
+    t.text "memo", limit: 255
     t.string "ip_address"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
### Enhancement

Set a length limit on the string and text fields of the invitation request column of the database to improve the consistency.

Solves #745 
