### PR TITLE
Use archive.md instead of archive.is

### DIFF
--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -278,7 +278,7 @@ class Story < ApplicationRecord
   end
 
   def archive_url
-    "https://archive.is/#{CGI.escape(self.url)}"
+    "https://archive.md/#{CGI.escape(self.url)}"
   end
 
   def as_json(options = {})


### PR DESCRIPTION
The archive.is website is not accessible in Russia. Using archive.md is fine.

See https://blocklist.rkn.gov.ru/ (enter archive.is in URL field).
Have no idea why that happened though.
