### PR TITLE
Highlight replies and user settings links in top nav

### DIFF
--- a/app/controllers/replies_controller.rb
+++ b/app/controllers/replies_controller.rb
@@ -6,6 +6,8 @@ class RepliesController < ApplicationController
 
   def all
     @heading = @title = "All Your Replies"
+    @cur_url = "/replies"
+
     @replies = ReplyingComment
                  .for_user(@user.id)
                  .offset((@page - 1) * REPLIES_PER_PAGE)

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -5,6 +5,7 @@ class SettingsController < ApplicationController
 
   def index
     @title = "Account Settings"
+    @cur_url = "/settings"
 
     @edit_user = @user.dup
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -48,7 +48,7 @@
           href="/" title="<%= Rails.application.name %> (Current traffic: <%=
           @traffic_intensity.to_i %>%)"></a>
 
-        <% if @cur_url.present? && !header_links.keys.include?(@cur_url) &&
+        <% if @cur_url.present? && !header_links.keys.include?(@cur_url) && !right_header_links.keys.include?(@cur_url) &&
         @heading.present? %>
           <span id="headertitle">
             <a href="<%= @cur_url %>"><%= @heading %></a>


### PR DESCRIPTION
Other top nav links are highlighted when their pages are displayed. These two may have been overlooked.

Replies, before:
![replies-before](https://user-images.githubusercontent.com/602569/133368085-d1a9a35c-1578-44b8-a0d9-e7a0d18d650c.png)

Replies, after:
![replies-after](https://user-images.githubusercontent.com/602569/133368088-737297ea-d694-424d-8de0-f8d97a012291.png)

Settings, after:
![settings-after](https://user-images.githubusercontent.com/602569/133368102-25178eb2-ea1a-4df3-afdf-587bf9e3ad59.png)