### PR TITLE
fix fake_data failed at User.is_new? validator

### DIFF
--- a/lib/tasks/fake_data.rake
+++ b/lib/tasks/fake_data.rake
@@ -15,6 +15,7 @@ class FakeDataGenerator
         password: password,
         password_confirmation: password,
         username: Faker::Internet.user_name(name, %w(_)),
+        created_at: User::NEW_USER_DAYS.days.ago,
       }
       create_args.merge!(is_moderator: true) if i % 7 == 0
       users << User.create!(create_args)


### PR DESCRIPTION
fake_data failed to run with following errors:

```
$ rails fake_data
rails aborted!
ActiveRecord::RecordInvalid: Validation failed: Url is an unseen domain from a new user
/home/favadi/code/personal/lobsters/lib/tasks/fake_data.rake:30:in `block in generate'
/home/favadi/code/personal/lobsters/lib/tasks/fake_data.rake:25:in `times'
/home/favadi/code/personal/lobsters/lib/tasks/fake_data.rake:25:in `generate'
/home/favadi/code/personal/lobsters/lib/tasks/fake_data.rake:100:in `block in <top (required)>'
bin/rails:4:in `require'
bin/rails:4:in `<main>'
Tasks: TOP => fake_data
(See full trace by running task with --trace)
```

Fixed by changing fake user created_at to NEW_USER_DAYS.days.ago.