### PR TITLE
apps/views/users: remove the "naughty box" that users can brigade

### DIFF
--- a/app/views/comments/threads.html.erb
+++ b/app/views/comments/threads.html.erb
@@ -1,5 +1,3 @@
-<%= render partial: 'users/flag_warning' if @show_flag_warning && @showing_user == @user %>
-
 <% @threads.each do |thread| %>
 <ol class="comments comments1">
   <% comments_by_parent = thread.group_by(&:parent_comment_id) %>

--- a/app/views/replies/show.html.erb
+++ b/app/views/replies/show.html.erb
@@ -11,8 +11,6 @@
   </div>
 </div>
 
-<%= render partial: 'users/flag_warning' if @show_flag_warning %>
-
 <% if @replies.present? %>
   <ol class="comments comments1">
     <% @replies.each do |reply| %>

--- a/app/views/users/_flag_warning.html.erb
+++ b/app/views/users/_flag_warning.html.erb
@@ -1,9 +1,0 @@
-<div class="flash-error">
-  Your comments have been heavily flagged across several stories in the last <%= @flag_warning_int[:human] %>.
-  Review <%= link_to 'your standing', user_standing_path(@user.username) %> for context on how unusual this is.
-  Reconsider your behavior or <a href="https://xkcd.com/386">take a break</a>.
-  <br><br>
-
-  You could also talk to <%= link_to 'a mod', moderators_path %> about what went wrong, or
-  delete your account from the bottom of your <%= link_to 'settings', settings_path %> if you prefer to leave.
-</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,5 +1,3 @@
-<%= render partial: 'users/flag_warning' if @show_flag_warning && @showing_user == @user %>
-
 <div class="box wide">
   <div class="legend">
     <% if !@showing_user.is_active? %>


### PR DESCRIPTION
As the site code works currently, if a user dislikes another user for
some reason they can go around and flag all of their comments and give
the flagged user the "naughty box"[1] for the next month. This will
leave the flagged user mystified as to what they did wrong which can
make them feel gaslit. This "naughty box" has affected other users in
the past (see [2] for a good example).

This does not disable the code that triggers the logic to display the
"naughty box", it merely disables the box itself. I do not feel
comfortable enough with Ruby and Rails to do more than this.

[1]: https://i.imgur.com/uYV1Yp7.png
[2]: https://lobste.rs/s/zp4ofg/lobster_burntsushi_has_left_site

Signed-off-by: Christine Dodrill <me@christine.website>

<!--
Issues and PRs are typically reviewed Wednesday and most weekend mornings.
-->
