### PR TITLE
filter out front page posts from 'newest'

### DIFF
--- a/app/models/story_repository.rb
+++ b/app/models/story_repository.rb
@@ -15,7 +15,8 @@ class StoryRepository
   end
 
   def newest
-    Story.base.filter_tags(@params[:exclude_tags] || []).order(id: :desc)
+    front_page = hottest.limit(StoriesPaginator::STORIES_PER_PAGE)
+    Story.base.filter_tags({} || []).where.not(id: front_page.ids).order(id: :desc)
   end
 
   def newest_by_user(user)

--- a/spec/models/story_repository_spec.rb
+++ b/spec/models/story_repository_spec.rb
@@ -4,6 +4,25 @@ describe StoryRepository do
   let(:submitter) { create(:user) }
   let(:repo) { StoryRepository.new(submitter) }
 
+  describe ".newest" do
+    context 'when there is front page content' do
+      before do
+        create(:story, user: submitter, title: "Front Page")
+        create(:story, user: submitter, title: "Front Page 2")
+
+        create(:story, user: submitter, title: "New Story", downvotes: 2)
+      end
+
+      it "selects newest stories" do
+        expect(repo.newest).to include Story.find_by(title: "New Story")
+      end
+
+      it "does not select front page stories" do
+        expect(repo.newest).to_not include Story.where("title LIKE ?", "Front Page")
+      end
+    end
+  end
+
   describe ".newest_by_user" do
     context "when user is viewing their own stories" do
       before do


### PR DESCRIPTION
<!--
Issues and PRs are typically reviewed Wednesday and most weekend mornings.
-->
According to:
https://github.com/lobsters/lobsters/blob/86fb86788e3afa4de4b8a10d25fd09785897b0dd/app/views/home/index.html.erb#L1-L5

Currently this is not reflected when visiting https://lobste.rs/newest.
