### PR TITLE
expire_page_cache: exit early during a maintenance window.

### DIFF
--- a/script/expire_page_cache
+++ b/script/expire_page_cache
@@ -1,4 +1,9 @@
 #!/bin/sh
 
+if [ -f /srv/lobste.rs/http/public/maintenance.html ];
+then
+  exit 0
+fi
+
 find /srv/lobste.rs/http/public/cache/ -type f -not -mmin 2 -not -name ".gitkeep" -delete
 find /srv/lobste.rs/http/public/cache/ -type d -empty -delete


### PR DESCRIPTION
during a scheduled maintenance window, don't expire the page
cache. exit without error instead.
