### PR TITLE
Allow gemini and gopher homepage URLs

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -83,7 +83,9 @@ class User < ApplicationRecord
             :uniqueness => { :case_sensitive => false }
 
   validates :homepage,
-            :format => { :with => /\Ahttps?:\/\/[^\/\s]+\.[^.\/\s]+(\/.*)?\Z/ },
+            :format => {
+              :with => /\A(?:https?|gemini|gopher):\/\/[^\/\s]+\.[^.\/\s]+(\/.*)?\Z/,
+            },
             :allow_blank => true
 
   validates :password, :presence => true, :on => :create

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -117,6 +117,11 @@
     <span class="d">
       <a href="<%= h(@showing_user.homepage) %>"
         rel="me ugc"><%= h(@showing_user.homepage) %></a>
+      <% if (@showing_user.homepage.start_with?('gemini://') %>
+        (<a href="https://portal.mozz.us/gemini/<% h(@showing_user.homepage[9..-1]) %>">HTTP proxy</a>)
+      <% elsif (@showing_user.homepage.start_with?('gopher://') %>
+        (<a href="https://gopher.floodgap.com/gopher/gw?<% h(@showing_user.homepage[9..-1]) %>">HTTP proxy</a>)
+      <% end %>
     </span>
     <br>
   <% end %>

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -73,6 +73,8 @@ describe User do
     expect(build(:user, :homepage => "https://ሙዚቃ.et")).to be_valid
     expect(build(:user, :homepage => "http://lobste.rs/ሙዚቃ")).to be_valid
     expect(build(:user, :homepage => "http://www.lobste.rs/")).to be_valid
+    expect(build(:user, :homepage => "gemini://www.lobste.rs/")).to be_valid
+    expect(build(:user, :homepage => "gopher://www.lobste.rs/")).to be_valid
 
     expect(build(:user, :homepage => "http://")).to_not be_valid
     expect(build(:user, :homepage => "http://notld")).to_not be_valid


### PR DESCRIPTION
I thought it would be nice to allow Gemini spaces and Gopher holes in the homepage field.