### PR TITLE
Updates User show view

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -95,7 +95,7 @@
   <span class="d"><%= comments_posted_content(@showing_user) %></span>
   <br>
 
-  <% if @showing_user.hats.any? %>
+  <% if @user && @showing_user.hats.any? %>
     <label class="required">Hats:</label>
     <div class="d">
     <% @showing_user.hats.each do |hat| %>

--- a/spec/features/userpage_spec.rb
+++ b/spec/features/userpage_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.feature "Viewing User page", type: :feature do
+
+  feature "when logged out" do
+    scenario "cannot see a user's hats" do
+      hat = create(:hat, hat: "Best Hat")
+      user_with_hat = create(:user, hats: [hat])
+
+      visit "/u/#{user_with_hat.username}"
+
+      expect(page).to_not have_content(user_with_hat.hats.first.hat)
+    end
+  end
+
+  feature "when logged in" do
+    scenario "can see a user's hats" do
+      hat = create(:hat, hat: "Best Hat")
+      user_with_hat = create(:user, hats: [hat])
+      stub_login_as user_with_hat
+
+      visit "/u/#{user_with_hat.username}"
+
+      expect(page).to have_content(user_with_hat.hats.first.hat)
+    end
+  end
+
+end


### PR DESCRIPTION
This hides hats on user pages unless the user is logged in.  This change
is to prevent scraping of the user pages and spam going to those users
with hats listed.

Issue: #854 
