### PR TITLE
passing Github access token in header instead of query parameter

### DIFF
--- a/extras/github.rb
+++ b/extras/github.rb
@@ -26,7 +26,8 @@ class Github
     tok = ps["access_token"].first
 
     if tok.present?
-      res = s.fetch("https://api.github.com/user?access_token=#{tok}").body
+      headers = { "Authorization" => "token #{tok}" }
+      res = s.fetch("https://api.github.com/user", :get, nil, nil, headers).body
       js = JSON.parse(res)
       if js && js["login"].present?
         return [tok, js["login"]]


### PR DESCRIPTION
https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/

Fixes #819 
