### PR TITLE
comments: remove dangling pipe (|) when vote_summary_for_user is empty.

### DIFF
--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -124,7 +124,9 @@ class="comment <%= comment.current_vote ? (comment.current_vote[:vote] == 1 ?
           <% if comment.flags > 0 &&
           comment.show_score_to_user?(@user) &&
           (comment.user_id == @user.try(:id) || @user.try("is_moderator?")) %>
-            | <%= comment.vote_summary_for_user(@user).downcase %>
+            <% if (s = comment.vote_summary_for_user(@user).downcase).present? %>
+              | <%= s %>
+            <% end %>
           <% elsif comment.current_vote && comment.current_vote[:vote] == -1 %>
             | -1
             <%= Vote::ALL_COMMENT_REASONS[comment.current_vote[:reason]].downcase %>


### PR DESCRIPTION
On /comments, when logged in as a moderator and when a comment has
received no upvotes or flags, a trailing pipe (|) appears in the
byline.

Once a comment is upvoted, the spurious pipe (|) disappears.

Do not display this character when the vote summary is the empty
string.
