### PR TITLE
Add a maxlength to memo field

### DIFF
--- a/app/views/users/_invitationform.html.erb
+++ b/app/views/users/_invitationform.html.erb
@@ -17,7 +17,7 @@ don't personally know.
 
   <div class="boxline">
     <%= f.label :memo, "Memo to User:", :class => "required" %>
-    <%= f.text_field :memo, :size => 60 %>
+    <%= f.text_field :memo, :size => 60, :maxlength => 255 %><!-- make sure maxlength corresponds to enforced maxlength -->
   </div>
 
   <div class="boxline">


### PR DESCRIPTION
So that user doesn't write a long text only to be discarded.

<!--
Issues and PRs are typically reviewed Wednesday and most weekend mornings.
-->
