### PR TITLE
fix fake_data failed to run due to DST adjustment

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -59,6 +59,8 @@ Rails.application.configure do
     Bullet.console = true
     Bullet.rails_logger = true
   end
+
+  config.time_zone = 'UTC'
 end
 
 Keybase.DOMAIN = Rails.application.domain

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -41,4 +41,6 @@ Rails.application.configure do
 
   # Raises error for missing translations
   config.action_view.raise_on_missing_translations = true
+
+  config.time_zone = 'UTC'
 end


### PR DESCRIPTION
The default application time zone, Central Time (US & Canada), got an DST adjustment today (March 08 2020) and causes following problems:

    irb(main):003:0> User::NEW_USER_DAYS.days.ago.utc
    => 2019-12-29 11:51:16 UTC
    irb(main):004:0> User::NEW_USER_DAYS.days.ago(Time.current.utc)
    => 2019-12-29 10:51:24 UTC

The commit changes timezone on development, test environment to UTC to avoid DST.

<!--
Issues and PRs are typically reviewed Wednesday and most weekend mornings.
-->
