### PR TITLE
Clear reply textarea after posting

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -210,6 +210,10 @@ var _Lobsters = Class.extend({
     params.push({"name": "show_tree_lines", "value": "true"});
 
     $.post($(form).attr("action"), params, function(data) {
+      // Clear form: Firefox will keep form values on reload (e.g. F5), which isn't too useful if
+      // it's already posted.
+      $(form).find('textarea').val('')
+
       var parsedHTML = $.parseHTML(data);
 
       var isEdit = $(form).hasClass("edit_comment");


### PR DESCRIPTION
1. Write your comment, post it.
2. Press F5
3. The reply field now contains your comment, since it was submitted and
   hidden via JS, and Firefox will still re-populate it after reloading.

This only happens in Firefox; Chrome doesn't have this behaviour.