### PR TITLE
Correct mismatched username case with a redirect

### DIFF
--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -55,4 +55,22 @@ describe 'users controller' do
       expect(response.body).to include("flags")
     end
   end
+
+  describe 'username case mismatch' do
+    it 'redirects to correct-case user page' do
+      user = create(:user)
+
+      get user_path(user.username.upcase)
+
+      expect(response).to redirect_to(user_path(user.username))
+    end
+
+    it 'redirects to correct-case user standing page' do
+      user = create(:user)
+
+      get user_standing_path(user.username.upcase)
+
+      expect(response).to redirect_to(user_standing_path(user.username))
+    end
+  end
 end


### PR DESCRIPTION
<!--
Issues and PRs are typically reviewed Wednesday and most weekend mornings.
-->
Fixes #1005

Continuation of https://github.com/lobsters/lobsters/pull/1007, implementing the redirect so that:
* `/u/uSeRnAmE` redirects to `/u/username`
* `/u/uSeRnAmE/standing` redirects to `/u/username/standing`
