### PR TITLE
Wrap Story and Comment creation inside of a transcation.

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -48,7 +48,7 @@ class CommentsController < ApplicationController
       end
     end
 
-    if comment.valid? && params[:preview].blank? && comment.save
+    if comment.valid? && params[:preview].blank? && ActiveRecord::Base.transaction { comment.save }
       comment.current_vote = { :vote => 1 }
 
       if request.xhr?

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -18,7 +18,7 @@ class StoriesController < ApplicationController
     @story.attributes = story_params
 
     if @story.valid? && !(@story.already_posted_recently? && !@story.seen_previous)
-      if @story.save
+      if ActiveRecord::Base.transaction { @story.save }
         ReadRibbon.where(user: @user, story: @story).first_or_create
         return redirect_to @story.comments_path
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,7 +63,7 @@ Rails.application.routes.draw do
   match "/login/set_new_password" => "login#set_new_password",
     :as => "set_new_password", :via => [:get, :post]
 
-  get "/categories/:category" => "home#category", as: :category
+  get "/categories/:category" => "home#category", :as => :category
   get "/t/:tag" => "home#tagged", :as => "tag"
   get "/t/:tag/page/:page" => "home#tagged"
 

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -3,8 +3,13 @@ require "rails_helper"
 describe Tag do
   context 'validations' do
     it 'allows a valid tag to be created' do
-      expect(Tag.create(category: Category.first, tag: 'tag_name', hotness_mod: 0.25, description: 'test description'))
-        .to be_valid
+      tag = Tag.create(
+        category: Category.first,
+        tag: 'tag_name',
+        hotness_mod: 0.25,
+        description: 'test description'
+      )
+      expect(tag).to be_valid
     end
 
     it 'does not allow a tag to be saved without a name' do


### PR DESCRIPTION
The new reconciliation process between an object's Vote and its
memoized count requires that MariaDB can see the records in the Vote
table. Currently, we are seeing the vote be created, then the
memoization for new comments and stories to zero.

We now force this behavior to take place inside of a transaction.
This should keep the code working the way we expect.

<!--
Issues and PRs are typically reviewed Wednesday and most weekend mornings.
-->
