### PR TITLE
Use meta tag style on about page meta tag

### DIFF
--- a/app/views/home/about.html.erb
+++ b/app/views/home/about.html.erb
@@ -62,7 +62,7 @@
   </ul>
 
   <p>
-  Creating new tags and retiring old tags is done by the community by submitting, discussing, and voting on <a href="/t/meta" class="tag">meta</a>-tagged requests about them,
+  Creating new tags and retiring old tags is done by the community by submitting, discussing, and voting on <a href="/t/meta" class="tag tag_meta">meta</a>-tagged requests about them,
   and these events are <a href="https://lobste.rs/moderations?utf8=✓&moderator=(All)&what[tags]=tags">logged</a> (since 2018-04).
   To propose a tag, post a <a href="/t/meta">meta</a> thread with the name and description.
   Explain the scope, list existing stories that should have been tagged, make a case for why people would want to specifically filter it out, and justify the increased complexity for submitters and mods.


### PR DESCRIPTION
This tag appears gray normally, but was yellow where specifically included in /about.