### PR TITLE
Add OpenSearch description document

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,6 +7,7 @@
   <link rel="apple-touch-icon" sizes="114x114" href="/apple-touch-icon.png" />
   <link rel="apple-touch-icon" sizes="72x72" href="/apple-touch-icon-144.png" />
   <link rel="apple-touch-icon" sizes="144x144" href="/apple-touch-icon-144.png" />
+  <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="Lobsters">
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="referrer" content="always" />
   <meta name="theme-color" content="#AC130D" />

--- a/public/opensearch.xml
+++ b/public/opensearch.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+<ShortName>Lobsters</ShortName>
+<Description>Computing-focused community centered around link aggregation and discussion</Description>
+<Url type="text/html" method="GET" template="https://lobste.rs/search?what=stories&amp;order=relevance&amp;q={searchTerms}" />
+<Url type="application/opensearchdescription+xml" rel="self" template="https://lobste.rs/opensearch.xml" />
+<Image height="64" width="64" type="image/x-icon">https://lobste.rs/favicon.ico</Image>
+<Language>en</Language>
+<moz:SearchForm>https://lobste.rs/search</moz:SearchForm>
+</OpenSearchDescription>


### PR DESCRIPTION
Mainly allows Firefox users to add Lobsters as a search engine.

See [the specifications](https://github.com/dewitt/opensearch) and [MDN](https://developer.mozilla.org/en-US/docs/Web/OpenSearch) for more info.