### PR TITLE
various cosmetic cleanups to moderation logs

### DIFF
--- a/app/models/mod_note.rb
+++ b/app/models/mod_note.rb
@@ -53,10 +53,10 @@ class ModNote < ApplicationRecord
       created_at: Time.current,
       note: "Attempted to post a story from a #{reason} domain:\n" +
         "url: #{story.url}" +
-        "title: #{story.title}" +
-        "user_is_author: #{story.user_is_author}" +
-        "tags: #{story.tags.map(&:tag).join(' ')}" +
-        "description: #{story.description}"
+        " title: #{story.title}" +
+        " user_is_author: #{story.user_is_author}" +
+        " tags: #{story.tags.map(&:tag).join(' ')}" +
+        " description: #{story.description}"
     )
   end
 end

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -588,7 +588,7 @@ class Story < ApplicationRecord
       m.action = all_changes.map {|k, v|
         if k == "merged_story_id"
           if v[1]
-            "merged into #{self.merged_into_story.short_id} " <<
+            "merged into story #{self.merged_into_story.short_id} " <<
               "(#{self.merged_into_story.title})"
           else
             "unmerged from another story"

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -567,6 +567,7 @@ class Story < ApplicationRecord
 
     all_changes = self.changes.merge(self.tagging_changes)
     all_changes.delete("unavailable_at")
+    all_changes.delete("domain_id")
 
     if !all_changes.any?
       return


### PR DESCRIPTION
Add some missing spaces between fields in a mod note, be extra clear that a short_id is a story short id, and remove the domain_id from the change report--the url contains the necessary information.