### PR TITLE
Plain text in comments and stories

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -154,6 +154,7 @@ class Comment < ApplicationRecord
       :score,
       :flags,
       { :comment => (self.is_gone? ? "<em>#{self.gone_text}</em>" : :markeddown_comment) },
+      { :comment_plain => (self.is_gone? ? self.gone_text : :comment) },
       :url,
       :indent_level,
       { :commenting_user => :user },

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -303,6 +303,7 @@ class Story < ApplicationRecord
       :flags,
       { :comment_count => :comments_count },
       { :description => :markeddown_description },
+      { :description_plain => :description },
       :comments_url,
       { :submitter_user => :user },
       { :tags => self.tags.map(&:tag).sort },


### PR DESCRIPTION
Intended for clients that don't need to (or can't) handle HTML, and can render (or simply display) the raw markdown themselves. Fixes #972