### PR TITLE
Remove CSS references to "flagger" within "voters"

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -401,8 +401,7 @@ li.story div.voters div.score {
 	margin-top: 2px;
 }
 
-div.voters .upvoter,
-div.voters .flagger {
+div.voters .upvoter {
 	border-color: transparent transparent #bbb transparent;
 	border-style: solid;
 	border-width: 6px;
@@ -422,23 +421,6 @@ div.voters .upvoter:hover,
 
 div.voters .upvoter {
 	border-bottom-width: 11px;
-}
-
-div.voters .flagger {
-	border-color: #bbb transparent transparent transparent;
-	border-width: 5px;
-	margin-top: 4px;
-	margin-left: 15px;
-	margin-bottom: -5px;
-	border-top-width: 9px;
-}
-div.voters .flagger:hover,
-.flagged div.voters .flagger {
-	border-top-color: gray;
-}
-
-div.voters .flagger.flagger_stub {
-	border-color: transparent;
 }
 
 li.story {

--- a/app/assets/stylesheets/mobile.css
+++ b/app/assets/stylesheets/mobile.css
@@ -105,8 +105,7 @@
 		margin-left: 35px;
 	}
 
-	div.voters a.upvoter,
-	div.voters a.flagger {
+	div.voters a.upvoter {
 		margin-left: 6px;
 		border-width: 9px;
 	}


### PR DESCRIPTION
Markup matching those selectors appears not to be emitted since downvote arrows were removed.

"voters" is this whole element:
![Screen Shot 2021-09-13 at 11 06 11 PM](https://user-images.githubusercontent.com/602569/133188192-c08d8a0e-88e6-47d9-b985-5ae95453f7f1.png)

"upvoter" is the up arrow. There was once a downvote arrow as well, named "downvoter". It was removed in 9535b05, but its CSS is still here. The term "downvote" appears to have been replaced with "flag" back in 20c1590, so the CSS more recently referred to a "flagger".

This is a side issue discovered while working on #637.