### PR TITLE
Filter out front page posts from 'recent'

### DIFF
--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -383,7 +383,7 @@ describe Story do
 
       it "returns the newest stories that have not yet reached the front page" do
         expect(Story.recent).to include Story.find_by(title: "New Story")
-        expect(Story.recent).to_not include(Sto.front_page)
+        expect(Story.recent).to_not include(Story.front_page)
       end
     end
   end

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -371,4 +371,20 @@ describe Story do
       expect(story_has_url_without_anchor.already_posted_recently?).to be true
     end
   end
+
+  describe "scopes" do
+    context "recent" do
+      before do
+        create(:story, title: "Front Page")
+        create(:story, title: "Front Page 2")
+
+        create(:story, title: "New Story", downvotes: 3) # downvotes simulate story off 'front'
+      end
+
+      it "returns the newest stories that have not yet reached the front page" do
+        expect(described_class.recent).to include described_class.find_by(title: "New Story")
+        expect(described_class.recent).to_not include(*described_class.front_page)
+      end
+    end
+  end
 end

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -383,7 +383,7 @@ describe Story do
 
       it "returns the newest stories that have not yet reached the front page" do
         expect(described_class.recent).to include described_class.find_by(title: "New Story")
-        expect(described_class.recent).to_not include(*described_class.front_page)
+        expect(Story.recent).to_not include(Sto.front_page)
       end
     end
   end

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -382,7 +382,7 @@ describe Story do
       end
 
       it "returns the newest stories that have not yet reached the front page" do
-        expect(described_class.recent).to include described_class.find_by(title: "New Story")
+        expect(Story.recent).to include Story.find_by(title: "New Story")
         expect(Story.recent).to_not include(Sto.front_page)
       end
     end


### PR DESCRIPTION
<!--
Issues and PRs are typically reviewed Wednesday and most weekend mornings.
-->

Continuing from discussion here: https://github.com/lobsters/lobsters/pull/880/

I am assuming front page is the literal list of articles on the home page.

Currently '/recent' filtering is just grabbing _low_ rated stories(?). 
https://github.com/lobsters/lobsters/blob/86fb86788e3afa4de4b8a10d25fd09785897b0dd/app/models/story.rb#L43
https://github.com/lobsters/lobsters/blob/86fb86788e3afa4de4b8a10d25fd09785897b0dd/app/models/story.rb#L50-L56

Not sure if this is intentional so I left it for now.

Front page articles are now properly filtered out with this PR.
