### PR TITLE
fix wrong namespace for LineLength

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,7 @@ AllCops:
     - 'bin/**/*'
     - 'db/**/*'
     - 'vendor/**/*'
+  UseCache: false
 
 # Cop configuration:
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -71,13 +71,13 @@ class ApplicationController < ActionController::Base
 
     color = :red
     [
-      # rubocop:disable Metrics/LineLength,
+      # rubocop:disable Layout/LineLength,
       [2_000_000, :blue, "background-color: #0000#{hex};"],
       [6, :yellow, "background-color: ##{hex}#{hex}00;"],
       [3, :calico, "background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAACXBIWXMAAC4jAAAuIwF4pT92AAAABmJLR0QA/wD/AP+gvaeTAAACpElEQVQYGQXBWW8bVRgA0Hu/u814NsdxGsUxztJUzaJSVS1CCCTKE7zxxiP/gH+I+lKKQEVCLUlJ5YTsU8f2eJvxbHfjHLz7sKeU2mhNfvl579vnEPKUEUJxji1YoBaIob4m6+cX8Our/m99TBwmpKGV0hZjz+EO06FHOAKlFNKIcE+p8HYo3rwd/Xk8m+pVEjW4EzIFdjopVVG6Nt1ocpc3ALnIhqMRnF3afz6qd2flcMElAOWu3nm4tr6xMh2cyDpprqwBwdjQ0Uz9fXJ9el0lRTOekVQ13DCKvCXVWO7sdl6+/Gp01cbpv/uHPcqGlUKIr50NZq+Pi7mymrt+GOxvbz9+zKjS5OLi1uV/ZeObAC3un4qgt+c0bL8/v5qJ64WbaocIPC2HzbaDGCOeF0ySJI7vzz9eLuZFpfDq2lZWmd/fx6/e3twkuDIiL3KCysV83D+/xZ/1uhYXjuC6lg0BVk2fHPXcQMWD7L+bvJCettzhEPpgzRIxjbe3u6VMCcXWMEY5E9qisqo1QlRLjDVwxqxSQpBW5CFnSB2PaulyRleCSEtNhDPLltjkdQWYCC+gDVF6pHzU8z8/7IKgVFaVtshSWaQxA2Osz4FiokTQrLRrQCLIXzxr/fT94cFWVFlGmXExNQznnbbzaGcVgb0bJqO8kS5BzmusNAMdYN5mPlsihRh5sL7pRYHXQM+OOj/+8MV3Xx+2mmQ8qQZxkmfKSGXq1Odyt9MShByffKLgcc3JsqrHk3Eyumu6LbkYFHcfsjttSaR5OFP29H755nzw/sq8+yMh/sYKYiRL76dxzOqr9RBsmeisnCWqVlZaMIyxgC5U9eEy7p9awj0ByDiQ7XfgmyfRl0fRwZbb7bLVNmOOXynADDY3Hxzs7+WL5XSY/w/0MGrkMYhXjAAAAABJRU5ErkJggg==) no-repeat center"],
       [2, :split, "background: linear-gradient(90deg, ##{hex}0000 50%, #0000#{hex} 50%)"],
       [2, :albino, "filter: invert(100%);"],
-      # rubocop:enable Metrics/LineLength,
+      # rubocop:enable Layout/LineLength,
     ].each do |cumulative_odds, name, style|
       break unless rand(cumulative_odds) == 0
       color = name


### PR DESCRIPTION
Without these changes, rubocop prints out:

```
$ bundle exec rubocop

Inspecting 172 files

.app/controllers/application_controller.rb: Metrics/LineLength has the wrong namespace - should be Layout

app/controllers/application_controller.rb: Metrics/LineLength has the wrong namespace - should be Layout

...........................................................................................................................................................................

172 files inspected, no offenses detected

The command "bundle exec rubocop" exited with 0.
```