### PR TITLE
Replace link to IRC channel in 500 error message

### DIFF
--- a/public/500.html
+++ b/public/500.html
@@ -6,6 +6,6 @@
 <body>
   <h1>Lobsters HTTP 500 status: server error</h1>
   <p>The page you requested cannot be displayed.</p>
-  <p>The site operators have been notified of this error.  You're welcome to and encouraged to also report it in <a href="/chat">chat</a>.</p>
+  <p>The site operators have been notified of this error.  You're welcome to and encouraged to also report it in the <a href="irc://irc.freenode.net/lobsters">IRC channel</a> (also accessible via <a href="https://webchat.freenode.net/#lobsters">webchat</a>).</p>
 </body>
 </html>


### PR DESCRIPTION
In case of 500 errors it's very likely that the link to `/chat` would also lead to a 500 error. This PR changes the link directly to the IRC channel.
