### PR TITLE
Mark story links as user generated content

### DIFF
--- a/app/views/stories/_listdetail.html.erb
+++ b/app/views/stories/_listdetail.html.erb
@@ -23,7 +23,7 @@ class="story <%= story.vote && story.vote[:vote] == 1 ? "upvoted" : "" %>
   <div class="details">
     <span class="link h-cite u-repost-of">
       <% if story.can_be_seen_by_user?(@user) %>
-        <a class="u-url" href="<%= story.url_or_comments_path %>"><%=
+        <a class="u-url" href="<%= story.url_or_comments_path %>" rel="ugc"><%=
           break_long_words(story.title) %></a>
       <% end %>
       <% if story.is_gone? %>


### PR DESCRIPTION
We aleady add rel=nofollow to links in our comments. This
does the same thing for stories following the newest Google recomendations.

https://webmasters.googleblog.com/2019/09/evolving-nofollow-new-ways-to-identify.html

<!--
Issues and PRs are typically reviewed Wednesday and most weekend mornings.
-->
