### PR TITLE
Reverse the order of messages

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -571,11 +571,11 @@ class User < ApplicationRecord
   end
 
   def undeleted_received_messages
-    received_messages.where(:deleted_by_recipient => false).order('id asc')
+    received_messages.where(:deleted_by_recipient => false).order('id desc')
   end
 
   def undeleted_sent_messages
-    sent_messages.where(:deleted_by_author => false).order('id asc')
+    sent_messages.where(:deleted_by_author => false).order('id desc')
   end
 
   def unread_message_count


### PR DESCRIPTION
Instead of sorting them from old to new this reverses the order from
new to old.

Keeping older messages around is useful for archive purposes, but having
new messages at the bottom is kind of awkward IMO: I need to scroll to
the bottom of the page first.

This is also consistent with how other parts of the site work (i.e.
stories, which also have newer things on top).

There could be a setting for this if some people are attached to the old
sorting.

<!--
Issues and PRs are typically reviewed Wednesday and most weekend mornings.
-->
