### PR TITLE
Support token-based access for the RSS feed of upvoted stories

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -4,7 +4,7 @@ class HomeController < ApplicationController
   caches_page :about, :chat, :index, :newest, :newest_by_user, :recent, :top, if: CACHE_PAGE
 
   # for rss feeds, load the user's tag filters if a token is passed
-  before_action :find_user_from_rss_token, :only => [:index, :newest, :saved]
+  before_action :find_user_from_rss_token, :only => [:index, :newest, :saved, :upvoted]
   before_action { @page = page }
   before_action :require_logged_in_user, :only => [:upvoted]
 

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -14,4 +14,23 @@ describe HomeController do
       expect(@controller.view_assigns['stories']).to include(story)
     end
   end
+
+  describe "#upvoted" do
+    it "redirects to the login page" do
+      get :upvoted
+      expect(response).to be_redirect
+    end
+
+    context "when accessing RSS feeds" do
+      it "supports session-based access" do
+        get :upvoted, as: :rss, session: { u: user.session_token }
+        expect(response).to be_successful
+      end
+
+      it "supports token-based access" do
+        get :upvoted, as: :rss, params: { token: user.rss_token }
+        expect(response).to be_successful
+      end
+    end
+  end
 end


### PR DESCRIPTION
Lobste.rs has a [page of a user's upvoted stories](https://lobste.rs/upvoted/stories), which includes an RSS feed. Most of Lobste.rs' feeds can authenticate a user via a `?token=` URL parameter, so feed readers can retrieve them without needing a user's session cookie. This was missing for upvoted stories; requests for the RSS feed redirect to the Lobste.rs login page.

This PR fixes this bug, and includes a test case to demonstrate it works as expected.