### PR TITLE
Allow users to link Freenode accounts to Lobste.rs accounts

### DIFF
--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -256,6 +256,30 @@ class SettingsController < ApplicationController
     return redirect_to "/settings"
   end
 
+  def freenode_callback
+    reader = FreenodeTaxonomyReader.new
+    taxonomy = reader.for_user(params[:user][:freenode_username])
+
+    if taxonomy['LOBSTERS'] == @user.username
+      @user.freenode_username = params[:user][:freenode_username]
+      @user.save!
+      flash[:success] = "Your account has been linked to Freenoe user #{@user.freenode_username}."
+    elsif taxonomy['LOBSTERS']
+      flash[:error] = "Expected #{@user.username} in the taxonomy, not #{taxonomy['LOBSTERS']}."
+    else
+      flash[:error] = "The LOBSTERS key was not in #{params[:user][:freenode_username]}'s taxonomy."
+    end
+
+    return redirect_to "/settings"
+  end
+
+  def freenode_disconnect
+    @user.freenode_username = nil
+    @user.save!
+    flash[:success] = "Your Freenode association has been removed."
+    return redirect_to "/settings"
+  end
+
 private
 
   def user_params

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -263,7 +263,7 @@ class SettingsController < ApplicationController
     if taxonomy['LOBSTERS'] == @user.username
       @user.freenode_username = params[:user][:freenode_username]
       @user.save!
-      flash[:success] = "Your account has been linked to Freenoe user #{@user.freenode_username}."
+      flash[:success] = "Your account has been linked to freenode user #{@user.freenode_username}."
     elsif taxonomy['LOBSTERS']
       flash[:error] = "Expected #{@user.username} in the taxonomy, not #{taxonomy['LOBSTERS']}."
     else
@@ -276,7 +276,7 @@ class SettingsController < ApplicationController
   def freenode_disconnect
     @user.freenode_username = nil
     @user.save!
-    flash[:success] = "Your Freenode association has been removed."
+    flash[:success] = "Your freenode association has been removed."
     return redirect_to "/settings"
   end
 

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -265,9 +265,9 @@ class SettingsController < ApplicationController
       @user.save!
       flash[:success] = "Your account has been linked to freenode user #{@user.freenode_username}."
     elsif taxonomy['LOBSTERS']
-      flash[:error] = "Checked on your username, but Freenode told us it's something other than #{@user.username}."
+      flash[:error] = "Checked on your username, but Freenode told us it's something other than #{@user.username}." # rubocop:disable Layout/LineLength
     else
-      flash[:error] = "The LOBSTERS key was not in #{params[:user][:freenode_username]}'s taxonomy. Message NickServ `SET PROPERTY LOBSTERS #{@user.username}` to set it."
+      flash[:error] = "The LOBSTERS key was not in #{params[:user][:freenode_username]}'s taxonomy. Message NickServ `SET PROPERTY LOBSTERS #{@user.username}` to set it." # rubocop:disable Layout/LineLength
     end
 
     return redirect_to "/settings"

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -265,9 +265,9 @@ class SettingsController < ApplicationController
       @user.save!
       flash[:success] = "Your account has been linked to freenode user #{@user.freenode_username}."
     elsif taxonomy['LOBSTERS']
-      flash[:error] = "Expected #{@user.username} in the taxonomy, not #{taxonomy['LOBSTERS']}."
+      flash[:error] = "Checked on your username, but Freenode told us it's something other than #{@user.username}."
     else
-      flash[:error] = "The LOBSTERS key was not in #{params[:user][:freenode_username]}'s taxonomy."
+      flash[:error] = "The LOBSTERS key was not in #{params[:user][:freenode_username]}'s taxonomy. Message NickServ `SET PROPERTY LOBSTERS #{@user.username}` to set it."
     end
 
     return redirect_to "/settings"
@@ -277,7 +277,7 @@ class SettingsController < ApplicationController
     @user.freenode_username = nil
     @user.save!
     flash[:success] = "Your freenode association has been removed."
-    return redirect_to "/settings"
+    return redirect_to user_path(@user)
   end
 
 private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -72,6 +72,7 @@ class User < ApplicationRecord
     s.string :twitter_username
     s.any :keybase_signatures, array: true
     s.string :homepage
+    s.string :freenode_username
   end
 
   validates :email,

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -72,86 +72,6 @@
     </p>
 
     <br>
-
-    <div class="legend">
-      External Accounts
-    </div>
-
-    <div class="boxline">
-      <%= f.label :gravatar,
-        raw("<a href=\"https://gravatar.com/\">Gravatar</a>:"),
-        :class => "required" %>
-      <span>
-        Your avatar will be cached from the Gravatar icon for your e-mail
-        address above.
-        (<%= link_to "Expire cache", "/avatars/expire", :method => :post %>)
-      </span>
-    </div>
-
-    <% if Pushover.enabled? %>
-      <div class="boxline">
-        <%= f.label :pushover_user_key,
-          raw("<a href=\"https://pushover.net/\">Pushover</a>:"),
-          :class => "required" %>
-        <span>
-        <%= link_to((@edit_user.pushover_user_key.present??
-          "Manage Pushover Subscription" : "Subscribe With Pushover"),
-          "/settings/pushover_auth", :class => "pushover_button",
-          :method => :post) %>
-        <span class="hint">
-          For optional comment and message notifications below
-        </span>
-        </span>
-      </div>
-    <% end %>
-
-    <% if Github.enabled? %>
-      <div class="boxline">
-        <span>
-        <%= f.label :github_username,
-          raw("<a href=\"https://github.com/\">GitHub</a>:"),
-          :class => "required" %>
-        <% if @edit_user.github_username.present? %>
-          Linked to
-          <strong><a href="https://github.com/<%= h(@edit_user.github_username)
-            %>"><%= h(@edit_user.github_username) %></a></strong>
-            (<%= link_to "Disconnect", "/settings/github_disconnect",
-              :method => :post %>)
-        <% else %>
-          <a href="/settings/github_auth">Connect</a>
-        <% end %>
-        </span>
-      </div>
-    <% end %>
-
-    <% if Twitter.enabled? %>
-      <div class="boxline">
-        <%= f.label :twitter_username,
-          raw("<a href=\"https://twitter.com/\">Twitter</a>:"),
-          :class => "required" %>
-        <span>
-        <% if @edit_user.twitter_username.present? %>
-          Linked to
-          <strong><a href="https://twitter.com/<%= h(@edit_user.twitter_username)
-            %>">@<%= h(@edit_user.twitter_username) %></a></strong>
-            (<%= link_to "Disconnect", "/settings/twitter_disconnect",
-              :method => :post %>)
-        <% else %>
-          <a href="/settings/twitter_auth">Connect</a>
-        <% end %>
-        </span>
-      </div>
-    <% end %>
-
-    <% if Keybase.enabled? %>
-      <div class="boxline">
-        <%= f.label :kb_username, raw("<a href=\"https://keybase.io/\">Keybase</a>:"), :class => "required" %>
-        <span>
-          <%= render :partial => "keybase_proofs/proofs", locals: {user: @edit_user, for_self: true} %>
-        </span>
-      </div>
-    <% end %>
-
     <br>
 
     <div class="legend">
@@ -295,6 +215,104 @@
     <br>
     <%= f.submit "Save All Settings" %>
   <% end %>
+
+  <br>
+  <br>
+
+  <div class="legend">
+    External Accounts
+  </div>
+
+  <div class="boxline">
+    <%= label_tag :gravatar,
+        raw("<a href=\"https://gravatar.com/\">Gravatar</a>:"),
+        :class => "required" %>
+    <span>
+      Your avatar will be cached from the Gravatar icon for your e-mail
+      address above.
+      (<%= link_to "Expire cache", "/avatars/expire", :method => :post %>)
+    </span>
+  </div>
+
+  <% if Pushover.enabled? %>
+  <div class="boxline">
+    <%= label_tag :pushover_user_key,
+        raw("<a href=\"https://pushover.net/\">Pushover</a>:"),
+        :class => "required" %>
+    <span>
+      <%= link_to((@edit_user.pushover_user_key.present??
+          "Manage Pushover Subscription" : "Subscribe With Pushover"),
+          "/settings/pushover_auth", :class => "pushover_button",
+      :method => :post) %>
+      <span class="hint">
+        For optional comment and message notifications below
+      </span>
+    </span>
+  </div>
+  <% end %>
+
+  <% if Github.enabled? %>
+  <div class="boxline">
+    <span>
+       <%= label_tag :github_username,
+          raw("<a href=\"https://github.com/\">GitHub</a>:"),
+          :class => "required" %>
+      <% if @edit_user.github_username.present? %>
+        Linked to
+        <strong><a href="https://github.com/<%= h(@edit_user.github_username)
+  		       %>"><%= h(@edit_user.github_username) %></a></strong>
+        (<%= link_to "Disconnect", "/settings/github_disconnect",
+             :method => :post %>)
+      <% else %>
+        <a href="/settings/github_auth">Connect</a>
+      <% end %>
+    </span>
+  </div>
+  <% end %>
+
+  <% if Twitter.enabled? %>
+  <div class="boxline">
+    <%= label_tag :twitter_username,
+        raw("<a href=\"https://twitter.com/\">Twitter</a>:"),
+        :class => "required" %>
+    <span>
+      <% if @edit_user.twitter_username.present? %>
+        Linked to
+        <strong><a href="https://twitter.com/<%= h(@edit_user.twitter_username)
+		       %>">@<%= h(@edit_user.twitter_username) %></a></strong>
+        (<%= link_to "Disconnect", "/settings/twitter_disconnect",
+             :method => :post %>)
+      <% else %>
+        <a href="/settings/twitter_auth">Connect</a>
+      <% end %>
+    </span>
+  </div>
+  <% end %>
+
+  <% if Keybase.enabled? %>
+  <div class="boxline">
+    <%= label_tag :kb_username, raw("<a href=\"https://keybase.io/\">Keybase</a>:"), :class => "required" %>
+    <span>
+      <%= render :partial => "keybase_proofs/proofs", locals: {user: @edit_user, for_self: true} %>
+    </span>
+  </div>
+  <% end %>
+
+  <div class="boxline">
+    <%= label_tag(:freenode_username, raw('<a href="https://freenode.net">Freenode</a>:'), class: "required") %>
+    <span>
+      <% if @edit_user.freenode_username.present? %>
+        <strong><%= @edit_user.freenode_username %></strong>
+        (<%= link_to "Disconnect", "/settings/freenode_disconnect",
+             :method => :post %>)
+      <% else %>
+        <%= form_with model: @edit_user, url: settings_freenode_callback_path, method: :post, id: 'freenode_link', local: true do |f| %>
+          <%= f.text_field :freenode_username, size: 70, autocomplete: "off", placeholder: "/msg NickServ SET PROPERTY LOBSTERS #{@edit_user.username}" %>
+          <%= f.submit 'Link Account' %>
+        <% end %>
+      <% end %>
+    </span>
+  </div>
 
   <br>
   <br>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -151,11 +151,10 @@
   <% end %>
 
   <% if @showing_user.freenode_username.present? %>
-    <label class="required">Freenode:</label>
+    <label class="required">freenode:</label>
 
     <span class="d">
-      <a href="irc://chat.freenode.net:667/<%= h(@showing_user.freenode_username) %>"
-        rel="me ugc">@<%= h(@showing_user.freenode_username) %></a>
+      <a>@<%= h(@showing_user.freenode_username) %></a>
     </span>
     <br>
   <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -154,7 +154,7 @@
     <label class="required">freenode:</label>
 
     <span class="d">
-      <a>@<%= h(@showing_user.freenode_username) %></a>
+      <a><%= h(@showing_user.freenode_username) %></a>
     </span>
     <br>
   <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -150,6 +150,16 @@
     <br>
   <% end %>
 
+  <% if @showing_user.freenode_username.present? %>
+    <label class="required">Freenode:</label>
+
+    <span class="d">
+      <a href="irc://chat.freenode.net:667/<%= h(@showing_user.freenode_username) %>"
+        rel="me ugc">@<%= h(@showing_user.freenode_username) %></a>
+    </span>
+    <br>
+  <% end %>
+
   <% if @showing_user.is_active? %>
     <label class="required">About:</label>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -158,6 +158,8 @@ Rails.application.routes.draw do
   get "/settings/twitter_auth" => "settings#twitter_auth"
   get "/settings/twitter_callback" => "settings#twitter_callback"
   post "/settings/twitter_disconnect" => "settings#twitter_disconnect"
+  post "/settings/freenode_callback" => "settings#freenode_callback"
+  post "/settings/freenode_disconnect" => "settings#freenode_disconnect"
 
   resources :keybase_proofs, only: [:new, :create, :destroy]
   get "/.well-known/keybase-proof-config" => "keybase_proofs#kbconfig", :as => "keybase_config"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,6 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2020_06_07_192351) do
+
   create_table "comments", id: :bigint, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at"
@@ -120,7 +121,6 @@ ActiveRecord::Schema.define(version: 2020_06_07_192351) do
     t.boolean "deleted_by_author", default: false
     t.boolean "deleted_by_recipient", default: false
     t.bigint "hat_id", unsigned: true
-    t.index ["author_user_id"], name: "author_user_id"
     t.index ["hat_id"], name: "index_messages_on_hat_id"
     t.index ["recipient_user_id"], name: "messages_recipient_user_id_fk"
     t.index ["short_id"], name: "random_hash", unique: true
@@ -317,7 +317,6 @@ ActiveRecord::Schema.define(version: 2020_06_07_192351) do
   add_foreign_key "invitations", "users", column: "new_user_id", name: "invitations_new_user_id_fk"
   add_foreign_key "invitations", "users", name: "invitations_user_id_fk"
   add_foreign_key "messages", "hats", name: "messages_hat_id_fk"
-  add_foreign_key "messages", "users", column: "author_user_id", name: "messages_ibfk_1"
   add_foreign_key "messages", "users", column: "recipient_user_id", name: "messages_recipient_user_id_fk"
   add_foreign_key "mod_notes", "users", column: "moderator_user_id", name: "mod_notes_moderator_user_id_fk"
   add_foreign_key "mod_notes", "users", name: "mod_notes_user_id_fk"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -47,7 +47,7 @@ ActiveRecord::Schema.define(version: 2020_08_11_022248) do
     t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
-  create_table "domains", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+  create_table "domains", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "domain"
     t.boolean "is_tracker", default: false, null: false
     t.datetime "created_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,15 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_11_022248) do
-
-  create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
-    t.string "category"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["category"], name: "index_categories_on_category", unique: true
-  end
-
+ActiveRecord::Schema.define(version: 2020_06_07_192351) do
   create_table "comments", id: :bigint, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at"
@@ -28,8 +20,8 @@ ActiveRecord::Schema.define(version: 2020_08_11_022248) do
     t.bigint "parent_comment_id", unsigned: true
     t.bigint "thread_id", unsigned: true
     t.text "comment", limit: 16777215, null: false
-    t.integer "score", default: 1, null: false
-    t.integer "flags", default: 0, null: false, unsigned: true
+    t.integer "upvotes", default: 0, null: false
+    t.integer "downvotes", default: 0, null: false
     t.decimal "confidence", precision: 20, scale: 19, default: "0.0", null: false
     t.text "markeddown_comment", limit: 16777215
     t.boolean "is_deleted", default: false
@@ -40,14 +32,14 @@ ActiveRecord::Schema.define(version: 2020_08_11_022248) do
     t.index ["confidence"], name: "confidence_idx"
     t.index ["hat_id"], name: "comments_hat_id_fk"
     t.index ["parent_comment_id"], name: "comments_parent_comment_id_fk"
-    t.index ["score"], name: "index_comments_on_score"
     t.index ["short_id"], name: "short_id", unique: true
     t.index ["story_id", "short_id"], name: "story_id_short_id"
     t.index ["thread_id"], name: "thread_id"
+    t.index ["user_id", "story_id", "downvotes", "created_at"], name: "downvote_index"
     t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
-  create_table "domains", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+  create_table "domains", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "domain"
     t.boolean "is_tracker", default: false, null: false
     t.datetime "created_at", null: false
@@ -128,6 +120,7 @@ ActiveRecord::Schema.define(version: 2020_08_11_022248) do
     t.boolean "deleted_by_author", default: false
     t.boolean "deleted_by_recipient", default: false
     t.bigint "hat_id", unsigned: true
+    t.index ["author_user_id"], name: "author_user_id"
     t.index ["hat_id"], name: "index_messages_on_hat_id"
     t.index ["recipient_user_id"], name: "messages_recipient_user_id_fk"
     t.index ["short_id"], name: "random_hash", unique: true
@@ -192,8 +185,8 @@ ActiveRecord::Schema.define(version: 2020_08_11_022248) do
     t.text "description", limit: 16777215
     t.string "short_id", limit: 6, default: "", null: false
     t.boolean "is_expired", default: false, null: false
-    t.integer "score", default: 1, null: false
-    t.integer "flags", default: 0, null: false, unsigned: true
+    t.integer "upvotes", default: 0, null: false, unsigned: true
+    t.integer "downvotes", default: 0, null: false, unsigned: true
     t.boolean "is_moderated", default: false, null: false
     t.decimal "hotness", precision: 20, scale: 10, default: "0.0", null: false
     t.text "markeddown_description", limit: 16777215
@@ -209,9 +202,8 @@ ActiveRecord::Schema.define(version: 2020_08_11_022248) do
     t.index ["description"], name: "index_stories_on_description", type: :fulltext
     t.index ["domain_id"], name: "index_stories_on_domain_id"
     t.index ["hotness"], name: "hotness_idx"
-    t.index ["id", "is_expired"], name: "index_stories_on_id_and_is_expired"
+    t.index ["id", "is_expired", "is_moderated"], name: "index_stories_on_id_and_is_expired_and_is_moderated"
     t.index ["merged_story_id"], name: "index_stories_on_merged_story_id"
-    t.index ["score"], name: "index_stories_on_score"
     t.index ["short_id"], name: "unique_short_id", unique: true
     t.index ["story_cache"], name: "index_stories_on_story_cache", type: :fulltext
     t.index ["title"], name: "index_stories_on_title", type: :fulltext
@@ -256,13 +248,11 @@ ActiveRecord::Schema.define(version: 2020_08_11_022248) do
   create_table "tags", id: :bigint, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "tag", limit: 25, null: false
     t.string "description", limit: 100
-    t.boolean "privileged", default: false, null: false
-    t.boolean "is_media", default: false, null: false
-    t.boolean "active", default: true, null: false
+    t.boolean "privileged", default: false
+    t.boolean "is_media", default: false
+    t.boolean "inactive", default: false
     t.float "hotness_mod", default: 0.0
     t.boolean "permit_by_new_users", default: true, null: false
-    t.bigint "category_id", null: false
-    t.index ["category_id"], name: "index_tags_on_category_id"
     t.index ["tag"], name: "tag", unique: true
   end
 
@@ -327,6 +317,7 @@ ActiveRecord::Schema.define(version: 2020_08_11_022248) do
   add_foreign_key "invitations", "users", column: "new_user_id", name: "invitations_new_user_id_fk"
   add_foreign_key "invitations", "users", name: "invitations_user_id_fk"
   add_foreign_key "messages", "hats", name: "messages_hat_id_fk"
+  add_foreign_key "messages", "users", column: "author_user_id", name: "messages_ibfk_1"
   add_foreign_key "messages", "users", column: "recipient_user_id", name: "messages_recipient_user_id_fk"
   add_foreign_key "mod_notes", "users", column: "moderator_user_id", name: "mod_notes_moderator_user_id_fk"
   add_foreign_key "mod_notes", "users", name: "mod_notes_user_id_fk"
@@ -358,6 +349,6 @@ ActiveRecord::Schema.define(version: 2020_08_11_022248) do
   add_foreign_key "votes", "users", name: "votes_user_id_fk"
 
   create_view "replying_comments", sql_definition: <<-SQL
-      select `read_ribbons`.`user_id` AS `user_id`,`comments`.`id` AS `comment_id`,`read_ribbons`.`story_id` AS `story_id`,`comments`.`parent_comment_id` AS `parent_comment_id`,`comments`.`created_at` AS `comment_created_at`,`parent_comments`.`user_id` AS `parent_comment_author_id`,`comments`.`user_id` AS `comment_author_id`,`stories`.`user_id` AS `story_author_id`,`read_ribbons`.`updated_at` < `comments`.`created_at` AS `is_unread`,(select `votes`.`vote` from `votes` where `votes`.`user_id` = `read_ribbons`.`user_id` and `votes`.`comment_id` = `comments`.`id`) AS `current_vote_vote`,(select `votes`.`reason` from `votes` where `votes`.`user_id` = `read_ribbons`.`user_id` and `votes`.`comment_id` = `comments`.`id`) AS `current_vote_reason` from (((`read_ribbons` join `comments` on(`comments`.`story_id` = `read_ribbons`.`story_id`)) join `stories` on(`stories`.`id` = `comments`.`story_id`)) left join `comments` `parent_comments` on(`parent_comments`.`id` = `comments`.`parent_comment_id`)) where `read_ribbons`.`is_following` = 1 and `comments`.`user_id` <> `read_ribbons`.`user_id` and `comments`.`is_deleted` = 0 and `comments`.`is_moderated` = 0 and (`parent_comments`.`user_id` = `read_ribbons`.`user_id` or `parent_comments`.`user_id` is null and `stories`.`user_id` = `read_ribbons`.`user_id`) and `stories`.`score` >= 0 and `comments`.`score` >= 0 and (`parent_comments`.`id` is null or `parent_comments`.`score` >= 0 and `parent_comments`.`is_moderated` = 0 and `parent_comments`.`is_deleted` = 0) and !exists(select 1 from (`votes` `f` join `comments` `c` on(`f`.`comment_id` = `c`.`id`)) where `f`.`vote` < 0 and `f`.`user_id` = `parent_comments`.`user_id` and `c`.`user_id` = `comments`.`user_id` and `f`.`story_id` = `comments`.`story_id` limit 1)
+      select `read_ribbons`.`user_id` AS `user_id`,`comments`.`id` AS `comment_id`,`read_ribbons`.`story_id` AS `story_id`,`comments`.`parent_comment_id` AS `parent_comment_id`,`comments`.`created_at` AS `comment_created_at`,`parent_comments`.`user_id` AS `parent_comment_author_id`,`comments`.`user_id` AS `comment_author_id`,`stories`.`user_id` AS `story_author_id`,`read_ribbons`.`updated_at` < `comments`.`created_at` AS `is_unread`,(select `votes`.`vote` from `votes` where `votes`.`user_id` = `read_ribbons`.`user_id` and `votes`.`comment_id` = `comments`.`id`) AS `current_vote_vote`,(select `votes`.`reason` from `votes` where `votes`.`user_id` = `read_ribbons`.`user_id` and `votes`.`comment_id` = `comments`.`id`) AS `current_vote_reason` from (((`read_ribbons` join `comments` on(`comments`.`story_id` = `read_ribbons`.`story_id`)) join `stories` on(`stories`.`id` = `comments`.`story_id`)) left join `comments` `parent_comments` on(`parent_comments`.`id` = `comments`.`parent_comment_id`)) where `read_ribbons`.`is_following` = 1 and `comments`.`user_id` <> `read_ribbons`.`user_id` and `comments`.`is_deleted` = 0 and `comments`.`is_moderated` = 0 and (`parent_comments`.`user_id` = `read_ribbons`.`user_id` or `parent_comments`.`user_id` is null and `stories`.`user_id` = `read_ribbons`.`user_id`) and `comments`.`upvotes` - `comments`.`downvotes` >= 0 and (`parent_comments`.`id` is null or `parent_comments`.`upvotes` - `parent_comments`.`downvotes` >= 0 and `parent_comments`.`is_moderated` = 0 and `parent_comments`.`is_deleted` = 0) and !exists(select 1 from (`votes` `f` join `comments` `c` on(`f`.`comment_id` = `c`.`id`)) where `f`.`vote` < 0 and `f`.`user_id` = `parent_comments`.`user_id` and `c`.`user_id` = `comments`.`user_id` and `f`.`story_id` = `comments`.`story_id` limit 1) and cast(`stories`.`upvotes` as signed) - cast(`stories`.`downvotes` as signed) >= 0
   SQL
 end

--- a/extras/freenode_taxonomy_reader.rb
+++ b/extras/freenode_taxonomy_reader.rb
@@ -3,14 +3,14 @@ require 'securerandom'
 require 'timeout'
 
 class FreenodeTaxonomyReader
-  NICKSERV = 'NickServ!NickServ@services.'
-  END_MESSAGE_REGEX = /End of (.+) taxonomy|(.+) is not registered/
+  NICKSERV = 'NickServ!NickServ@services.'.freeze
+  END_MESSAGE_REGEX = /End of (.+) taxonomy|(.+) is not registered/.freeze
   MAX_LINES = 100
 
   def initialize(
-        socket_provider: ->() { ssl_socket },
-        username_provider: ->() { "#{Rails.application.name}-#{SecureRandom.alphanumeric(8)}" }
-      )
+    socket_provider: -> { ssl_socket },
+    username_provider: -> { "#{Rails.application.name}-#{SecureRandom.alphanumeric(8)}" }
+  )
     @socket_provider = socket_provider
     @nick = username_provider.call
   end
@@ -20,12 +20,12 @@ class FreenodeTaxonomyReader
 
     taxonomy_lines.map do |line|
       line
-        .split(':')[2,3]
-        .map { |t| t.strip }
+        .split(':')[2, 3]
+        .map(&:strip)
     end.to_h
   end
 
-  private
+private
 
   def taxonomy_for(username)
     taxonomy_lines = []

--- a/extras/freenode_taxonomy_reader.rb
+++ b/extras/freenode_taxonomy_reader.rb
@@ -7,8 +7,8 @@ class FreenodeTaxonomyReader
   END_MESSGE_REGEX = /End of (.+) taxonomy|(.+) is not registered/
 
   def initialize(
-        socket_provider: ->() { TCPSocket.new('chat.freenode.net', 6667) },
-        username_provider: ->() { SecureRandom.alphanumeric(16) }
+        socket_provider: ->() { ssl_socket },
+        username_provider: ->() { "lobsters-#{SecureRandom.alphanumeric(8)}" }
       )
     @socket_provider = socket_provider
     @nick = username_provider.call
@@ -45,5 +45,15 @@ class FreenodeTaxonomyReader
     taxonomy_lines
   ensure
     s.close
+  end
+
+  def ssl_socket
+    tcp = TCPSocket.new('chat.freenode.net', 6697)
+    ssl = OpenSSL::SSL::SSLSocket.new(tcp)
+
+    ssl.sync_close = true
+    ssl.connect
+
+    ssl
   end
 end

--- a/extras/freenode_taxonomy_reader.rb
+++ b/extras/freenode_taxonomy_reader.rb
@@ -3,7 +3,7 @@ require 'securerandom'
 require 'timeout'
 
 class FreenodeTaxonomyReader
-  NICKSERV = 'NickServ@services'
+  NICKSERV = 'NickServ!NickServ@services.'
   END_MESSGE_REGEX = /End of (.+) taxonomy|(.+) is not registered/
 
   def initialize(
@@ -36,7 +36,7 @@ class FreenodeTaxonomyReader
       s.write("PRIVMSG NickServ :TAXONOMY #{username}\r\n")
 
       while line = s.gets
-        next unless line.include?(NICKSERV)
+        next unless line.include?(":#{NICKSERV}")
         break if line.match(END_MESSGE_REGEX)
         taxonomy_lines.push(line)
       end

--- a/extras/freenode_taxonomy_reader.rb
+++ b/extras/freenode_taxonomy_reader.rb
@@ -1,0 +1,49 @@
+require 'socket'
+require 'securerandom'
+require 'timeout'
+
+class FreenodeTaxonomyReader
+  NICKSERV = 'NickServ@services'
+  END_MESSGE_REGEX = /End of (.+) taxonomy|(.+) is not registered/
+
+  def initialize(
+        socket_provider: ->() { TCPSocket.new('chat.freenode.net', 6667) },
+        username_provider: ->() { SecureRandom.alphanumeric(16) }
+      )
+    @socket_provider = socket_provider
+    @nick = username_provider.call
+  end
+
+  def for_user(username)
+    _head, *taxonomy_lines = taxonomy_for(username)
+
+    taxonomy_lines.map do |line|
+      line
+        .split(':')[2,3]
+        .map { |t| t.strip }
+    end.to_h
+  end
+
+  private
+
+  def taxonomy_for(username)
+    taxonomy_lines = []
+    s = @socket_provider.call
+
+    Timeout.timeout(30) do
+      s.write("NICK #{@nick}\r\n")
+      s.write("USER #{@nick} * * :Lobsters\r\n")
+      s.write("PRIVMSG NickServ :TAXONOMY #{username}\r\n")
+
+      while line = s.gets
+        next unless line.include?(NICKSERV)
+        break if line.match(END_MESSGE_REGEX)
+        taxonomy_lines.push(line)
+      end
+    end
+
+    taxonomy_lines
+  ensure
+    s.close
+  end
+end

--- a/spec/extras/freenode_taxonomy_reader_spec.rb
+++ b/spec/extras/freenode_taxonomy_reader_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe FreenodeTaxonomyReader do
+  let(:socket) { double('TCPSocket') }
+  let(:username) { 'example' }
+  subject { described_class.new(socket_provider: -> () { socket }, username_provider: -> () { username }) }
+
+  it 'talks to NickServ to get a taxonomy' do
+    expect(socket).to receive(:write).with("NICK #{username}\r\n")
+    expect(socket).to receive(:write).with("USER #{username} * * :Lobsters\r\n")
+    expect(socket).to receive(:write).with("PRIVMSG NickServ :TAXONOMY sample\r\n")
+
+    expect(socket).to receive(:gets).and_return(
+                        ":#{described_class::NICKSERV}: Taxonomy for sample:",
+                        ":#{described_class::NICKSERV}: Key: Value",
+                        ":#{described_class::NICKSERV}: End of sample taxonomy"
+                      )
+    expect(socket).to receive(:close)
+
+    expect(subject.for_user('sample')).to eql('Key' => 'Value')
+  end
+end

--- a/spec/extras/freenode_taxonomy_reader_spec.rb
+++ b/spec/extras/freenode_taxonomy_reader_spec.rb
@@ -1,9 +1,10 @@
 require 'rails_helper'
 
 describe FreenodeTaxonomyReader do
+  subject { described_class.new(socket_provider: -> { socket }, username_provider: -> { username }) }
+
   let(:socket) { double('TCPSocket') }
   let(:username) { 'example' }
-  subject { described_class.new(socket_provider: -> () { socket }, username_provider: -> () { username }) }
 
   it 'talks to NickServ to get a taxonomy' do
     expect(socket).to receive(:write).with("NICK #{username}\r\n")
@@ -11,10 +12,10 @@ describe FreenodeTaxonomyReader do
     expect(socket).to receive(:write).with("PRIVMSG NickServ :TAXONOMY sample\r\n")
 
     expect(socket).to receive(:gets).and_return(
-                        ":#{described_class::NICKSERV}: Taxonomy for sample:",
-                        ":#{described_class::NICKSERV}: LOBSTERS: Value",
-                        ":#{described_class::NICKSERV}: End of sample taxonomy"
-                      )
+      ":#{described_class::NICKSERV}: Taxonomy for sample:",
+      ":#{described_class::NICKSERV}: LOBSTERS: Value",
+      ":#{described_class::NICKSERV}: End of sample taxonomy"
+    )
     expect(socket).to receive(:close)
 
     expect(subject.for_user('sample')).to eql('LOBSTERS' => 'Value')

--- a/spec/extras/freenode_taxonomy_reader_spec.rb
+++ b/spec/extras/freenode_taxonomy_reader_spec.rb
@@ -12,11 +12,11 @@ describe FreenodeTaxonomyReader do
 
     expect(socket).to receive(:gets).and_return(
                         ":#{described_class::NICKSERV}: Taxonomy for sample:",
-                        ":#{described_class::NICKSERV}: Key: Value",
+                        ":#{described_class::NICKSERV}: LOBSTERS: Value",
                         ":#{described_class::NICKSERV}: End of sample taxonomy"
                       )
     expect(socket).to receive(:close)
 
-    expect(subject.for_user('sample')).to eql('Key' => 'Value')
+    expect(subject.for_user('sample')).to eql('LOBSTERS' => 'Value')
   end
 end


### PR DESCRIPTION
Mirroring our integrations for Twitter, Github and Keybase, I've added one that allows a user to claim a Freenode account by using the taxonomy features of NickServ. 

The scope of the changes is:
- Added a class to connect to Freenode and read the taxonomy information directly. The alternative to this would be to add a HTTP endpoint to Mockturtle and use that to query the information we need. I'm hesitant to do that because it couples us to the bot which I don't want to do without first having the appropriate discussion.
- Moved the `External Accounts` links out of the general user settings `form_with` tag and into its own section on the page. You can't nest two `form_with` tags and we can keep the same visual styling using `label_tag` to replace our usage of `f.label ...`.