### PR TITLE
Remember collapsed threads

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -600,7 +600,7 @@ $(document).ready(function() {
         storyID  = $('.story').attr('data-shortid'),
         collapse = JSON.parse(localStorage.getItem(storyID) || '{}');
     if (e.target.checked)
-      collapse[id] = true;
+      collapse[id] = 1;
     else
       delete(collapse[id]);
     localStorage.setItem(storyID, JSON.stringify(collapse));
@@ -612,7 +612,7 @@ $(document).ready(function() {
         collapse = JSON.parse(localStorage.getItem(storyID) || '{}');
 
     for (var k in collapse)
-      $('input#comment_folder_' + k).attr('checked', (collapse[k]))
+      $('input#comment_folder_' + k).attr('checked', !!collapse[k])
   });
 
   $('textarea#comment').keydown(function (e) {

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -596,7 +596,7 @@ $(document).ready(function() {
 
   // Remember story collapses; this is stored in localStorage for every story ID as an object.
   $(document).on('change', '.comment_folder_button', function(e) {
-    var id       = $(e.target).closest('.comments_subtree').find('[data-shortid]:first').attr('data-shortid'),
+    var id       = $(e.target).find('~ div.comment').attr('data-shortid'),
         storyID  = $('.story').attr('data-shortid'),
         collapse = JSON.parse(localStorage.getItem(storyID) || '{}');
     collapse[id] = e.target.checked

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -599,8 +599,11 @@ $(document).ready(function() {
     var id       = $(e.target).find('~ div.comment').attr('data-shortid'),
         storyID  = $('.story').attr('data-shortid'),
         collapse = JSON.parse(localStorage.getItem(storyID) || '{}');
-    collapse[id] = e.target.checked
-    localStorage.setItem(storyID, JSON.stringify(collapse))
+    if (e.target.checked)
+      collapse[id] = true;
+    else
+      delete(collapse[id]);
+    localStorage.setItem(storyID, JSON.stringify(collapse));
   })
 
   // Collapse stories on load; the actual hiding is done in CSS; just need to switch the checkbox.

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -594,6 +594,24 @@ $(document).ready(function() {
       this.value = 'http://' + this.value;
   });
 
+  // Remember story collapses; this is stored in localStorage for every story ID as an object.
+  $(document).on('change', '.comment_folder_button', function(e) {
+    var id       = $(e.target).closest('.comments_subtree').find('[data-shortid]:first').attr('data-shortid'),
+        storyID  = $('.story').attr('data-shortid'),
+        collapse = JSON.parse(localStorage.getItem(storyID) || '{}');
+    collapse[id] = e.target.checked
+    localStorage.setItem(storyID, JSON.stringify(collapse))
+  })
+
+  // Collapse stories on load; the actual hiding is done in CSS; just need to switch the checkbox.
+  $(document).ready(function() {
+    var storyID  = $('.story').attr('data-shortid'),
+        collapse = JSON.parse(localStorage.getItem(storyID) || '{}');
+
+    for (var k in collapse)
+      $('input#comment_folder_' + k).attr('checked', (collapse[k]))
+  });
+
   $('textarea#comment').keydown(function (e) {
     if ((e.metaKey || e.ctrlKey) && e.keyCode == 13) {
       $(".comment-post").click();


### PR DESCRIPTION
This change remembers collapsed threads, similar to HN. Unlike HN, it
doesn't store this on the server but in the browser's localStorage. This
is done for both logged in and logged out users.

Alternatively, we could use sessionStorage so it's less persistent. Or
add a "remember collapsed threads" setting with the options
"persistent", "session", and "none". I'm not sure if there are any
people who would consider this feature undesirable?

Tested locally in Firefox and Chromium and seems to work well.
