### PR TITLE
Feat(aria='button' for label.comment_fold): Adding an aria button for

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -67,6 +67,10 @@ var _Lobsters = Class.extend({
     Lobsters._showDownvoteWhyAt("comment", voterEl, function(k) {
       Lobsters.vote("comment", voterEl, -1, k); });
   },
+  foldComment: function(folderEl) {
+    var input = document.getElementById(folderEl.getAttribute("for"));
+    folderEl.setAttribute("aria-expanded", input.checked ? "true" : "false");
+  },
   _showDownvoteWhyAt: function(thingType, voterEl, onChooseWhy) {
     if (!Lobsters.curUser)
       return Lobsters.bounceToLogin();
@@ -396,6 +400,11 @@ $(document).ready(function() {
   $olcomments.on("click", ".comment a.upvoter", function() {
     Lobsters.upvoteComment(this);
     return false;
+  });
+
+  $olcomments.on("click", ".comment label.comment_folder", function(event) {
+    Lobsters.foldComment(this);
+    return true;
   });
 
   $("li.story a.flagger").click(function() {

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -12,7 +12,7 @@ class="comment <%= comment.current_vote ? (comment.current_vote[:vote] == 1 ?
 
   <% if defined?(show_tree_lines) && show_tree_lines %>
     <label for="comment_folder_<%= comment.short_id %>"
-      class="comment_folder"></label>
+      class="comment_folder" role="button" aria-expanded="true"></label>
   <% end %>
 
   <% if !comment.is_gone? %>
@@ -43,10 +43,10 @@ class="comment <%= comment.current_vote ? (comment.current_vote[:vote] == 1 ?
 
       <% if defined?(show_tree_lines) && show_tree_lines %>
         <label for="comment_folder_<%= comment.short_id %>"
-          class="comment_folder comment_folder_inline"></label>
+          class="comment_folder comment_folder_inline" role="button" aria-expanded="true"></label>
       <% else %>
         <label for="comment_folder_<%= comment.short_id %>"
-          class="comment_folder comment_folder_inline force_inline"></label>
+          class="comment_folder comment_folder_inline force_inline" role="button" aria-expanded="true"></label>
       <% end %>
 
       <% if defined?(was_merged) && was_merged %>


### PR DESCRIPTION
Adding an aria button for folder button on comments + aria expanded to play well w/ a11y.

This PR is in reference to https://github.com/lobsters/lobsters/issues/793

> While using Qutebrowser or Vimium for FF/Chrome you cannot collapse comments with the keyboard alone. This is due to the comment collapsing label not being treated as a button by Qutebrowser/Vimium. Adding a role of button to the label.comment_folder makes this much more enjoyable to use. I'm not sure of the a11y implications. If anyone has knowledge on this portion, if it might hurt accessiblity, I would appreciate to hear your thoughts.

Referenced [MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/button_role) for the accessibility bit. Looks like `aria-exanded` fits this case perfectly.