### PR TITLE
Reduce unused CSS properties in flash banners

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1193,17 +1193,14 @@ div.flash-success div {
 div.flash-error {
 	background-color: #fdcfcc;
 	text-shadow: none;
-	border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
 }
 div.flash-success {
 	background-color: #dff0d8;
 	text-shadow: none;
-	border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
 }
 div.flash-notice {
 	background-color: #339bb9;
 	text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
-	border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
 }
 
 div.flash-error h2,

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1161,9 +1161,7 @@ div.flash-success {
 	position: relative;
 	padding: 7px 15px;
 	margin-bottom: 18px;
-	background-color: #eedc94;
 	border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
-	text-shadow: 0 1px 0 rgba(255, 255, 255, 0.5);
 	border-width: 1px;
 	border-style: solid;
 	border-radius: 4px;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1162,10 +1162,6 @@ div.flash-success {
 	padding: 7px 15px;
 	margin-bottom: 18px;
 	background-color: #eedc94;
-	background-repeat: repeat-x;
-	background-image: linear-gradient(top, #fceec1, #eedc94);
-	text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
-	border-color: #eedc94 #eedc94 #e4c652;
 	border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
 	text-shadow: 0 1px 0 rgba(255, 255, 255, 0.5);
 	border-width: 1px;
@@ -1198,26 +1194,17 @@ div.flash-success div {
 }
 div.flash-error {
 	background-color: #fdcfcc;
-	background-repeat: repeat-x;
-	background-image: linear-gradient(top, #ee5f5b, #c43c35);
 	text-shadow: none;
-	border-color: #c43c35 #c43c35 #882a25;
 	border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
 }
 div.flash-success {
 	background-color: #dff0d8;
-	background-repeat: repeat-x;
-	background-image: linear-gradient(top, #62c462, #57a957);
 	text-shadow: none;
-	border-color: #57a957 #57a957 #3d773d;
 	border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
 }
 div.flash-notice {
 	background-color: #339bb9;
-	background-repeat: repeat-x;
-	background-image: linear-gradient(top, #5bc0de, #339bb9);
 	text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
-	border-color: #339bb9 #339bb9 #22697d;
 	border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
 }
 


### PR DESCRIPTION
Flash banners (of green success, red error, and blue notice types) have yellow default coloring that's always overridden, gradients we never see due to syntax errors, and some properties set twice in one class such that their first value is never used. This change reduces the bulk of that CSS while keeping appearance unchanged.

Before:
![before](https://user-images.githubusercontent.com/602569/133322012-bf19fd4e-a3d9-4a20-b2e2-e62f26bc4b97.png)

After:
![after](https://user-images.githubusercontent.com/602569/133322018-5cfd0c43-4f35-43a6-8a36-1a1d0afa2d79.png)

…as captured by Safari Technology Preview web inspector.

This is a side issue discovered while working on #637.