### PR TITLE
Use a details tag for the story guidelines

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -584,11 +584,6 @@ $(document).ready(function() {
   $(document).on("blur change", "#story_title", Lobsters.checkStoryTitle);
   $(document).ready(Lobsters.checkStoryTitle);
 
-  $(document).on("click", "#story_guidelines_toggler", function() {
-    $("#story_guidelines").toggle();
-    return false;
-  });
-
   $(document).on("blur", "#user_homepage", function() {
     if (this.value.trim() !== '' && !this.value.match('^https?:\/\/'))
       this.value = 'http://' + this.value;

--- a/app/views/stories/_form.html.erb
+++ b/app/views/stories/_form.html.erb
@@ -73,54 +73,50 @@ Please don't use this to promote the story, summarize the post, or explain why y
 See the guidelines below for more." %>
     </div>
 
-    <div class="boxline actions markdown_help_toggler">
-      <a href="#" id="story_guidelines_toggler">
-        Story submission guidelines
-      </a>
-      <div id="story_guidelines" style="<%= show_guidelines?? "" : "display: none;" %>">
-        <ul>
+    <%= tag.details class: "boxline actions", open: show_guidelines? ? true : nil do %>
+      <summary>Story submission guidelines</summary>
+      <ul>
 
-          <li><p>
-          Do not editorialize story titles, but when the original story's
-          title has no context or is unclear, please change it.  <strong>Please
-          remove extraneous components from titles such as the name of the
-          site, blog, section, and author.</strong>
-          </p></li>
+        <li><p>
+        Do not editorialize story titles, but when the original story's
+        title has no context or is unclear, please change it.  <strong>Please
+        remove extraneous components from titles such as the name of the
+        site, blog, section, and author.</strong>
+        </p></li>
 
-          <li><p>
-          When the story being submitted is more than a year or so old,
-          please add the year the story was written to the post title in
-          parentheses.
-          </p></li>
+        <li><p>
+        When the story being submitted is more than a year or so old,
+        please add the year the story was written to the post title in
+        parentheses.
+        </p></li>
 
-          <li><p>
-          When submitting a URL, the text field is optional and should only
-          be used when additional context or explanation of the URL is
-          needed.  Commentary or opinion should be reserved for a comment,
-          so that it can be voted on separately from the story.
-          </p></li>
+        <li><p>
+        When submitting a URL, the text field is optional and should only
+        be used when additional context or explanation of the URL is
+        needed.  Commentary or opinion should be reserved for a comment,
+        so that it can be voted on separately from the story.
+        </p></li>
 
-          <li><p>
-          If no <a href="/tags">tags</a> clearly apply to the story you are submitting, chances
-          are it does not belong here.  Do not overreach with tags if they
-          are not the primary focus of the story.
-          </p></li>
+        <li><p>
+        If no <a href="/tags">tags</a> clearly apply to the story you are submitting, chances
+        are it does not belong here.  Do not overreach with tags if they
+        are not the primary focus of the story.
+        </p></li>
 
-          <li><p>
-          To be able to easily submit a page you're viewing in your browser
-          to <%= Rails.application.name %>, drag this bookmarklet to your
-          bookmark bar:
-          [<a href="javascript:{window.open(%22<%= Rails.application.root_url
-          %>stories/new?url=%22+encodeURIComponent(document.location)+<%
-          %>%22&title=%22+encodeURIComponent(document.title));%20void(0);}<%
-          %>">Submit to <%= Rails.application.name %></a>].
-          You'll be taken to this page with the viewed page's URL and title.
-          (It can't recognize and remove blog/author names for you, though.)
-          </p></li>
+        <li><p>
+        To be able to easily submit a page you're viewing in your browser
+        to <%= Rails.application.name %>, drag this bookmarklet to your
+        bookmark bar:
+        [<a href="javascript:{window.open(%22<%= Rails.application.root_url
+        %>stories/new?url=%22+encodeURIComponent(document.location)+<%
+        %>%22&title=%22+encodeURIComponent(document.title));%20void(0);}<%
+        %>">Submit to <%= Rails.application.name %></a>].
+        You'll be taken to this page with the viewed page's URL and title.
+        (It can't recognize and remove blog/author names for you, though.)
+        </p></li>
 
-        </ul>
-      </div>
-    </div>
+      </ul>
+    <% end %>
   <% end %>
 </div>
 <% unless defined?(suggesting) %>


### PR DESCRIPTION
Use a `<details>` tag for the story guidelines on the story submission page, instead of an anchor tag with a click handler. This improves accessibility, and is related to #755.

Collapsed:
<img width="1224" alt="story submission guidelines collapsed" src="https://user-images.githubusercontent.com/2503289/86975304-e866e280-c12c-11ea-802b-56b4c9c3d56f.png">

Expanded:
<img width="1224" alt="story submission guidelines expanded" src="https://user-images.githubusercontent.com/2503289/86975310-ec930000-c12c-11ea-976b-bce1a7946e9b.png">

I wanted to contribute back to Lobsters (which has been an amazing community). This seemed like a straightforward change to make as my first one to this project.

https://github.com/lobsters/lobsters/issues/755#issuecomment-538805549 rightfully indicates an aversion to bike-shedding, and I think this is a clear accessibility win, because

- Assistive technology will indicate that there's more content, and whether it's expanded or collapsed.
- We avoid an anchor tag, which generally is expected to navigate to another url or another location on this page. That's not really what's happening here.

Also, we end up with (slightly) less JS, which is always nice.

One thing to note is that [IE11 doesn't support the details tag](https://caniuse.com/#feat=details) (although it is supported on all versions of Edge). I haven't been able to find any info on browser support for Lobsters, but if we want to support IE11, these changes won't be a good solution.