### PR TITLE
Add X-Is-Author to mailing list headers

### DIFF
--- a/script/mail_new_activity.rb
+++ b/script/mail_new_activity.rb
@@ -86,6 +86,7 @@ if __FILE__ == $PROGRAM_NAME
         [{}, "/usr/sbin/sendmail", "-i", "-f", "nobody@#{Rails.application.domain}", u.email],
         "w") do |mail|
         mail.puts "From: #{s.user.username} <#{s.user.username}@#{Rails.application.domain}>"
+        mail.puts "X-Is-Author: #{s.user_is_author?}"
         mail.puts "Reply-To: #{list}"
         mail.puts "To: #{list}"
         mail.puts "X-BeenThere: #{list}"


### PR DESCRIPTION
Currently, there is no way to tell whether a story has been authored by a submitter or not from the e-mail that is received when one subscribes to the mailing list. This information can be useful for

1. Marking a story as authored by the submitter in things like mockturtle;
2. Filtering out authored articles at the user's preference.

The `X-Is-Author` header will be `true` when the submitter of the story checks the "Authored" box, and `false` otherwise.

<!--
Issues and PRs are typically reviewed Wednesday and most weekend mornings.
-->
