### PR TITLE
Remove double pipe (| |) in comment byline for those not logged in.

### DIFF
--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -105,7 +105,7 @@ class="comment <%= comment.current_vote ? (comment.current_vote[:vote] == 1 ?
         <% elsif flagged %>
           | <a class="flagger">unflag</a>
         <% else %>
-          | <span class="flagger flagger_stub"></span>
+          <span class="flagger flagger_stub"></span>
         <% end %>
 
         <% if @user && !comment.story.is_gone? && !comment.is_gone? %>


### PR DESCRIPTION
The byline, where logged in users might variously have the option
to flag or unflag a comment, displays a spurious pipe (|) to readers
without the option to flag.

Remove that, retaining the stub span.

<!--
Issues and PRs are typically reviewed Wednesday and most weekend mornings.
-->
