### PR TITLE
Fixes bug #893 by not considering tags on expired stories.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -495,7 +495,7 @@ class User < ApplicationRecord
     Tag.active.joins(
       :stories
     ).where(
-      :stories => { :user_id => self.id, is_expired: false }
+      :stories => { :user_id => self.id, :is_expired => false }
     ).group(
       Tag.arel_table[:id]
     ).order(

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -495,7 +495,7 @@ class User < ApplicationRecord
     Tag.active.joins(
       :stories
     ).where(
-      :stories => { :user_id => self.id }
+      :stories => { :user_id => self.id, is_expired: false }
     ).group(
       Tag.arel_table[:id]
     ).order(


### PR DESCRIPTION
The code to compute a user's most common tags to display on their profile page doesn't take into account the state of the story, leading to users being able to have 0 stories, yet a most common tag for those 0 stories, as evidenced in Bug #893. This change edits `lobsters/app/models/user.rb` to have `most_common_story_tag` take into account the `is_expired` nature of the story and ensure the story is still visible. 

https://github.com/threeplanetssoftware/lobsters/blob/87dc77fe7ef3989045fd2fbea96c4a0e38aee052/app/models/user.rb#L494

This pull request should fix #893, unless it is intended behavior for expired posts to be included in these calculations. If that is the case this can be tossed out and the bug report closed as a feature. 

