### PR TITLE
Update message reply form to only include wearable hats. 

### DIFF
--- a/app/views/messages/_form.html.erb
+++ b/app/views/messages/_form.html.erb
@@ -24,9 +24,9 @@
   <% if @user.wearable_hats.any? %>
     <div class="boxline">
       <%= f.label :hat_id, 'Put on hat:' %>
-      <%= f.select :hat_id, options_for_select( [['','']] +
-        @user.hats.map{|h| [h.hat, { 'data-modnote' => h.modlog_use }, h.id] }
-      ) %>
+      <%= f.select :hat_id,
+        options_from_collection_for_select(@user.wearable_hats, "id", "hat"),
+        :include_blank => true %>
 
       <% if @user.is_moderator? %>
         &nbsp;&nbsp;

--- a/app/views/messages/_form.html.erb
+++ b/app/views/messages/_form.html.erb
@@ -24,10 +24,9 @@
   <% if @user.wearable_hats.any? %>
     <div class="boxline">
       <%= f.label :hat_id, 'Put on hat:' %>
-      <%= f.select :hat_id,
-        options_from_collection_for_select(@user.wearable_hats, "id", "hat"),
-        :include_blank => true %>
-
+      <%= f.select :hat_id, options_for_select( [['','']] +
+        @user.wearable_hats.map{|h| [h.hat, { 'data-modnote' => h.modlog_use }, h.id] }
+      ) %>
       <% if @user.is_moderator? %>
         &nbsp;&nbsp;
         <%= f.check_box 'mod_note', class: 'normal' %>


### PR DESCRIPTION
Fixes #927 by only allowing wearable hats to populate the message reply form. Copied the syntax from the comment reply box to ensure consistency. 