### PR TITLE
[Fix #897] Recognize links with or without .htm(l)

### DIFF
--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -254,6 +254,7 @@ class Story < ApplicationRecord
       urls2.push u_without_slash + ".html"
       urls2.push u_without_slash + ".htm"
       urls2.push u.gsub(/\/index.html?\z/, "")
+      urls2.push u.gsub(/\.html?\z/, "")
     end
     urls = urls2.uniq
 

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -211,11 +211,30 @@ class Story < ApplicationRecord
 
   # all stories with similar urls
   def self.find_similar_by_url(url)
-    url = url.to_s.gsub('[', '\\[')
-    url = url.to_s.gsub(']', '\\]')
+    similar_urls = similar_urls_to(url)
+
+    similar_urls.each do |similar_url|
+      similar_url.to_s.gsub!('[', '\\[')
+      similar_url.gsub!(']', '\\]')
+    end
+
+    # trailing pound
+    urls_with_trailing_pound = []
+    similar_urls.each do |u|
+      urls_with_trailing_pound.push u + "#"
+    end
+
+    # if a previous submission was moderated, return it to block it from being
+    # submitted again
+    Story
+      .where(:url => similar_urls)
+      .or(Story.where("url RLIKE ?", urls_with_trailing_pound.join(".|")))
+      .where("is_expired = ? OR is_moderated = ?", false, true)
+  end
+
+  def self.similar_urls_to(url)
     urls = [url.to_s.gsub(/(#.*)/, "")]
     urls2 = [url.to_s.gsub(/(#.*)/, "")]
-    urls_with_trailing_pound = []
 
     # https
     urls.each do |u|
@@ -241,18 +260,6 @@ class Story < ApplicationRecord
       urls2.push u.gsub(/^(https?:\/\/)/i) {|_| "#{$1}www." }
     end
     urls = urls2.uniq
-
-    # trailing pound
-    urls.each do |u|
-      urls_with_trailing_pound.push u + "#"
-    end
-
-    # if a previous submission was moderated, return it to block it from being
-    # submitted again
-    Story
-      .where(:url => urls)
-      .or(Story.where("url RLIKE ?", urls_with_trailing_pound.join(".|")))
-      .where("is_expired = ? OR is_moderated = ?", false, true)
   end
 
   # doesn't include deleted/moderated/merged stories

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -233,33 +233,38 @@ class Story < ApplicationRecord
   end
 
   def self.similar_urls_to(url)
-    urls = [url.to_s.gsub(/(#.*)/, "")]
-    urls2 = [url.to_s.gsub(/(#.*)/, "")]
+    url_without_anchor = url.to_s.gsub(/(#.*)/, "")
+    urls = [url_without_anchor]
+    urls2 = urls.dup
 
-    # https
+    # http(s)
     urls.each do |u|
       urls2.push u.gsub(/^http:\/\//i, "https://")
       urls2.push u.gsub(/^https:\/\//i, "http://")
     end
     urls = urls2.uniq
 
-    # trailing slash or index.html
+    # add trailing slash or index.html
     urls.each do |u|
       u_without_slash = u.gsub(/\/+\z/, "")
       urls2.push u_without_slash
       urls2.push u_without_slash + "/"
       urls2.push u_without_slash + "/index.htm"
       urls2.push u_without_slash + "/index.html"
+      urls2.push u_without_slash + ".html"
+      urls2.push u_without_slash + ".htm"
       urls2.push u.gsub(/\/index.html?\z/, "")
     end
     urls = urls2.uniq
 
-    # www prefix
+    # add/remove www
     urls.each do |u|
       urls2.push u.gsub(/^(https?:\/\/)www\d*\./i) {|_| $1 }
       urls2.push u.gsub(/^(https?:\/\/)/i) {|_| "#{$1}www." }
     end
     urls = urls2.uniq
+
+    urls
   end
 
   # doesn't include deleted/moderated/merged stories

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -342,6 +342,11 @@ describe Story do
         'https://example.com/foo.htm'
       )
     end
+
+    it "includes removal of .htm(l)" do
+      expect(Story.similar_urls_to('https://example.com/foo.html')).to include('https://example.com/foo')
+      expect(Story.similar_urls_to('https://example.com/foo.htm')).to include('https://example.com/foo')
+    end
   end
 
   describe "#calculated_hotness" do

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -323,7 +323,7 @@ describe Story do
       )
     end
 
-    it "removes trailing slash or index.htm(l) if it ends with it" do
+    it "includes trailing slash or index.htm(l)" do
       expect(Story.similar_urls_to('https://example.com/')).to include('https://example.com')
       expect(Story.similar_urls_to('https://example.com/index.html')).to include('https://example.com')
       expect(Story.similar_urls_to('https://example.com/index.htm')).to include('https://example.com')
@@ -332,6 +332,13 @@ describe Story do
     it "includes or excludes the www prefix" do
       expect(Story.similar_urls_to('https://example.com/')).to include('https://www.example.com')
       expect(Story.similar_urls_to('https://www.example.com/')).to include('https://example.com')
+    end
+
+    it "includes .htm(l) appended" do
+      expect(Story.similar_urls_to('https://example.com/foo')).to include(
+        'https://example.com/foo.html',
+        'https://example.com/foo.htm'
+      )
     end
   end
 

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -310,12 +310,12 @@ describe Story do
   end
 
   describe ".similar_urls_to" do
-    it "includes http(s) scheme" do
+    it "includes alternate http(s) scheme" do
       expect(Story.similar_urls_to('https://example.com')).to include('http://example.com')
       expect(Story.similar_urls_to('http://example.com')).to include('https://example.com/')
     end
 
-    it "includes a trailing slash or index.htm(l)" do
+    it "includes addition of a trailing slash or index.htm(l)" do
       expect(Story.similar_urls_to('https://example.com')).to include(
         'https://example.com/',
         'https://example.com/index.html',
@@ -323,18 +323,20 @@ describe Story do
       )
     end
 
-    it "includes trailing slash or index.htm(l)" do
+    it "includes removal of a trailing slash or index.htm(l)" do
       expect(Story.similar_urls_to('https://example.com/')).to include('https://example.com')
-      expect(Story.similar_urls_to('https://example.com/index.html')).to include('https://example.com')
-      expect(Story.similar_urls_to('https://example.com/index.htm')).to include('https://example.com')
+      expect(Story.similar_urls_to('http://example.com/index.htm')).to include('http://example.com')
+      expect(Story.similar_urls_to('http://example.com/index.html')).to include(
+        'http://example.com'
+      )
     end
 
-    it "includes or excludes the www prefix" do
+    it "includes addition or removal of www prefix" do
       expect(Story.similar_urls_to('https://example.com/')).to include('https://www.example.com')
       expect(Story.similar_urls_to('https://www.example.com/')).to include('https://example.com')
     end
 
-    it "includes .htm(l) appended" do
+    it "includes addition of .htm(l)" do
       expect(Story.similar_urls_to('https://example.com/foo')).to include(
         'https://example.com/foo.html',
         'https://example.com/foo.htm'

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -309,6 +309,32 @@ describe Story do
     end
   end
 
+  describe ".similar_urls_to" do
+    it "includes http(s) scheme" do
+      expect(Story.similar_urls_to('https://example.com')).to include('http://example.com')
+      expect(Story.similar_urls_to('http://example.com')).to include('https://example.com/')
+    end
+
+    it "includes a trailing slash or index.htm(l)" do
+      expect(Story.similar_urls_to('https://example.com')).to include(
+        'https://example.com/',
+        'https://example.com/index.html',
+        'https://example.com/index.htm',
+      )
+    end
+
+    it "removes trailing slash or index.htm(l) if it ends with it" do
+      expect(Story.similar_urls_to('https://example.com/')).to include('https://example.com')
+      expect(Story.similar_urls_to('https://example.com/index.html')).to include('https://example.com')
+      expect(Story.similar_urls_to('https://example.com/index.htm')).to include('https://example.com')
+    end
+
+    it "includes or excludes the www prefix" do
+      expect(Story.similar_urls_to('https://example.com/')).to include('https://www.example.com')
+      expect(Story.similar_urls_to('https://www.example.com/')).to include('https://example.com')
+    end
+  end
+
   describe "#calculated_hotness" do
     let(:story) do
       create(:story, url: 'https://example.com', user_is_author: true, created_at: Time.zone.at(0))


### PR DESCRIPTION
Fixes #897 (the similar URLs part)

URLs like `example.com/foo` should now be similar to `example.com/foo.html` or `example.com/foo.htm` (and vice versa).

The issue also includes mention of following redirects when fetching the URLs data but that seems like a separate change?