### PR TITLE
/mod: use story/comment specific mod_flagged_path call.

### DIFF
--- a/app/views/mod/_nav.html.erb
+++ b/app/views/mod/_nav.html.erb
@@ -1,8 +1,8 @@
 <div class="box wide">
   <div class="legend right">
     <%= link_to 'Notes', mod_notes_path(period: '2w') %>
-    F-Stories: <% @periods.each do |p| %><%= link_to_different_page(p, mod_flagged_path(period: p)) %> <% end %>
-    F-Comments: <% @periods.each do |p| %><%= link_to_different_page(p, mod_flagged_path(period: p)) %> <% end %>
+    F-Stories: <% @periods.each do |p| %><%= link_to_different_page(p, mod_flagged_stories_path(period: p)) %> <% end %>
+    F-Comments: <% @periods.each do |p| %><%= link_to_different_page(p, mod_flagged_comments_path(period: p)) %> <% end %>
   Commenters: <% %w{1m 2m 3m 6m}.each do |p| %><%= link_to_different_page(p, mod_commenters_path(period: p)) %> <% end %>
   </div>
 


### PR DESCRIPTION
Rather than mod_flagged_path, call mod_flagged_stories_path or
mod_flagged_comments_path depending on context. This is part of
renaming comment downvotes to flags, just as we do stories.