### PR TITLE
rename comment scope

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -237,7 +237,7 @@ class CommentsController < ApplicationController
       raise ActionController::RoutingError.new("page out of bounds")
     end
 
-    @comments = Comment.for_user(@user)
+    @comments = Comment.accessible_to_user(@user)
       .not_on_story_hidden_by(@user)
       .order("id DESC")
       .includes(:user, :hat, :story => :user)
@@ -283,7 +283,7 @@ class CommentsController < ApplicationController
       raise ActionController::RoutingError.new("page out of bounds")
     end
 
-    @comments = Comment.for_user(@user)
+    @comments = Comment.accessible_to_user(@user)
       .where.not(user_id: @user.id)
       .order("id DESC")
       .includes(:user, :hat, :story => :user)
@@ -331,7 +331,7 @@ class CommentsController < ApplicationController
       for_user: @user
     )
 
-    comments = Comment.for_user(@user)
+    comments = Comment.accessible_to_user(@user)
       .where(:thread_id => thread_ids)
       .includes(:user, :hat, :story => :user, :votes => :user)
       .joins(:story).where.not(stories: { is_expired: true })

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -33,7 +33,7 @@ class Comment < ApplicationRecord
   scope :not_deleted, -> { where(is_deleted: false) }
   scope :not_moderated, -> { where(is_moderated: false) }
   scope :active, -> { not_deleted.not_moderated }
-  scope :for_user, ->(user) { user && user.is_moderator? ? all : active }
+  scope :accessible_to_user, ->(user) { user && user.is_moderator? ? all : active }
   scope :not_on_story_hidden_by, ->(user) {
     user ? where.not(
       HiddenStory.select('TRUE')

--- a/spec/features/comment_spec.rb
+++ b/spec/features/comment_spec.rb
@@ -73,7 +73,6 @@ RSpec.feature "Commenting" do
       comment.reload
       expect(comment.user).to eq(user)
     end
-
   end
 
   feature "Merging story comments" do

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -37,4 +37,18 @@ describe Comment do
     comment = build(:comment, markeddown_comment: "a" * 16_777_216)
     expect(comment).to_not be_valid
   end
+
+  describe ".accessible_to_user" do
+    it "when user is a moderator" do
+      moderator = build(:user, :moderator)
+
+      expect(Comment.accessible_to_user(moderator)).to eq(Comment.all)
+    end
+
+    it "when user does not a moderator" do
+      user = build(:user)
+
+      expect(Comment.accessible_to_user(user)).to eq(Comment.active)
+    end
+  end
 end


### PR DESCRIPTION
As quoted in #864, i change the `for_user`scope to `accessible_to_user` 
I also change the condition `user && user.is_moderator?` to ` user&.is_moderator?`
