### PR TITLE
Highlight comments for showing user

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -481,6 +481,12 @@ li div.details {
 	border-radius: 20px;
 }
 
+.showing-user-comment .time_ago {
+	background-color: #fffcd7;
+	border-radius: 5px;
+	padding: 3px;
+}
+
 li .link {
 	font-weight: bold;
 	vertical-align: middle;

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -180,7 +180,7 @@ module ApplicationHelper
       ago = "#{years} #{'year'.pluralize(years)} ago"
     end
 
-    span_class = ''
+    span_class = 'time_ago '
 
     if options[:mark_unread]
       span_class += 'comment_unread'

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -37,7 +37,7 @@ class="comment <%= comment.current_vote ? (comment.current_vote[:vote] == 1 ?
       <%= defined?(children) && children ? "" : "no_children" %>"></div>
   <% end %>
 
-  <div class="details">
+  <div class="details <%= @showing_user == comment.user ? "showing-user-comment" : "" %>">
     <div class="byline">
       <a name="c_<%= comment.short_id %>"></a>
 


### PR DESCRIPTION
When reading comments by a particular user, it can be difficult to find where their comments start, as comment threads are shown from the root, not from where the user commented.

This commit adds a highlight on comments by the @showing_user's comments to make them easier to distinguish.

Adding the `showing-user-comment` class to the `details` comment div looks like this:

<img width="350" alt="Screenshot of Safari (25-03-20, 4-14-47 PM)" src="https://user-images.githubusercontent.com/811954/77498499-a767fc80-6eb4-11ea-9ea9-2c3d5e0f9575.png">

Adding the `showing-user-comment` class to the `comment` class (which is where the existing `:target` based selector applies) looks like this:

<img width="350" alt="Screenshot of Safari (25-03-20, 4-14-59 PM)" src="https://user-images.githubusercontent.com/811954/77498532-be0e5380-6eb4-11ea-9d00-9e29a59e9b87.png">

I don't really mind which, I thought the former looked better, but either is fine.

<!--
Issues and PRs are typically reviewed Wednesday and most weekend mornings.
-->