### PR TITLE
Create test data just oustide the new user window

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -19,7 +19,7 @@ User.create(
     User::MIN_KARMA_TO_SUBMIT_STORIES,
     User::MIN_KARMA_FOR_INVITATION_REQUESTS
   ].max,
-  :created_at => User::NEW_USER_DAYS.days.ago
+  :created_at => (User::NEW_USER_DAYS+1).days.ago
 )
 
 c = Category.create!(category: "Category")

--- a/lib/tasks/fake_data.rake
+++ b/lib/tasks/fake_data.rake
@@ -18,7 +18,7 @@ class FakeDataGenerator
         password: password,
         password_confirmation: password,
         username: Faker::Internet.user_name(specifier: name, separators: %w(_)),
-        created_at: User::NEW_USER_DAYS.days.ago,
+        created_at: (User::NEW_USER_DAYS + 1).days.ago,
       }
       create_args.merge!(is_moderator: true) if i % 7 == 0
       users << User.create!(create_args)


### PR DESCRIPTION
 When we set our fake data to `NEW_USER_DAYS.days.ago` then we end up hitting the `is_new?` validation check during fake data generation (especially given that the randomly generated domains tend to hit the error), preventing stories and the like from being created.  Adding an extra day lets these accounts create stories without issue. 

I'm not 100% if this is the right way to resolve this issue, or if I'm doing something wrong, but this feels pretty harmless to me