### PR TITLE
Run specs against MySQL and PostgreSQL

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,4 +63,5 @@ group :test, :development do
   gem "vcr"
   gem "webmock" # used to support vcr
   gem 'simplecov', require: false
+  gem "pg"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,9 @@ group :test, :development do
   gem "rubocop-rspec", require: false
   gem "faker"
   gem "byebug"
+  gem "pry"
+  gem "pry-byebug"
+  gem "pry-rails"
   gem "rb-readline"
   gem "vcr"
   gem "webmock" # used to support vcr

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,7 @@ GEM
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
     chunky_png (1.3.12)
+    coderay (1.1.3)
     commonmarker (0.21.0)
       ruby-enum (~> 0.5)
     concurrent-ruby (1.1.7)
@@ -147,6 +148,14 @@ GEM
       ruby-rc4
       ttfunk
     pg (1.2.3)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.9.0)
+      byebug (~> 11.0)
+      pry (~> 0.13.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     public_suffix (4.0.6)
     puma (4.3.6)
       nio4r (~> 2.0)
@@ -305,6 +314,9 @@ DEPENDENCIES
   oauth
   pdf-reader
   pg
+  pry
+  pry-byebug
+  pry-rails
   puma
   rack-mini-profiler
   rails (~> 6.0.3.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,6 +146,7 @@ GEM
       hashery (~> 2.0)
       ruby-rc4
       ttfunk
+    pg (1.2.3)
     public_suffix (4.0.6)
     puma (4.3.6)
       nio4r (~> 2.0)
@@ -303,6 +304,7 @@ DEPENDENCIES
   nokogiri (>= 1.10.8)
   oauth
   pdf-reader
+  pg
   puma
   rack-mini-profiler
   rails (~> 6.0.3.3)

--- a/README.md
+++ b/README.md
@@ -59,28 +59,24 @@ There's an external project [docker-lobsters](https://github.com/utensils/docker
       macOS 10.4+ and Homebrew `openssl`, in which case see
       [this solution](https://stackoverflow.com/a/39628463/1042144).
 
-* Create test databases and configure them appropriately. If you have Docker installed then you can
-`cp config/database.yml.sample config/database.yml` and run `start_test_databases.sh`. Otherwise you have
-to adjust `config/database.yml.sample` to match your configuration.
+* Create test databases and configure them appropriately. Start with
+`cp config/database.yml.sample config/database.yml` and match it to your database set up.
 
 * To run specs use `bundle exec rake`. This ensures we run the spec suite against MySQL and PostgreSQL.
 
-* Add development configuration for your database to `config/database.yml`. If
-you're using provided Docker scripts then you can reuse `test_mysql` section
-(remember to change the database name):
+* Add development configuration for your database to `config/database.yml`:
 
     ```yaml
     development:
-      <<: *test_defaults
+      host: localhost
+      # Or use 127.0.0.1 if you dont want to use socket based authentication
+      #host: 127.0.0.1
+      #port: 3306
+      #username: lobsters
+      #password: lobsters
       adapter: mysql2
       encoding: utf8mb4
       database: lobsters_dev
-
-    test_mysql:
-      <<: *test_defaults
-      adapter: mysql2
-      encoding: utf8mb4
-      port: 3306
     ```
 
 * Load the schema into the new database:

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ There's an external project [docker-lobsters](https://github.com/utensils/docker
     ```sh
     lobsters$ bundle
     ```
-    
+
     * If when installing the `mysql2` gem on macOS, you see 
       `ld: library not found for -l-lpthread` in the output, see 
       [this solution](https://stackoverflow.com/a/44790834/204052) for a fix.
@@ -59,29 +59,28 @@ There's an external project [docker-lobsters](https://github.com/utensils/docker
       macOS 10.4+ and Homebrew `openssl`, in which case see
       [this solution](https://stackoverflow.com/a/39628463/1042144).
 
-* Create a MySQL (other DBs supported by ActiveRecord may work, only MySQL and
-MariaDB have been tested) database, username, and password and put them in a
-`config/database.yml` file.  You will also want a separate database for
-running tests:
+* Create test databases and configure them appropriately. If you have Docker installed then you can
+`cp config/database.yml.sample config/database.yml` and run `start_test_databases.sh`. Otherwise you have
+to adjust `config/database.yml.sample` to match your configuration.
+
+* To run specs use `bundle exec rake`. This ensures we run the spec suite against MySQL and PostgreSQL.
+
+* Add development configuration for your database to `config/database.yml`. If
+you're using provided Docker scripts then you can reuse `test_mysql` section
+(remember to change the database name):
 
     ```yaml
     development:
+      <<: *test_defaults
       adapter: mysql2
       encoding: utf8mb4
-      reconnect: false
       database: lobsters_dev
-      socket: /tmp/mysql.sock
-      username: *dev_username*
-      password: *dev_password*
-      
-    test:
+
+    test_mysql:
+      <<: *test_defaults
       adapter: mysql2
       encoding: utf8mb4
-      reconnect: false
-      database: lobsters_test
-      socket: /tmp/mysql.sock
-      username: *test_username*
-      password: *test_password*
+      port: 3306
     ```
 
 * Load the schema into the new database:

--- a/Rakefile
+++ b/Rakefile
@@ -9,3 +9,54 @@ if Rails.env.development? || Rails.env.test?
 end
 
 Lobsters::Application.load_tasks
+
+def run_against_database(name: :mysql)
+  adapter_name = name == :mysql ? "mysql2" : "postgresql"
+  config_name, _adapter = check_for_test_configuration(adapter: adapter_name)
+
+  if config_name.nil?
+    puts "No configuration found for adapter #{adapter_name}, please check config/database.yml"
+    return
+  end
+
+  puts "Running specs against #{name}"
+  rename_test_configuration(config_name) do
+    Rake::Task['spec'].reenable
+    Rake::Task['spec'].invoke
+  end
+end
+
+def check_for_test_configuration(adapter: "mysql2")
+  configurations = Rails.application.config.database_configuration
+  names_with_adapters = configurations.map {|key, value| [key, value.dig("adapter")] }
+  matching = names_with_adapters.select do |pair|
+    pair.first.match?(/test/) && pair.last.eql?(adapter)
+  end
+  matching.flatten
+end
+
+def rename_test_configuration(name)
+  trap("INT") do
+    puts "Shutting down..."
+    system("sed -i -e 's/test:/#{name}:/' config/database.yml")
+  end
+
+  print "Renaming #{name} into test"
+  system("sed -i -e 's/#{name}:/test:/' config/database.yml")
+  yield if block_given?
+  print "Renaming test into #{name}"
+  system("sed -i -e 's/test:/#{name}:/' config/database.yml")
+end
+
+## We can't really enable this cop since there should be no 'test' environment
+## in the sample configuration
+# rubocop:disable Rails/RakeEnvironment
+task :custom_spec do
+  run_against_database(name: :mysql)
+  run_against_database(name: :postgresql)
+end
+# rubocop:enable Rails/RakeEnvironment
+
+# Clear off the default RSpec task
+Rake::Task[:default].clear
+task :default => :custom_spec

--- a/config/database.yml.sample
+++ b/config/database.yml.sample
@@ -1,0 +1,21 @@
+## The following test configuration assumes you ran the test databases using
+## start_test_databases.sh script in the project root.
+
+test_defaults: &test_defaults
+  ## Can't use localhost here because MySQL treats localhost as socket :(
+  host: 127.0.0.1
+  database: lobsters_test
+  username: test
+  password: test
+
+test_mysql:
+  <<: *test_defaults
+  adapter: mysql2
+  encoding: utf8mb4
+  port: 3306
+
+test_postgres:
+  <<: *test_defaults
+  adapter: postgresql
+  encoding: unicode
+  port: 5432

--- a/config/database.yml.sample
+++ b/config/database.yml.sample
@@ -1,6 +1,3 @@
-## The following test configuration assumes you ran the test databases using
-## start_test_databases.sh script in the project root.
-
 test_defaults: &test_defaults
   ## Can't use localhost here because MySQL treats localhost as socket :(
   host: 127.0.0.1

--- a/start_test_databases.sh
+++ b/start_test_databases.sh
@@ -1,3 +1,0 @@
-#/usr/bin/env bash
-docker run --name lobsters_mariadb -p 3306:3306 -e MYSQL_ROOT_PASSWORD=test -e MYSQL_DATABASE=lobsters_test -e MYSQL_USER=test -e MYSQL_PASSWORD=test -d mariadb:10.3-focal
-docker run --name lobsters_postgres -p 5432:5432 -e POSTGRES_DB=lobsters_test -e POSTGRES_USER=test -e POSTGRES_PASSWORD=test -d postgres:12-alpine

--- a/start_test_databases.sh
+++ b/start_test_databases.sh
@@ -1,0 +1,3 @@
+#/usr/bin/env bash
+docker run --name lobsters_mariadb -p 3306:3306 -e MYSQL_ROOT_PASSWORD=test -e MYSQL_DATABASE=lobsters_test -e MYSQL_USER=test -e MYSQL_PASSWORD=test -d mariadb:10.3-focal
+docker run --name lobsters_postgres -p 5432:5432 -e POSTGRES_DB=lobsters_test -e POSTGRES_USER=test -e POSTGRES_PASSWORD=test -d postgres:12-alpine


### PR DESCRIPTION
This is the dumbest approach that:

1. Checks if there's a database configuration with a name matching `/test/` and a given adapter.
2. If there's a match then it renames the configuration to `test` instead of whatever it was.
3. Runs the spec suite
4. Reverts the changes made (even if you CTRL+C)
5. Exits cleanly if there's no adapter found of any of the databases

Advantages:

* It is relatively simple
* Doesn't involve monkey-patching
* Doesn't mess with Rails internal connection handling

Disadvantages:

* Relies on `sed` (this can be refactored if portability is a concern)
* Relies on the configuration name to have the word `test` in it

Related to #861