### PR TITLE
Add null check for title match

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -273,9 +273,13 @@ var _Lobsters = Class.extend({
 
     // common separators or (parens) that don't enclose a 4-digit year
     if (title.match(/: | - | – | — | \| | · | • | by /) ||
-        title.match(/\([^\)]*\)/g).some(function (p) { return !p.match(/\(\d{4}\)/) })
+        title.match(/\([^\)]*\)/g)!= null
     ) {
-      $('.title-reminder').slideDown();
+        if (title.match(/: | - | – | — | \| | · | • | by /) ||
+            title.match(/\([^\)]*\)/g).some(function (p) { return !p.match(/\(\d{4}\)/) })
+        ) {
+          $('.title-reminder').slideDown();
+        }
     }
   },
 


### PR DESCRIPTION
Replicating the error: 
On the submit a story page, type in a title then click on the text box. A TypeError appears in the console because .some is read on the null value returned by  ```title.match(/: | - | – | — | \| | · | • | by /) || title.match(/\([^\)]*\)/g)```. This fix adds a null check before reading .some on the value.

![clicking_away](https://user-images.githubusercontent.com/22798606/103312963-9a9caa00-49ec-11eb-9621-e57af4b42e96.png)
![error](https://user-images.githubusercontent.com/22798606/103312964-9a9caa00-49ec-11eb-8668-b7ebdc41cd38.png)

