### PR TITLE
/chat: freenode is not capitalized, despite being a proper name.

### DIFF
--- a/app/views/home/chat.html.erb
+++ b/app/views/home/chat.html.erb
@@ -7,7 +7,7 @@
   <p>
   An official real-time discussion channel is available to members and guests
   of the site, hosted on the
-  <a href="http://www.freenode.net">Freenode IRC network</a>
+  <a href="http://www.freenode.net">freenode IRC network</a>
   in <tt>#lobsters</tt>.  This channel was originally
   <a href="/s/2hdoop">created</a>
   by


### PR DESCRIPTION
freenode.net doesn't capitalize the name anywhere on the site.

<!--
Issues and PRs are typically reviewed Wednesday and most weekend mornings.
-->
