### PR TITLE
Updates hats index view

### DIFF
--- a/app/models/hat.rb
+++ b/app/models/hat.rb
@@ -36,7 +36,7 @@ class Hat < ApplicationRecord
         "title=\"Granted #{self.created_at.strftime('%Y-%m-%d')}"
 
     if !hl && self.link.present?
-      h << " - #{ERB::Util.html_escape(self.link)}"
+      h << " - #{ERB::Util.html_escape(self.sanitized_link)}"
     end
 
     h << "\">" <<
@@ -69,5 +69,14 @@ class Hat < ApplicationRecord
     m.action = "Granted hat \"#{self.hat}\"" + (self.link.present? ?
       " (#{self.link})" : "")
     m.save
+  end
+
+  def sanitized_link
+    if link.include? "@"
+      a = Mail::Address.new(link)
+      a.domain
+    else
+      link
+    end
   end
 end

--- a/app/views/hats/index.html.erb
+++ b/app/views/hats/index.html.erb
@@ -33,7 +33,11 @@
           <% elsif hh.link.blank? %>
             <span class="na">None</span>
           <% else %>
-            <%= hh.link %>
+            <% if @user %>
+              <%= hh.link %>
+            <% else %>
+              <%= hh.sanitized_link %>
+            <% end %>
           <% end %>
           <% if hh.doffed_at? %>
             doffed <%= time_ago_in_words_label(hh.doffed_at) %>

--- a/spec/features/hatpage_spec.rb
+++ b/spec/features/hatpage_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.feature "Viewing Hats page", type: :feature do
+  feature "when logged out" do
+    scenario "cannot see a user's email" do
+      hat = create(:hat, link: "foo@bar.com")
+      user_with_hat = create(:user, hats: [hat])
+
+      visit "/hats"
+
+      expect(page).to have_content("bar.com")
+      expect(page).to_not have_content(user_with_hat.hats.first.link)
+    end
+  end
+
+  feature "when logged in" do
+    scenario "can see a user's hats" do
+      hat = create(:hat, link: "foo@bar.com")
+      user_with_hat = create(:user, hats: [hat])
+      stub_login_as user_with_hat
+
+      visit "/hats"
+
+      expect(page).to have_content(user_with_hat.hats.first.link)
+    end
+  end
+end

--- a/spec/models/hat_spec.rb
+++ b/spec/models/hat_spec.rb
@@ -15,4 +15,14 @@ describe Hat do
     hat = build(:hat, link: "a" * 256)
     expect(hat).to_not be_valid
   end
+
+  it "santizes email addresses" do
+    hat = build(:hat, link: "foo@bar.com")
+    expect(hat.sanitized_link).to eq("bar.com")
+  end
+
+  it "doesn't sanitize links that aren't email addressees" do
+    hat = build(:hat, link: "google.com")
+    expect(hat.sanitized_link).to eq("google.com")
+  end
 end


### PR DESCRIPTION
This checks that a user is logged in before showing the hat's link on
the hat index page.  This change is needed because a malicious anonymous
user scraped the page and send a user spam based on the email found on
it.

Issue: #854

<!--
Issues and PRs are typically reviewed Wednesday and most weekend mornings.
-->
