### PR TITLE
production.rb.sample: s/StoryCacher/DiffBot/

### DIFF
--- a/config/initializers/production.rb.sample
+++ b/config/initializers/production.rb.sample
@@ -23,7 +23,7 @@ if Rails.env.production?
   Pushover.API_TOKEN = "secret"
   Pushover.SUBSCRIPTION_CODE = "secret"
 
-  StoryCacher.DIFFBOT_API_KEY = "secret"
+  DiffBot.DIFFBOT_API_KEY = "secret"
 
   Twitter.CONSUMER_KEY = "secret"
   Twitter.CONSUMER_SECRET = "secret"


### PR DESCRIPTION
StoryCacher was renamed to DiffBot but the sample configuration
was not brought up-to-date.

<!--
Issues and PRs are typically reviewed Wednesday and most weekend mornings.
-->
