### PR TITLE
Dark mode

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -47,10 +47,10 @@
     --color-markdown_help-background: #f4f4f4;
     --color-markdown_help-border: #e0e0e0;
 
-    --color-downvote_why: #555555;
-    --color-downvote_why-background: #ffffff;
-    --color-downvote_why-background-hover: #eeeeee;
-    --color-downvote_why-background-cancel: #eeeeee;
+    --color-flag_why: #555555;
+    --color-flag_why-background: #ffffff;
+    --color-flag_why-background-hover: #eeeeee;
+    --color-flag_why-background-cancel: #eeeeee;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -93,10 +93,10 @@
     --color-markdown_help-border: #777777;
     --color-markdown_help-background: #222222;
 
-    --color-downvote_why: #cccccc;
-    --color-downvote_why-background: #333333;
-    --color-downvote_why-background-hover: #3f3f3f;
-    --color-downvote_why-background-cancel: #222222;
+    --color-flag_why: #cccccc;
+    --color-flag_why-background: #333333;
+    --color-flag_why-background-hover: #3f3f3f;
+    --color-flag_why-background-cancel: #222222;
 }
 }
 
@@ -908,18 +908,18 @@ div.comment_text code {
 	z-index: 15;
 }
 #flag_why a {
-	background-color: var(--color-downvote_why-background);
-	color: var(--color-downvote_why);
+	background-color: var(--color-flag_why-background);
+	color: var(--color-flag_why);
 	border-bottom: 1px solid #ccc;
 	display: block;
 	padding: 3px;
 	font-size: 9pt;
 }
 #flag_why a:hover {
-	background-color: var(--color-downvote_why-background-hover);
+	background-color: var(--color-flag_why-background-hover);
 }
 #flag_why a.cancelreason {
-	background-color: var(--color-downvote_why-background-cancel);
+	background-color: var(--color-flag_why-background-cancel);
 	font-size: 8pt;
 }
 

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -5,201 +5,253 @@
  *= require_tree ./local
 */
 
-
-/* generics */
-
+/* light mode palette */
 :root {
-    --color: #333333;
-    --color-background: #fefefe;
+	--palette-background: 254, 254, 254;
+	--palette-foreground: 0, 0, 0;
+
+	--palette-link: 37, 98, 220;
+	--palette-accent: 172, 19, 13; /* red as in lobste.rs */
+	--palette-accent-background: 172, 19, 13;
+	--palette-negative: 139, 0, 0; /* red as in warning */
+	--palette-affirmative: 0, 128, 0;
+	--palette-author: 96, 129, 189;
+	--palette-target: 255, 252, 215;
+	--palette-shape: 187, 187, 187;
+
+	--palette-light: 255, 255, 255;
+	--palette-shadow: 0, 0, 0;
+
+	--palette-box-background: 255, 255, 255;
+	--palette-box-background-shaded: 238, 238, 238;
+	--palette-box-border: 204, 204, 204;
+	--palette-box-border-focus: 128, 128, 128;
+
+	--palette-button-background: 250, 250, 250;
+	--palette-button-background-shaded: 230, 230, 230;
+
+	--palette-table-header-background: 234, 234, 234;
+	--palette-table-header-border: 202, 202, 202;
+	--palette-table-row-background-even: 248, 248, 248;
+	--palette-table-row-background-odd: 245, 245, 245;
+	--palette-table-row-border: 234, 234, 234;
+
+	--palette-tag-background: 255, 252, 215;
+	--palette-tag-border: 213, 212, 88;
+	--palette-tag-media-background: 221, 235, 249;
+	--palette-tag-media-border: 178, 204, 240;
+	--palette-tag-meta-background: 224, 224, 224;
+	--palette-tag-meta-border: 200, 200, 200;
+
+	--palette-hat-crown-background: 221, 221, 221;
+	--palette-hat-crown-border: 238, 238, 238;
+	--palette-hat-brim: 80, 80, 80;
+
+	--opacity-gradient-lit: 0%;
+	--opacity-gradient-shadowed: calc(1 - 13 / 15);
+}
+
+/* dark mode palette */
+@media (prefers-color-scheme: dark) {
+	:root {
+		--palette-background: 0, 0, 0;
+		--palette-foreground: 255, 255, 255;
+
+		/* dark mode foreground colors are lighter and less saturated in order to work on black */
+		--palette-link: 91, 145, 255;
+		--palette-accent: 207, 54, 49; /* red as in lobste.rs */
+		--palette-accent-background: 253, 78, 72;
+		--palette-negative: 190, 45, 45; /* red as in warning */
+		--palette-affirmative: 42, 180, 42;
+		--palette-author: 97, 122, 173;
+		--palette-target: 27, 24, 11;
+		--palette-shape: 80, 80, 80;
+
+		--palette-light: 255, 255, 255;
+		--palette-shadow: 0, 0, 0;
+
+		--palette-box-background: 8, 8, 8;
+		--palette-box-background-shaded: 20, 20, 20;
+		--palette-box-border: 36, 36, 36;
+		--palette-box-border-focus: 128, 128, 128;
+
+		--palette-button-background: 12, 12, 12;
+		--palette-button-background-shaded: 24, 24, 24;
+
+		--palette-table-header-background: 29, 29, 29;
+		--palette-table-header-border: 55, 55, 55;
+		--palette-table-row-background-even: 15, 15, 15;
+		--palette-table-row-background-odd: 18, 18, 18;
+		--palette-table-row-border: 29, 29, 29;
+
+		--palette-tag-background: 59, 50, 13;
+		--palette-tag-border: 94, 75, 9;
+		--palette-tag-media-background: 21, 41, 61;
+		--palette-tag-media-border: 33, 63, 105;
+		--palette-tag-meta-background: 48, 48, 48;
+		--palette-tag-meta-border: 72, 72, 72;
+
+		--palette-hat-crown-background: 25, 25, 25;
+		--palette-hat-crown-border: 42, 42, 42;
+		--palette-hat-brim: 80, 80, 80;
+
+		--opacity-gradient-lit: calc(1 - 13 / 15);
+		--opacity-gradient-shadowed: 3%;
+	}
+}
+
+html {
+	/* color terms in common between light and dark mode */
+
+	/* a text color is a foreground color blended by some opacity. */
+	--opacity-text: calc(1 - 3 / 15); /* black foreground on white -> #333 */
+	--opacity-text-nudged: 75%; /* -> #404040 */
+	--opacity-text-deemphasized: calc(1 - 5 / 15); /* -> #555 */
+	--opacity-text-withdrawn: calc(1 - 6 / 15); /* -> #666 */
+	--opacity-text-minor: calc(1 - 7 / 15); /* -> #777 */
+	--opacity-text-disabled: 50%; /* -> #808080 */
+	--opacity-text-detail: calc(1 - 8 / 15); /* -> #888 */
+	--opacity-text-footnote: calc(1 - 9 / 15); /* -> #999 */
+	--opacity-text-faint: calc(1 - 10 / 15); /* -> #aaa */
+
+	/* TODO: make theme-specific and opaque */
+	--palette-flash-background-error: 250, 66, 54; /* red */
+	--palette-flash-background-success: 130, 198, 102; /* green */
+	--palette-flash-background-notice: 54, 158, 190; /* blue */
+
+	/* computed colors */
+    --color: rgba(var(--palette-foreground), var(--opacity-text));
+    --color-background: rgb(var(--palette-background));
     --color-selection: HighlightText;
     --color-selection-background: Highlight;
 
-    --color-link: #2562dc;
-    --color-link-visited: #7395d9;
+    --color-link: rgb(var(--palette-link));
+    --color-link-visited: rgba(var(--palette-link), var(--opacity-text-deemphasized));
 
-    --color-form: #555555;
-    --color-form-focus: #303030;
-    --color-form-border: #cccccc;
-    --color-form-border-focus: #888888;
-    --color-form-background: #ffffff;
-	--color-form-placeholder: #aaa;
-    --color-textarea-disabled: #f0f0f0;
+    --color-form: rgba(var(--palette-foreground), var(--opacity-text-deemphasized));
+    --color-form-focus: rgba(var(--palette-foreground), var(--opacity-text));
+    --color-form-border: rgb(var(--palette-box-border));
+    --color-form-border-focus: rgb(var(--palette-box-border-focus));
+    --color-form-background: rgb(var(--palette-box-background));
+	--color-form-placeholder: rgba(var(--palette-foreground), var(--opacity-text-faint));
+    --color-form-disabled-background: rgb(var(--palette-box-background-shaded));
+    --color-form-disabled: rgba(var(--palette-foreground), var(--opacity-text-disabled));
 
-    --color-input-disabled-background: #e9e9e9;
-    --color-input-disabled: gray;
-    --color-input-destructive: darkred;
+    --color-input-destructive: rgb(var(--palette-negative));
 
-    --color-button: #333333;
-    --color-button-border: #cccccc;
-    --color-button-border-bottom: #bbb;
-    --color-button-border-focus: #888;
-    --color-button-hover: #333333;
-    --color-button-background: #fafafa;
-    --color-button-background-hover: #e6e6e6;
+    --color-button: rgba(var(--palette-foreground), var(--opacity-text-deemphasized));
+    --color-button-border: rgb(var(--palette-box-border));
+    --color-button-border-bottom: rgb(var(--palette-shape));
+    --color-button-border-focus: rgb(var(--palette-box-border-focus));
+    --color-button-hover: rgba(var(--palette-foreground), var(--opacity-text-deemphasized));
+    --color-button-background: rgb(var(--palette-button-background));
+    --color-button-background-hover: rgb(var(--palette-button-background-shaded));
 
-	--color-select-focus-border: rgba(160,160,160,.8);
-	--color-select-focus: #303030;
+    --color-tag: rgba(var(--palette-foreground), var(--opacity-text-deemphasized));
+    --color-tag-background: rgb(var(--palette-tag-background));
+    --color-tag-border: rgb(var(--palette-tag-border));
+    --color-tag-media: rgba(var(--palette-foreground), var(--opacity-text-deemphasized));
+    --color-tag-media-background: rgb(var(--palette-tag-media-background));
+    --color-tag-media-border: rgb(var(--palette-tag-media-border));
+    --color-tag_meta-background: rgb(var(--palette-tag-meta-background));
+    --color-tag_meta-border: rgb(var(--palette-tag-meta-border));
 
-    --color-tag: #555555;
-    --color-tag-background: #fffcd7;
-    --color-tag-border: #d5d458;
-    --color-tag-media: #555555;
-    --color-tag-media-background: #ddebf9;
-    --color-tag-media-border: #b2ccf0;
-    --color-tag_meta-background: #eee;
-    --color-tag_meta-border: #c8c8c8;
+	--color-hat-border-bottom: rgb(var(--palette-hat-brim));
+	--color-hat-crown-background: rgb(var(--palette-hat-crown-background));
+	--color-hat-crown-border: rgb(var(--palette-hat-crown-border));
+	--color-hat-link: rgba(var(--palette-foreground), var(--opacity-text-minor));
 
-	--color-hat-border-bottom: #bbb;
-	--color-hat-crown-background: #ddd;
-	--color-hat-crown-border: #eee;
-	--color-hat-link: #777;
+	--color-na: rgba(var(--palette-foreground), var(--opacity-text-disabled));
 
-	--color-na: gray;
+    --color-header-title: rgba(var(--palette-foreground), var(--opacity-text));
+    --color-header-link: rgba(var(--palette-foreground), var(--opacity-text-minor));
+    --color-header-link-cur_url: rgba(var(--palette-foreground), var(--opacity-text));
+	--color-header-link-new_messages: rgb(var(--palette-accent));
 
-    --color-header-title: #333333;
-    --color-header-link: #777777;
-    --color-header-link-cur_url: #333333;
-	--color-header-link-new_messages: #ac130d;
+    --color-markdown_help-label: rgba(var(--palette-foreground), var(--opacity-text-faint));
 
-    --color-markdown_help-background: #f4f4f4;
-    --color-markdown_help-border: #e0e0e0;
-    --color-markdown_help-label: #aaa;
+    --color-flag_why: rgba(var(--palette-foreground), var(--opacity-text-deemphasized));
+    --color-flag_why-background: rgb(var(--palette-box-background));
+    --color-flag_why-background-dimmed: rgb(var(--palette-box-background-shaded));
+	--color-flag_why-border: rgb(var(--palette-box-border));
 
-    --color-flag_why: #555555;
-    --color-flag_why-background: #ffffff;
-    --color-flag_why-background-hover: #eeeeee;
-    --color-flag_why-background-cancel: #eeeeee;
-	--color-flag_why-border: #ccc;
+	--color-footer-link: rgba(var(--palette-foreground), var(--opacity-text-footnote));
 
-	--color-footer-link: #aaa;
+	--color-gravatar-border: rgb(var(--palette-box-background));
+	--color-gravatar-shadow: rgba(var(--palette-shadow), 80%);
 
-	--color-gravatar-border: #fff;
-	--color-gravatar-shadow: rgba(0, 0, 0, 0.8);
+	--color-voters-score: rgba(var(--palette-foreground), var(--opacity-text-faint));
+	--color-voters-upvoter-fill: rgb(var(--palette-shape));
+	--color-voters-upvoter-fill-upvoted: rgb(var(--palette-accent));
 
-	--color-voters-score: #aaa;
-	--color-voters-upvoter-fill: #bbb;
-	--color-voters-upvoter-fill-upvoted: #ac130d;
+	--color-comment-link: rgba(var(--palette-foreground), var(--opacity-text-withdrawn));
+	--color-comment-target: rgb(var(--palette-target));
 
-	--color-comment-link: #666;
-	--color-comment-target: #fffcd7;
+	--color-story-description_present: rgba(var(--palette-foreground), var(--opacity-text-disabled));
 
-	--color-story-description_present: gray;
+	--color-domain: rgba(var(--palette-foreground), var(--opacity-text-detail));
 
-	--color-domain: #888;
+	--color-comment_folder: rgba(var(--palette-foreground), var(--opacity-text-faint));
 
-	--color-comment_folder: #aaa;
+	--color-comment-tree-line-stroke: rgb(var(--palette-shape));
 
-	--color-comment-tree-line-stroke: #bbb;
+	--color-byline: rgba(var(--palette-foreground), var(--opacity-text-detail));
+	--color-byline-new_user: rgb(var(--palette-affirmative));
+	--color-byline-inactive_user: rgba(var(--palette-foreground), var(--opacity-text-disabled));
+	--color-byline-author: rgb(var(--palette-author));
 
-	--color-byline: #888;
-	--color-byline-new_user: green;
-	--color-byline-inactive_user: gray;
-	--color-byline-highlight: #6081bd;
+	--color-saver-saved: rgb(var(--palette-affirmative));
+	--color-story-expired-link: rgba(var(--palette-foreground), var(--opacity-text-disabled));
+	--color-stories-list-story_content: rgba(var(--palette-foreground), var(--opacity-text-minor));
 
-	--color-saver-saved: green;
-	--color-story-expired-link: gray;
-	--color-stories-list-story_content: #777;
+	--color-morelink-link: rgba(var(--palette-foreground), var(--opacity-text-withdrawn));
+	--color-page_link_buttons-item: rgba(var(--palette-foreground), var(--opacity-text-withdrawn));
 
-	--color-morelink-link: #666;
-	--color-page_link_buttons-item-border: #d0d0d0;
-	--color-page_link_buttons-item-background: #f3f3f3;
-	--color-page_link_buttons-item: #666;
+	--color-blockquote: rgba(var(--palette-foreground), var(--opacity-text-disabled));
 
-	--color-blockquote: gray;
+	--color-comment_unread: rgb(var(--palette-accent));
 
-	--color-comment_unread: #ac130d;
+	--color-tree-line-stroke: rgb(var(--palette-shape));
+	--color-user_tree: rgba(var(--palette-foreground), var(--opacity-text-detail));
 
-	--color-tree-line-stroke: #bbb;
-	--color-user_tree: #888;
+	--color-modmodlog-row-border-left: rgb(var(--palette-accent));
 
-	--color-modmodlog-row-border-left: #ac130d;
+	--color-nominal: rgb(var(--palette-accent));
 
-	--color-nominal: #ac130d;
+    --color-table-data-header-background: rgb(var(--palette-table-header-background));
+	--color-table-data-header-border: rgb(var(--palette-table-header-border));
+    --color-table-data-row-background-even: rgb(var(--palette-table-row-background-even));
+    --color-table-data-row-background-odd: rgb(var(--palette-table-row-background-odd));
+    --color-table-data-row-border: rgb(var(--palette-table-row-border));
 
-    --color-table-data-header-background: #eaeaea;
-	--color-table-data-header-border: #cacaca;
-    --color-table-data-row-background-even: #f8f8f8;
-    --color-table-data-row-background-odd: #f5f5f5;
-    --color-table-data-row-border: #eaeaea;
+	--color-box-sublegend: rgba(var(--palette-foreground), var(--opacity-text-disabled));
 
-	--color-box-sublegend: gray;
+	--color-hint: rgba(var(--palette-foreground), var(--opacity-text-disabled));
 
-	--color-hint: gray;
+	--color-flash-border-highlight: rgba(var(--palette-shadow), 10%);
+	--color-flash-border-shadow: rgba(var(--palette-shadow), 25%);
+	--color-flash-box-shadow: rgba(var(--palette-light), 25%);
+	--color-flash-link: rgba(var(--palette-foreground), var(--opacity-text-nudged));
+	--color-flash-error-background: rgba(var(--palette-flash-background-error), 25%);
+	--color-flash-success-background: rgba(var(--palette-flash-background-success), 25%);
+	--color-flash-notice-background: rgba(var(--palette-flash-background-notice), 25%);
+	--color-flash-notice-text-shadow: rgba(var(--palette-shadow), 25%);
 
-	--color-flash-border-highlight: rgba(0, 0, 0, 0.1);
-	--color-flash-border-shadow: rgba(0, 0, 0, 0.25);
-	--color-flash-box-shadow: rgba(255, 255, 255, 0.25);
-	--color-flash-link: #404040;
-	--color-flash-paragraph-link: #ffffff;
-	--color-flash-error-background: #fdcfcc;
-	--color-flash-success-background: #dff0d8;
-	--color-flash-notice-background: #339bb9;
-	--color-flash-notice-text-shadow: rgba(0, 0, 0, 0.25);
+	--color-select2-multi-choices-background: rgb(var(--palette-box-background));
+	--color-select2-multi-choices-border: rgb(var(--palette-box-border));
+	--color-select2-multi-choices-border-active: rgb(var(--palette-box-border-focus));
+	--color-select2-results-item-highlighted-background: rgb(var(--palette-accent-background));
+	--color-select2-results-item-highlighted: rgb(var(--palette-box-background));
+	--color-select2-results-item-em: rgba(var(--palette-foreground), var(--opacity-text-faint));
 
-	--color-select2-multi-choices-border: #ccc;
-	--color-select2-multi-choices-border-active: rgba(160,160,160,.8);
-	--color-select2-single-choice-border: #aaa;
-	--color-select2-results-item-highlighted-background: darkred;
-	--color-select2-results-item-highlighted: #fff;
-	--color-select2-results-item-em: #aaa;
-
-	--color-pushover_button-background: #eee;
-	--color-pushover_button-gradient-top: #fff;
-	--color-pushover_button-gradient-bottom: #dedede;
-	--color-pushover_button-border: #ccc;
-	--color-pushover_button: #333;
-	--color-pushover_button-text-shadow: rgba(255, 255, 255, 0.5);
+	--color-pushover_button-gradient-top: rgba(var(--palette-foreground), var(--opacity-gradient-lit));
+	--color-pushover_button-gradient-bottom: rgba(var(--palette-foreground), var(--opacity-gradient-shadowed));
+	--color-pushover_button-border: rgb(var(--palette-box-border));
+	--color-pushover_button: rgba(var(--palette-foreground), var(--opacity-text-deemphasized));
+	--color-pushover_button-text-shadow: rgba(var(--palette-background), 50%);
 }
 
-@media (prefers-color-scheme: dark) {
-:root {
-    --color: #bbbbbb;
-    --color-background: #333333;
-    --color-selection: #bbbbbb;
-    --color-selection-background: #111111;
-
-    --color-link: #cccccc;
-    --color-link-visited: #888888;
-
-    --color-form: #999999;
-    --color-form-focus: #cccccc;
-    --color-form-border: #777777;
-    --color-form-border-focus: #cccccc;
-    --color-form-background: #444444;
-
-    --color-button: #cccccc;
-    --color-button-border: #777777;
-    --color-button-hover: #cccccc;
-    --color-button-background: #222222;
-    --color-button-background-hover: #2f2f2f;
-
-    --color-table-background-header: #333333;
-    --color-table-background-odd: #444444;
-    --color-table-background-even: #4f4f4f;
-
-    --color-tag: #cccccc;
-    --color-tag-background: #222222;
-    --color-tag-border: #444444;
-    --color-tag-media: #555555;
-    --color-tag-media-background: #ddebf9;
-    --color-tag-media-border: #b2ccf0;
-    --color-tag_meta-background: #eee;
-    --color-tag_meta-border: #c8c8c8;
-
-    --color-header-title: #aaaaaa;
-    --color-header-link: #777777;
-    --color-header-link-cur_url: #aaaaaa;
-	--color-header-link-new_messages: #ac130d;
-
-    --color-markdown_help-border: #777777;
-    --color-markdown_help-background: #222222;
-
-    --color-flag_why: #cccccc;
-    --color-flag_why-background: #333333;
-    --color-flag_why-background-hover: #3f3f3f;
-    --color-flag_why-background-cancel: #222222;
-}
-}
+/* generics */
 
 /* force a vertical scrollbar to avoid page-shifting */
 html {
@@ -266,7 +318,7 @@ a.tag_meta {
 
 span.hat {
 	border-bottom: 6px solid var(--color-hat-border-bottom);
-	border-radius: 4px;
+	border-radius: 0px 0px 4px 4px;
 	padding: 1px 8px;
 	vertical-align: super;
 	white-space: nowrap;
@@ -339,13 +391,8 @@ textarea:focus {
 	outline: 0;
 }
 textarea::placeholder {
-	color: var(--color);
-	opacity: 0.8;
+	color: var(--color-form-placeholder);
 }
-textarea:disabled {
-	background-color: var(--color-form-disabled);
-}
-
 
 input[type="submit"]:focus,
 button:focus {
@@ -400,8 +447,8 @@ select {
 	min-width: 100px;
 }
 select:focus {
-	border-color: var(--color-select-focus-border);
-	color: var(--color-select-focus);
+	border-color: var(--color-form-border-focus);
+	color: var(--color-form-focus);
 	outline: 0;
 }
 select::-moz-focus-inner {
@@ -410,9 +457,10 @@ select::-moz-focus-inner {
 }
 
 input:disabled,
+textarea:disabled,
 button:disabled {
-	background-color: var(--color-input-disabled-background);
-	color: var(--color-input-disabled);
+	background-color: var(--color-form-disabled-background);
+	color: var(--color-form-disabled);
 }
 
 a.button,
@@ -854,10 +902,10 @@ li .byline a.inactive_user,
 }
 span.user_is_author, a.user_is_author,
 li .byline a.user_is_author {
-	color: var(--color-byline-highlight);
+	color: var(--color-byline-author);
 }
 li .byline a.story_has_suggestions {
-	color: var(--color-byline-highlight);
+	color: var(--color-byline-author);
 }
 
 li.story.hidden {
@@ -914,8 +962,8 @@ div.page_link_buttons {
 }
 div.page_link_buttons a,
 div.page_link_buttons span {
-	border: 1px solid var(--color-page_link_buttons-item-border);
-	background-color: var(--color-page_link_buttons-item-background);
+	border: 1px solid var(--color-button-border);
+	background-color: var(--color-button-background);
 	color: var(--color-page_link_buttons-item);
 	padding: 0.25em 0.5em;
 	font-weight: bold;
@@ -1017,10 +1065,10 @@ div.comment_text code {
 	font-size: 9pt;
 }
 #flag_why a:hover {
-	background-color: var(--color-flag_why-background-hover);
+	background-color: var(--color-flag_why-background-dimmed);
 }
 #flag_why a.cancelreason {
-	background-color: var(--color-flag_why-background-cancel);
+	background-color: var(--color-flag_why-background-dimmed);
 	font-size: 8pt;
 }
 
@@ -1037,8 +1085,8 @@ div.comment_text code {
 
 
 div.markdown_help {
-	background-color: var(--color-markdown_help-background);
-	border: 1px solid var(--color-markdown_help-border);
+	background-color: var(--color-form-disabled-background);
+	border: 1px solid var(--color-form-border);
 	padding: 0 1em;
 	margin-top: 0.5em;
 }
@@ -1372,11 +1420,6 @@ div.flash-success a {
 	font-weight: bold;
 	color: var(--color-flash-link);
 }
-div.flash-error p a,
-div.flash-notice p a,
-div.flash-success p a {
-	color: var(--color-flash-paragraph-link);
-}
 div.flash-error p,
 div.flash-notice p,
 div.flash-success p {
@@ -1421,8 +1464,14 @@ div.flash-success h2 {
 
 .select2-container-multi .select2-choices {
 	border-color: var(--color-select2-multi-choices-border);
+	background-color: var(--color-select2-multi-choices-background);
 	background-image: none;
 	padding-top: 2px;
+}
+
+.select2-container .select2-drop {
+	background-color: var(--color-select2-multi-choices-background);
+	border-color: var(--color-select2-multi-choices-border-active);
 }
 
 .select2-container-multi.select2-container-active .select2-choices {
@@ -1435,7 +1484,6 @@ div.flash-success h2 {
 }
 
 .select2-dropdown-open .select2-choice {
-	border: 1px solid var(--color-select2-single-choice-border);
 	border-bottom-color: transparent;
 	box-shadow        : none;
 }
@@ -1447,11 +1495,13 @@ div.flash-success h2 {
 	padding-left: 0.5em;
 }
 
+.select2-container .select2-results .select2-highlighted em {
+	color: var(--color-select2-results-item-highlighted);
+}
 
 /* pushover */
 .pushover_button {
 	box-sizing: border-box;
-	background-color: var(--color-pushover_button-background);
 	background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABmJLR0QAJQCeAPHNVUx7AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH3wEPAh02ee0QVwAAACZpVFh0Q29tbWVudAAAAAAAQ3JlYXRlZCB3aXRoIEdJTVAgb24gYSBNYWOV5F9bAAABqElEQVQ4y62TvUtbURjGf+fek2vQpMF2ED9QkfpR6VLaDoIEF0UKWQRBQ+yQP6GDU0Xw4y/obOgg6dDSJVS61MlBcXFQB6M1BsF+IES9NnrzcRy8xpvrBwH7bOflfc553+d5jsCF9tiRDwgBEaDXLi8B80AiGQ2Yzn7hIo8Cce5HOBkNfLo6aA7ydAVkgLjdez3BrS8rRbBJEmyU+AyBVVDE1i1SJ6psEmHvfOLktj0SjL/2snKQx8wpNg+LBJt0RjoN+j6bqOvN/ZotWAldtYK5gWpmV84YbPUw2ePlb7bI73+Kep+OLFONkGarXcK7l16+7+V57BW8qJMs7Ob5k4VQm4fVXzlyquyGiHRYBcC+WWQxnSP63AAgtn7O0FNJ9xOd0W+nbkF7pbsytXxOQw30N0t2MgX6Wzy8qtMJL5zy81jdsETaIXnjLL7trkLqGl+2svxI5/mwZt1l6ZJmJ6yEGqkYbveQOioQ2yiz7TbMa0DCWRnuMPBXaXzcsJx23YWEZmc7fJkqxdgzg8xZka/bFhVE2hSuKL+nMswko4GJ//KZxEO/8wVmfpjJTWeCTQAAAABJRU5ErkJggg==) 2px 2px no-repeat, linear-gradient(var(--color-pushover_button-gradient-top), var(--color-pushover_button-gradient-bottom));
 	border: 1px solid var(--color-pushover_button-border);
 	border-radius: 3px;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -299,7 +299,7 @@ textarea:focus {
 	outline: 0;
 }
 textarea::placeholder {
-	color: var(--color-fg-33);
+	color: var(--color-fg-60);
 }
 
 input[type="submit"]:focus,
@@ -310,11 +310,11 @@ button:focus {
 
 /* these must be separate */
 ::-webkit-input-placeholder {
-	color: var(--color-fg-33);
+	color: var(--color-fg-50);
 	font-style: italic;
 }
 :-moz-placeholder {
-	color: var(--color-fg-33);
+	color: var(--color-fg-50);
 	font-style: italic;
 }
 

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -51,7 +51,7 @@
 
 	--color-hat-crown-fill: #ddd;
 	--color-hat-crown-stroke: #eee;
-	--color-hat-brim-stroke: #505050;
+	--color-hat-brim-stroke: #bbb;
 
 	--color-flash-bg-error: #fdcfcc;
 	--color-flash-bg-success: #dff0d8;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -63,7 +63,7 @@
 	:root {
 		/* main monochrome */
 		--palette-bg: 0, 0, 0;
-		--palette-fg: 255, 255, 255;
+		--palette-fg: 225, 225, 225;
 		--palette-light: 255, 255, 255;
 		--palette-shadow: 0, 0, 0;
 
@@ -128,8 +128,7 @@ html {
 	--color-bg: rgb(var(--palette-bg));
 	--color-bg-50: rgba(var(--palette-bg), 50%);
 
-	/* c1c1c1 on dark mode. 88% gives d9d9d9, same contrast as light mode. */
-	--color-fg: rgb(var(--palette-fg)); /* 272727, 14.90, 272727, 14.90, primary text */
+	--color-fg: rgb(var(--palette-fg)); /* 272727, 14.90, 272727, 14.90, dadada, 14.99, primary text */
 	--color-fg-75: rgba(var(--palette-fg), 94%); /* 313131, 12.87, 313131, 13.03, links in flash banners */
 	--color-fg-67: rgba(var(--palette-fg), 83%); /* 444444, 9.75, 444444, 9.75, most text in a box */
 	--color-fg-60: rgba(var(--palette-fg), 75%); /* 545454, 7.60, 545454, 7.60, table page links*/

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -78,7 +78,7 @@
 		--palette-fg-accent: 207, 54, 49; /* red as in lobste.rs */
 		--palette-fg-negative: 190, 45, 45; /* red as in warning */
 		--palette-fg-affirmative: 42, 180, 42;
-		--palette-fg-author: 97, 122, 173;
+		--palette-fg-author: 80, 112, 177;
 		--palette-fg-shape: 80, 80, 80;
 
 		/* explicit view colors */
@@ -97,9 +97,9 @@
 		--color-table-row-border: #1d1d1d;
 
 		--color-tag-bg: #3b320d;
-		--color-tag-border: #5e4b09;
+		--color-tag-border: #665501;
 		--color-tag-media-bg: #15293d;
-		--color-tag-media-border: #213f69;
+		--color-tag-media-border: #214669;
 		--color-tag-meta-bg: #2c2c2c;
 		--color-tag-meta-border: #484848;
 

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -8,6 +8,98 @@
 
 /* generics */
 
+:root {
+    --color: #333333;
+    --color-background: #fefefe;
+    --color-selection: HighlightText;
+    --color-selection-background: Highlight;
+
+    --color-link: #2562dc;
+    --color-link-visited: #7395d9;
+
+    --color-form: #555555;
+    --color-form-focus: #303030;
+    --color-form-border: #cccccc;
+    --color-form-border-focus: #888888;
+    --color-form-background: #ffffff;
+
+    --color-button: #333333;
+    --color-button-border: #cccccc;
+    --color-button-hover: #333333;
+    --color-button-background: #fafafa;
+    --color-button-background-hover: #e6e6e6;
+
+    --color-table-background-header: #eaeaea;
+    --color-table-background-odd: #f8f8f8;
+    --color-table-background-even: #f5f5f5;
+
+    --color-tag: #555555;
+    --color-tag-background: #fffcd7;
+    --color-tag-border: #d5d458;
+    --color-tag-media: #555555;
+    --color-tag-media-background: #ddebf9;
+    --color-tag-media-border: #b2ccf0;
+
+    --color-header: #777777;
+    --color-header-lobsters: #333333;
+    --color-header-title: #333333;
+
+    --color-markdown_help-background: #f4f4f4;
+    --color-markdown_help-border: #e0e0e0;
+
+    --color-downvote_why: #555555;
+    --color-downvote_why-background: #ffffff;
+    --color-downvote_why-background-hover: #eeeeee;
+    --color-downvote_why-background-cancel: #eeeeee;
+}
+
+@media (prefers-color-scheme: dark) {
+:root {
+    --color: #bbbbbb;
+    --color-background: #333333;
+    --color-selection: #bbbbbb;
+    --color-selection-background: #111111;
+
+    --color-link: #cccccc;
+    --color-link-visited: #888888;
+
+    --color-form: #999999;
+    --color-form-focus: #cccccc;
+    --color-form-border: #777777;
+    --color-form-border-focus: #cccccc;
+    --color-form-background: #444444;
+
+    --color-button: #cccccc;
+    --color-button-border: #777777;
+    --color-button-hover: #cccccc;
+    --color-button-background: #222222;
+    --color-button-background-hover: #2f2f2f;
+
+    --color-table-background-header: #333333;
+    --color-table-background-odd: #444444;
+    --color-table-background-even: #4f4f4f;
+
+    --color-tag: #cccccc;
+    --color-tag-background: #222222;
+    --color-tag-border: #444444;
+    --color-tag-media: #555555;
+    --color-tag-media-background: #ddebf9;
+    --color-tag-media-border: #b2ccf0;
+
+    --color-header: #777777;
+    --color-header-lobsters: #aaaaaa;
+    --color-header-title: #aaaaaa;
+
+    --color-markdown_help-border: #777777;
+    --color-markdown_help-background: #222222;
+
+    --color-downvote_why: #cccccc;
+    --color-downvote_why-background: #333333;
+    --color-downvote_why-background-hover: #3f3f3f;
+    --color-downvote_why-background-cancel: #222222;
+}
+}
+
 /* force a vertical scrollbar to avoid page-shifting */
 html {
 	overflow-y: scroll;
@@ -16,21 +108,21 @@ html {
 body, textarea, input, button {
 	font-family: "helvetica neue", arial, sans-serif;
 	font-size: 10pt;
-	color: #333;
+	color: var(--color);
 	line-height: 1.45em;
 }
 
 body {
-	background-color: #fefefe;
+	background-color: var(--color-background);
 }
 
 a {
-	color: #2562dc;
+	color: var(--color-link);
 	cursor: pointer;
 }
 
 li.story div.details span.link a:visited {
-	color: #7395d9;
+	color: var(--color-link-visited);
 }
 
 h1 {
@@ -49,10 +141,10 @@ h2 {
 }
 
 a.tag {
-	background-color: #fffcd7;
-	border: 1px solid #d5d458;
+	background-color: var(--color-tag-background);
+	border: 1px solid var(--color-tag-border);
 	border-radius: 5px;
-	color: #555;
+	color: var(--color-tag);
 	font-size: 8pt;
 	margin-left: 0.25em;
 	padding: 0px 0.4em 1px 0.4em;
@@ -61,8 +153,9 @@ a.tag {
 }
 
 a.tag_is_media {
-	background-color: #ddebf9;
-	border-color: #b2ccf0;
+	background-color: var(--color-tag-media-background);
+	border-color: var(--color-tag-media-border);
+    color: var(--color-tag-media);
 }
 
 a.tag_meta {
@@ -112,8 +205,8 @@ input,
 button,
 select,
 textarea {
-	color: #555;
-	background-color: white;
+	color: var(--color-form);
+	background-color: var(--color-form-background);
 	padding: 3px 5px;
 }
 textarea {
@@ -126,7 +219,7 @@ input[type="email"],
 input[type="number"],
 input[type="url"],
 textarea {
-	border: 1px solid #ccc;
+	border: 1px solid var(--color-form-border);
 }
 input:focus, textarea:focus {
 	outline-style: solid;
@@ -140,8 +233,8 @@ select {
 }
 input:focus,
 textarea:focus {
-	border-color: #888;
-	color: #303030;
+	border-color: var(--color-form-border-focus);
+	color: var(--color-form-focus);
 	outline: 0;
 }
 textarea::placeholder {
@@ -175,10 +268,10 @@ input[type="reset"],
 input[type="submit"],
 div.select2-choices,
 a.button {
-	background-color: #fafafa;
+	background-color: var(--color-button-background);
 	border-bottom-color: #bbb;
-	border: 1px solid #ccc;
-	color: #333333;
+	border: 1px solid var(--color-button-border);
+	color: var(--color-button);
 	cursor: pointer;
 	display: inline-block;
 	line-height: 18px;
@@ -196,9 +289,9 @@ button:hover,
 input[type="button"]:hover,
 input[type="reset"]:hover,
 input[type="submit"]:hover {
-	color: #333333;
+	color: var(--color-button-hover);
 	text-decoration: none;
-	background-color: #e6e6e6;
+	background-color: var(--color-button-background-hover);
 }
 
 select {
@@ -232,6 +325,11 @@ input.deletion {
 .totp_code::-webkit-outer-spin-button {
   -webkit-appearance: none;
   margin: 0;
+}
+
+::selection {
+    color: var(--color-selection);
+    background-color: var(--color-selection-background);
 }
 
 
@@ -279,12 +377,12 @@ div#inside {
 	padding-right: 0.75em;
 }
 #headertitle a {
-	color: #333;
+	color: var(--color-header-title);
 	text-decoration: none;
 }
 
 .headerlinks a {
-	color: #777;
+	color: var(--color-header);
 	text-decoration: none;
 	padding-right: 0.75em;
 }
@@ -300,7 +398,7 @@ div#inside {
 }
 
 #header a.cur_url {
-	color: #333;
+	color: var(--color-header-lobsters);
 }
 
 #header a.new_messages {
@@ -810,18 +908,18 @@ div.comment_text code {
 	z-index: 15;
 }
 #flag_why a {
-	background-color: white;
-	color: #555;
+	background-color: var(--color-downvote_why-background);
+	color: var(--color-downvote_why);
 	border-bottom: 1px solid #ccc;
 	display: block;
 	padding: 3px;
 	font-size: 9pt;
 }
 #flag_why a:hover {
-	background-color: #eee;
+	background-color: var(--color-downvote_why-background-hover);
 }
 #flag_why a.cancelreason {
-	background-color: #eee;
+	background-color: var(--color-downvote_why-background-cancel);
 	font-size: 8pt;
 }
 
@@ -838,8 +936,8 @@ div.comment_text code {
 
 
 div.markdown_help {
-	background-color: #f4f4f4;
-	border: 1px solid #e0e0e0;
+	background-color: var(--color-markdown_help-background);
+	border: 1px solid var(--color-markdown_help-border);
 	padding: 0 1em;
 	margin-top: 0.5em;
 }
@@ -1001,7 +1099,7 @@ td.warned div, td.unwarned div {
 /* data tables */
 
 table.data th {
-	background-color: #eaeaea;
+	background-color: var(--color-table-background-header);
 	border-bottom: 1px solid #cacaca;
 	border-top: 1px solid #cacaca;
 	text-align: left;
@@ -1026,11 +1124,11 @@ table.data tr.bold td {
 }
 
 table.data.zebra tr:nth-child(even) td {
-	background-color: #f8f8f8;
+	background-color: var(--color-table-background-odd);
 	border-bottom: 1px solid #eaeaea;
 }
 table.data.zebra tr:nth-child(odd) td {
-	background-color: #f5f5f5;
+	background-color: var(--color-table-background-even);
 	border-bottom: 1px solid #eaeaea;
 }
 table.data tr.nobottom td {

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -327,7 +327,7 @@ a.button {
 	background-color: var(--color-button-bg);
 	border-bottom-color: var(--color-fg-shape);
 	border: 1px solid var(--color-box-border);
-	color: var(--color-fg-67);
+	color: var(--color-fg);
 	cursor: pointer;
 	display: inline-block;
 	line-height: 18px;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -103,9 +103,9 @@
 		--color-tag-meta-bg: #2c2c2c;
 		--color-tag-meta-border: #484848;
 
-		--color-hat-crown-fill: #191919;
-		--color-hat-crown-stroke: #2a2a2a;
-		--color-hat-brim-stroke: #505050;
+		--color-hat-crown-fill: #333;
+		--color-hat-crown-stroke: #181818;
+		--color-hat-brim-stroke: #222;
 
 		--color-flash-bg-error: #451714;
 		--color-flash-bg-success: #273820;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -5,250 +5,158 @@
  *= require_tree ./local
 */
 
-/* light mode palette */
+/* light mode */
 :root {
-	--palette-background: 254, 254, 254;
-	--palette-foreground: 0, 0, 0;
-
-	--palette-link: 37, 98, 220;
-	--palette-accent: 172, 19, 13; /* red as in lobste.rs */
-	--palette-accent-background: 172, 19, 13;
-	--palette-negative: 139, 0, 0; /* red as in warning */
-	--palette-affirmative: 0, 128, 0;
-	--palette-author: 96, 129, 189;
-	--palette-target: 255, 252, 215;
-	--palette-shape: 187, 187, 187;
-
+	/* main monochrome */
+	--palette-bg: 254, 254, 254;
+	--palette-fg: 0, 0, 0;
 	--palette-light: 255, 255, 255;
 	--palette-shadow: 0, 0, 0;
 
-	--palette-box-background: 255, 255, 255;
-	--palette-box-background-shaded: 238, 238, 238;
-	--palette-box-border: 204, 204, 204;
-	--palette-box-border-focus: 128, 128, 128;
-
-	--palette-button-background: 250, 250, 250;
-	--palette-button-background-shaded: 230, 230, 230;
-
-	--palette-table-header-background: 234, 234, 234;
-	--palette-table-header-border: 202, 202, 202;
-	--palette-table-row-background-even: 248, 248, 248;
-	--palette-table-row-background-odd: 245, 245, 245;
-	--palette-table-row-border: 234, 234, 234;
-
-	--palette-tag-background: 255, 252, 215;
-	--palette-tag-border: 213, 212, 88;
-	--palette-tag-media-background: 221, 235, 249;
-	--palette-tag-media-border: 178, 204, 240;
-	--palette-tag-meta-background: 224, 224, 224;
-	--palette-tag-meta-border: 200, 200, 200;
-
-	--palette-hat-crown-background: 221, 221, 221;
-	--palette-hat-crown-border: 238, 238, 238;
-	--palette-hat-brim: 80, 80, 80;
-
 	--opacity-gradient-lit: 0%;
-	--opacity-gradient-shadowed: calc(1 - 13 / 15);
+	--opacity-gradient-shadowed: 13%;
+
+	/* colored backgrounds and foregrounds */
+	--palette-bg-accent: 172, 19, 13; /* behind light text */
+	--palette-bg-target: 255, 252, 215;
+
+	--palette-fg-link: 37, 98, 220;
+	--palette-fg-accent: 172, 19, 13; /* red as in lobste.rs */
+	--palette-fg-negative: 139, 0, 0; /* red as in warning */
+	--palette-fg-affirmative: 0, 128, 0;
+	--palette-fg-author: 96, 129, 189;
+	--palette-fg-shape: 187, 187, 187;
+
+	/* explicit view colors */
+	--color-box-bg: #fff;
+	--color-box-bg-shaded: #eee;
+	--color-box-border: #ccc;
+	--color-box-border-focus: #808080;
+
+	--color-button-bg: #fafafa;
+	--color-button-bg-shaded: #e6e6e6;
+
+	--color-table-header-bg: #eaeaea;
+	--color-table-header-border: #cacaca;
+	--color-table-row-bg-even: #f8f8f8;
+	--color-table-row-bg-odd: #f5f5f5;
+	--color-table-row-border: #eaeaea;
+
+	--color-tag-bg: #fffcd7;
+	--color-tag-border: #d5d458;
+	--color-tag-media-bg: #ddebf9;
+	--color-tag-media-border: #b2ccf0;
+	--color-tag-meta-bg: #e0e0e0;
+	--color-tag-meta-border: #c8c8c8;
+
+	--color-hat-crown-fill: #ddd;
+	--color-hat-crown-stroke: #eee;
+	--color-hat-brim-stroke: #505050;
+
+	--color-flash-bg-error: #fdcfcc;
+	--color-flash-bg-success: #dff0d8;
+	--color-flash-bg-notice: #cce6ee;
 }
 
-/* dark mode palette */
+/* dark mode */
 @media (prefers-color-scheme: dark) {
 	:root {
-		--palette-background: 0, 0, 0;
-		--palette-foreground: 255, 255, 255;
-
-		/* dark mode foreground colors are lighter and less saturated in order to work on black */
-		--palette-link: 91, 145, 255;
-		--palette-accent: 207, 54, 49; /* red as in lobste.rs */
-		--palette-accent-background: 253, 78, 72;
-		--palette-negative: 190, 45, 45; /* red as in warning */
-		--palette-affirmative: 42, 180, 42;
-		--palette-author: 97, 122, 173;
-		--palette-target: 27, 24, 11;
-		--palette-shape: 80, 80, 80;
-
+		/* main monochrome */
+		--palette-bg: 0, 0, 0;
+		--palette-fg: 255, 255, 255;
 		--palette-light: 255, 255, 255;
 		--palette-shadow: 0, 0, 0;
 
-		--palette-box-background: 8, 8, 8;
-		--palette-box-background-shaded: 20, 20, 20;
-		--palette-box-border: 36, 36, 36;
-		--palette-box-border-focus: 128, 128, 128;
-
-		--palette-button-background: 12, 12, 12;
-		--palette-button-background-shaded: 24, 24, 24;
-
-		--palette-table-header-background: 29, 29, 29;
-		--palette-table-header-border: 55, 55, 55;
-		--palette-table-row-background-even: 15, 15, 15;
-		--palette-table-row-background-odd: 18, 18, 18;
-		--palette-table-row-border: 29, 29, 29;
-
-		--palette-tag-background: 59, 50, 13;
-		--palette-tag-border: 94, 75, 9;
-		--palette-tag-media-background: 21, 41, 61;
-		--palette-tag-media-border: 33, 63, 105;
-		--palette-tag-meta-background: 48, 48, 48;
-		--palette-tag-meta-border: 72, 72, 72;
-
-		--palette-hat-crown-background: 25, 25, 25;
-		--palette-hat-crown-border: 42, 42, 42;
-		--palette-hat-brim: 80, 80, 80;
-
-		--opacity-gradient-lit: calc(1 - 13 / 15);
+		--opacity-gradient-lit: 13%;
 		--opacity-gradient-shadowed: 3%;
+
+		/* colored backgrounds and foregrounds */
+		--palette-bg-accent: 253, 78, 72; /* behind dark text */
+		--palette-bg-target: 27, 24, 11;
+
+		--palette-fg-link: 91, 145, 255;
+		--palette-fg-accent: 207, 54, 49; /* red as in lobste.rs */
+		--palette-fg-negative: 190, 45, 45; /* red as in warning */
+		--palette-fg-affirmative: 42, 180, 42;
+		--palette-fg-author: 97, 122, 173;
+		--palette-fg-shape: 80, 80, 80;
+
+		/* explicit view colors */
+		--color-box-bg: #080808;
+		--color-box-bg-shaded: #141414;
+		--color-box-border: #242424;
+		--color-box-border-focus: #808080;
+
+		--color-button-bg: #0c0c0c;
+		--color-button-bg-shaded: #181818;
+
+		--color-table-header-bg: #1d1d1d;
+		--color-table-header-border: #373737;
+		--color-table-row-bg-even: #0f0f0f;
+		--color-table-row-bg-odd: #121212;
+		--color-table-row-border: #1d1d1d;
+
+		--color-tag-bg: #3b320d;
+		--color-tag-border: #5e4b09;
+		--color-tag-media-bg: #15293d;
+		--color-tag-media-border: #213f69;
+		--color-tag-meta-bg: #2c2c2c;
+		--color-tag-meta-border: #484848;
+
+		--color-hat-crown-fill: #191919;
+		--color-hat-crown-stroke: #2a2a2a;
+		--color-hat-brim-stroke: #505050;
+
+		--color-flash-bg-error: #451714;
+		--color-flash-bg-success: #273820;
+		--color-flash-bg-notice: #142e36;
 	}
 }
 
 html {
-	/* color terms in common between light and dark mode */
+	/* environment colors */
+	--color-selection-fg: HighlightText;
+	--color-selection-bg: Highlight;
 
-	/* a text color is a foreground color blended by some opacity. */
-	--opacity-text: calc(1 - 3 / 15); /* black foreground on white -> #333 */
-	--opacity-text-nudged: 75%; /* -> #404040 */
-	--opacity-text-deemphasized: calc(1 - 5 / 15); /* -> #555 */
-	--opacity-text-withdrawn: calc(1 - 6 / 15); /* -> #666 */
-	--opacity-text-minor: calc(1 - 7 / 15); /* -> #777 */
-	--opacity-text-disabled: 50%; /* -> #808080 */
-	--opacity-text-detail: calc(1 - 8 / 15); /* -> #888 */
-	--opacity-text-footnote: calc(1 - 9 / 15); /* -> #999 */
-	--opacity-text-faint: calc(1 - 10 / 15); /* -> #aaa */
+	/* derived colors */
 
-	/* TODO: make theme-specific and opaque */
-	--palette-flash-background-error: 250, 66, 54; /* red */
-	--palette-flash-background-success: 130, 198, 102; /* green */
-	--palette-flash-background-notice: 54, 158, 190; /* blue */
+	/* These colors are derived from the light or dark palette. This
+	   opacity-mixing technique is usually inappropriate for backgrounds and
+	   borders, so other colors are given explicitly per display mode. */
 
-	/* computed colors */
-    --color: rgba(var(--palette-foreground), var(--opacity-text));
-    --color-background: rgb(var(--palette-background));
-    --color-selection: HighlightText;
-    --color-selection-background: Highlight;
+	/* main monochrome and variants */
+	--color-bg: rgb(var(--palette-bg));
+	--color-bg-50: rgba(var(--palette-bg), 50%);
 
-    --color-link: rgb(var(--palette-link));
-    --color-link-visited: rgba(var(--palette-link), var(--opacity-text-deemphasized));
+	--color-fg: rgba(var(--palette-fg), 80%); /* primary text */
+	--color-fg-75: rgba(var(--palette-fg), 75%); /* links in flash banners */
+	--color-fg-67: rgba(var(--palette-fg), 67%); /* most text in a box */
+	--color-fg-60: rgba(var(--palette-fg), 60%); /* table page links */
+	--color-fg-53: rgba(var(--palette-fg), 53%); /* uncolored text links */
+	--color-fg-50: rgba(var(--palette-fg), 50%); /* disabled, expired */
+	--color-fg-47: rgba(var(--palette-fg), 47%); /* byline */
+	--color-fg-40: rgba(var(--palette-fg), 40%); /* footer link */
+	--color-fg-33: rgba(var(--palette-fg), 33%); /* faint text */
+	--color-fg-gradient-lit: rgba(var(--palette-fg), var(--opacity-gradient-lit));
+	--color-fg-gradient-shadowed: rgba(var(--palette-fg), var(--opacity-gradient-shadowed));
 
-    --color-form: rgba(var(--palette-foreground), var(--opacity-text-deemphasized));
-    --color-form-focus: rgba(var(--palette-foreground), var(--opacity-text));
-    --color-form-border: rgb(var(--palette-box-border));
-    --color-form-border-focus: rgb(var(--palette-box-border-focus));
-    --color-form-background: rgb(var(--palette-box-background));
-	--color-form-placeholder: rgba(var(--palette-foreground), var(--opacity-text-faint));
-    --color-form-disabled-background: rgb(var(--palette-box-background-shaded));
-    --color-form-disabled: rgba(var(--palette-foreground), var(--opacity-text-disabled));
+	--color-light-25: rgba(var(--palette-light), 25%);
 
-    --color-input-destructive: rgb(var(--palette-negative));
+	--color-shadow-80: rgba(var(--palette-shadow), 80%);
+	--color-shadow-25: rgba(var(--palette-shadow), 25%);
+	--color-shadow-10: rgba(var(--palette-shadow), 10%);
 
-    --color-button: rgba(var(--palette-foreground), var(--opacity-text-deemphasized));
-    --color-button-border: rgb(var(--palette-box-border));
-    --color-button-border-bottom: rgb(var(--palette-shape));
-    --color-button-border-focus: rgb(var(--palette-box-border-focus));
-    --color-button-hover: rgba(var(--palette-foreground), var(--opacity-text-deemphasized));
-    --color-button-background: rgb(var(--palette-button-background));
-    --color-button-background-hover: rgb(var(--palette-button-background-shaded));
+	/* colored backgrounds and foregrounds and variants */
+	--color-bg-accent: rgb(var(--palette-bg-accent));
+	--color-bg-target: rgb(var(--palette-bg-target));
 
-    --color-tag: rgba(var(--palette-foreground), var(--opacity-text-deemphasized));
-    --color-tag-background: rgb(var(--palette-tag-background));
-    --color-tag-border: rgb(var(--palette-tag-border));
-    --color-tag-media: rgba(var(--palette-foreground), var(--opacity-text-deemphasized));
-    --color-tag-media-background: rgb(var(--palette-tag-media-background));
-    --color-tag-media-border: rgb(var(--palette-tag-media-border));
-    --color-tag_meta-background: rgb(var(--palette-tag-meta-background));
-    --color-tag_meta-border: rgb(var(--palette-tag-meta-border));
-
-	--color-hat-border-bottom: rgb(var(--palette-hat-brim));
-	--color-hat-crown-background: rgb(var(--palette-hat-crown-background));
-	--color-hat-crown-border: rgb(var(--palette-hat-crown-border));
-	--color-hat-link: rgba(var(--palette-foreground), var(--opacity-text-minor));
-
-	--color-na: rgba(var(--palette-foreground), var(--opacity-text-disabled));
-
-    --color-header-title: rgba(var(--palette-foreground), var(--opacity-text));
-    --color-header-link: rgba(var(--palette-foreground), var(--opacity-text-minor));
-    --color-header-link-cur_url: rgba(var(--palette-foreground), var(--opacity-text));
-	--color-header-link-new_messages: rgb(var(--palette-accent));
-
-    --color-markdown_help-label: rgba(var(--palette-foreground), var(--opacity-text-faint));
-
-    --color-flag_why: rgba(var(--palette-foreground), var(--opacity-text-deemphasized));
-    --color-flag_why-background: rgb(var(--palette-box-background));
-    --color-flag_why-background-dimmed: rgb(var(--palette-box-background-shaded));
-	--color-flag_why-border: rgb(var(--palette-box-border));
-
-	--color-footer-link: rgba(var(--palette-foreground), var(--opacity-text-footnote));
-
-	--color-gravatar-border: rgb(var(--palette-box-background));
-	--color-gravatar-shadow: rgba(var(--palette-shadow), 80%);
-
-	--color-voters-score: rgba(var(--palette-foreground), var(--opacity-text-faint));
-	--color-voters-upvoter-fill: rgb(var(--palette-shape));
-	--color-voters-upvoter-fill-upvoted: rgb(var(--palette-accent));
-
-	--color-comment-link: rgba(var(--palette-foreground), var(--opacity-text-withdrawn));
-	--color-comment-target: rgb(var(--palette-target));
-
-	--color-story-description_present: rgba(var(--palette-foreground), var(--opacity-text-disabled));
-
-	--color-domain: rgba(var(--palette-foreground), var(--opacity-text-detail));
-
-	--color-comment_folder: rgba(var(--palette-foreground), var(--opacity-text-faint));
-
-	--color-comment-tree-line-stroke: rgb(var(--palette-shape));
-
-	--color-byline: rgba(var(--palette-foreground), var(--opacity-text-detail));
-	--color-byline-new_user: rgb(var(--palette-affirmative));
-	--color-byline-inactive_user: rgba(var(--palette-foreground), var(--opacity-text-disabled));
-	--color-byline-author: rgb(var(--palette-author));
-
-	--color-saver-saved: rgb(var(--palette-affirmative));
-	--color-story-expired-link: rgba(var(--palette-foreground), var(--opacity-text-disabled));
-	--color-stories-list-story_content: rgba(var(--palette-foreground), var(--opacity-text-minor));
-
-	--color-morelink-link: rgba(var(--palette-foreground), var(--opacity-text-withdrawn));
-	--color-page_link_buttons-item: rgba(var(--palette-foreground), var(--opacity-text-withdrawn));
-
-	--color-blockquote: rgba(var(--palette-foreground), var(--opacity-text-disabled));
-
-	--color-comment_unread: rgb(var(--palette-accent));
-
-	--color-tree-line-stroke: rgb(var(--palette-shape));
-	--color-user_tree: rgba(var(--palette-foreground), var(--opacity-text-detail));
-
-	--color-modmodlog-row-border-left: rgb(var(--palette-accent));
-
-	--color-nominal: rgb(var(--palette-accent));
-
-    --color-table-data-header-background: rgb(var(--palette-table-header-background));
-	--color-table-data-header-border: rgb(var(--palette-table-header-border));
-    --color-table-data-row-background-even: rgb(var(--palette-table-row-background-even));
-    --color-table-data-row-background-odd: rgb(var(--palette-table-row-background-odd));
-    --color-table-data-row-border: rgb(var(--palette-table-row-border));
-
-	--color-box-sublegend: rgba(var(--palette-foreground), var(--opacity-text-disabled));
-
-	--color-hint: rgba(var(--palette-foreground), var(--opacity-text-disabled));
-
-	--color-flash-border-highlight: rgba(var(--palette-shadow), 10%);
-	--color-flash-border-shadow: rgba(var(--palette-shadow), 25%);
-	--color-flash-box-shadow: rgba(var(--palette-light), 25%);
-	--color-flash-link: rgba(var(--palette-foreground), var(--opacity-text-nudged));
-	--color-flash-error-background: rgba(var(--palette-flash-background-error), 25%);
-	--color-flash-success-background: rgba(var(--palette-flash-background-success), 25%);
-	--color-flash-notice-background: rgba(var(--palette-flash-background-notice), 25%);
-	--color-flash-notice-text-shadow: rgba(var(--palette-shadow), 25%);
-
-	--color-select2-multi-choices-background: rgb(var(--palette-box-background));
-	--color-select2-multi-choices-border: rgb(var(--palette-box-border));
-	--color-select2-multi-choices-border-active: rgb(var(--palette-box-border-focus));
-	--color-select2-results-item-highlighted-background: rgb(var(--palette-accent-background));
-	--color-select2-results-item-highlighted: rgb(var(--palette-box-background));
-	--color-select2-results-item-em: rgba(var(--palette-foreground), var(--opacity-text-faint));
-
-	--color-pushover_button-gradient-top: rgba(var(--palette-foreground), var(--opacity-gradient-lit));
-	--color-pushover_button-gradient-bottom: rgba(var(--palette-foreground), var(--opacity-gradient-shadowed));
-	--color-pushover_button-border: rgb(var(--palette-box-border));
-	--color-pushover_button: rgba(var(--palette-foreground), var(--opacity-text-deemphasized));
-	--color-pushover_button-text-shadow: rgba(var(--palette-background), 50%);
+	--color-fg-link: rgb(var(--palette-fg-link));
+	--color-fg-link-visited: rgba(var(--palette-fg-link), 67%);
+	--color-fg-accent: rgb(var(--palette-fg-accent));
+	--color-fg-negative: rgb(var(--palette-fg-negative));
+	--color-fg-affirmative: rgb(var(--palette-fg-affirmative));
+	--color-fg-author: rgb(var(--palette-fg-author));
+	--color-fg-shape: rgb(var(--palette-fg-shape));
 }
 
 /* generics */
@@ -261,21 +169,21 @@ html {
 body, textarea, input, button {
 	font-family: "helvetica neue", arial, sans-serif;
 	font-size: 10pt;
-	color: var(--color);
+	color: var(--color-fg);
 	line-height: 1.45em;
 }
 
 body {
-	background-color: var(--color-background);
+	background-color: var(--color-bg);
 }
 
 a {
-	color: var(--color-link);
+	color: var(--color-fg-link);
 	cursor: pointer;
 }
 
 li.story div.details span.link a:visited {
-	color: var(--color-link-visited);
+	color: var(--color-fg-link-visited);
 }
 
 h1 {
@@ -294,10 +202,10 @@ h2 {
 }
 
 a.tag {
-	background-color: var(--color-tag-background);
+	background-color: var(--color-tag-bg);
 	border: 1px solid var(--color-tag-border);
 	border-radius: 5px;
-	color: var(--color-tag);
+	color: var(--color-fg-67);
 	font-size: 8pt;
 	margin-left: 0.25em;
 	padding: 0px 0.4em 1px 0.4em;
@@ -306,26 +214,26 @@ a.tag {
 }
 
 a.tag_is_media {
-	background-color: var(--color-tag-media-background);
+	background-color: var(--color-tag-media-bg);
 	border-color: var(--color-tag-media-border);
-    color: var(--color-tag-media);
+	color: var(--color-fg-67);
 }
 
 a.tag_meta {
-	background-color: var(--color-tag_meta-background);
-	border-color: var(--color-tag_meta-border);
+	background-color: var(--color-tag-meta-bg);
+	border-color: var(--color-tag-meta-border);
 }
 
 span.hat {
-	border-bottom: 6px solid var(--color-hat-border-bottom);
+	border-bottom: 6px solid var(--color-hat-brim-stroke);
 	border-radius: 0px 0px 4px 4px;
 	padding: 1px 8px;
 	vertical-align: super;
 	white-space: nowrap;
 }
 span.hat span.crown {
-	background-color: var(--color-hat-crown-background);
-	border: 1px solid var(--color-hat-crown-border);
+	background-color: var(--color-hat-crown-fill);
+	border: 1px solid var(--color-hat-crown-stroke);
 	border-bottom: 0;
 	border-radius: 5px 5px 0px 0px;
 	font-size: 8pt;
@@ -335,12 +243,12 @@ span.hat span.crown {
 }
 
 span.hat span.crown, span.hat a {
-	color: var(--color-hat-link);
+	color: var(--color-fg-53);
 	text-decoration: none;
 }
 
 span.na {
-	color: var(--color-na);
+	color: var(--color-fg-50);
 	font-style: italic;
 }
 
@@ -358,8 +266,8 @@ input,
 button,
 select,
 textarea {
-	color: var(--color-form);
-	background-color: var(--color-form-background);
+	color: var(--color-fg-67);
+	background-color: var(--color-box-bg);
 	padding: 3px 5px;
 }
 textarea {
@@ -372,7 +280,7 @@ input[type="email"],
 input[type="number"],
 input[type="url"],
 textarea {
-	border: 1px solid var(--color-form-border);
+	border: 1px solid var(--color-box-border);
 }
 input:focus, textarea:focus {
 	outline-style: solid;
@@ -382,31 +290,31 @@ input[type="checkbox"] {
 	margin-top: 0.5em;
 }
 select {
-	border: 1px solid var(--color-form-border);
+	border: 1px solid var(--color-box-border);
 }
 input:focus,
 textarea:focus {
-	border-color: var(--color-form-border-focus);
-	color: var(--color-form-focus);
+	border-color: var(--color-box-border-focus);
+	color: var(--color-fg);
 	outline: 0;
 }
 textarea::placeholder {
-	color: var(--color-form-placeholder);
+	color: var(--color-fg-33);
 }
 
 input[type="submit"]:focus,
 button:focus {
-	border-color: var(--color-button-border-focus);
-	outline: 1px solid var(--color-button-border-focus);
+	border-color: var(--color-box-border-focus);
+	outline: 1px solid var(--color-box-border-focus);
 }
 
 /* these must be separate */
 ::-webkit-input-placeholder {
-	color: var(--color-form-placeholder);
+	color: var(--color-fg-33);
 	font-style: italic;
 }
 :-moz-placeholder {
-	color: var(--color-form-placeholder);
+	color: var(--color-fg-33);
 	font-style: italic;
 }
 
@@ -416,10 +324,10 @@ input[type="reset"],
 input[type="submit"],
 div.select2-choices,
 a.button {
-	background-color: var(--color-button-background);
-	border-bottom-color: var(--color-button-border-bottom);
-	border: 1px solid var(--color-button-border);
-	color: var(--color-button);
+	background-color: var(--color-button-bg);
+	border-bottom-color: var(--color-fg-shape);
+	border: 1px solid var(--color-box-border);
+	color: var(--color-fg-67);
 	cursor: pointer;
 	display: inline-block;
 	line-height: 18px;
@@ -437,9 +345,9 @@ button:hover,
 input[type="button"]:hover,
 input[type="reset"]:hover,
 input[type="submit"]:hover {
-	color: var(--color-button-hover);
+	color: var(--color-fg-67);
 	text-decoration: none;
-	background-color: var(--color-button-background-hover);
+	background-color: var(--color-button-bg-shaded);
 }
 
 select {
@@ -447,8 +355,8 @@ select {
 	min-width: 100px;
 }
 select:focus {
-	border-color: var(--color-form-border-focus);
-	color: var(--color-form-focus);
+	border-color: var(--color-box-border-focus);
+	color: var(--color-fg);
 	outline: 0;
 }
 select::-moz-focus-inner {
@@ -459,15 +367,15 @@ select::-moz-focus-inner {
 input:disabled,
 textarea:disabled,
 button:disabled {
-	background-color: var(--color-form-disabled-background);
-	color: var(--color-form-disabled);
+	background-color: var(--color-box-bg-shaded);
+	color: var(--color-fg-50);
 }
 
 a.button,
 button.deletion,
 input.deletion {
-  color: var(--color-input-destructive);
-  border: 1px solid var(--color-input-destructive);
+  color: var(--color-fg-negative);
+  border: 1px solid var(--color-fg-negative);
 }
 
 .totp_code::-webkit-inner-spin-button,
@@ -477,8 +385,8 @@ input.deletion {
 }
 
 ::selection {
-    color: var(--color-selection);
-    background-color: var(--color-selection-background);
+	color: var(--color-selection-fg);
+	background-color: var(--color-selection-bg);
 }
 
 
@@ -526,12 +434,12 @@ div#inside {
 	padding-right: 0.75em;
 }
 #headertitle a {
-	color: var(--color-header-title);
+	color: var(--color-fg);
 	text-decoration: none;
 }
 
 .headerlinks a {
-	color: var(--color-header-link);
+	color: var(--color-fg-53);
 	text-decoration: none;
 	padding-right: 0.75em;
 }
@@ -547,11 +455,11 @@ div#inside {
 }
 
 #header a.cur_url {
-	color: var(--color-header-link-cur_url);
+	color: var(--color-fg);
 }
 
 #header a.new_messages {
-	color: var(--color-header-link-new_messages);
+	color: var(--color-fg-accent);
 }
 
 div#leader {
@@ -567,7 +475,7 @@ div#footer {
 	padding-right: 10px;
 }
 div#footer a {
-	color: var(--color-footer-link);
+	color: var(--color-fg-40);
 	text-decoration: none;
 	padding-left: 0.75em;
 }
@@ -575,9 +483,9 @@ div#footer a {
 
 /* other specifics */
 div#gravatar {
-	border: 2px solid var(--color-gravatar-border);
+	border: 2px solid var(--color-box-bg);
 	border-radius: 100% 100%;
-	box-shadow: 0 1px 4px var(--color-gravatar-shadow);
+	box-shadow: 0 1px 4px var(--color-shadow-80);
 	float: right;
 	height: 100px;
 	width: 100px;
@@ -636,7 +544,7 @@ div.voters {
 }
 
 div.voters div.score {
-	color: var(--color-voters-score);
+	color: var(--color-fg-33);
 	font-size: 9pt;
 	margin-top: 1px;
 	margin-bottom: -3px;
@@ -650,7 +558,7 @@ li.story div.voters div.score {
 
 div.voters .upvoter,
 div.voters .flagger {
-	border-color: transparent transparent var(--color-voters-upvoter-fill) transparent;
+	border-color: transparent transparent var(--color-fg-shape) transparent;
 	border-style: solid;
 	border-width: 6px;
 	text-decoration: none;
@@ -664,7 +572,7 @@ div.voters .flagger {
 
 div.voters .upvoter:hover,
 .upvoted div.voters .upvoter {
-	border-bottom-color: var(--color-voters-upvoter-fill-upvoted);
+	border-bottom-color: var(--color-fg-accent);
 }
 
 div.voters .upvoter {
@@ -705,7 +613,7 @@ ol.stories li.story div.story_liner {
 }
 
 .comment a {
-	color: var(--color-comment-link);
+	color: var(--color-fg-60);
 }
 
 ol.stories li:first-child div.story_liner {
@@ -730,7 +638,7 @@ li div.details {
 }
 
 .comment:target, li:target, p:target {
-	background-color: var(--color-comment-target);
+	background-color: var(--color-bg-target);
 	border-radius: 8px;
 }
 
@@ -745,7 +653,7 @@ li .link a {
 }
 
 li.story .description_present {
-	color: var(--color-story-description_present);
+	color: var(--color-fg-50);
 	padding-left: 0.25em;
 	text-decoration: none;
 	vertical-align: middle;
@@ -760,7 +668,7 @@ li .tags {
 }
 
 li .domain {
-	color: var(--color-domain);
+	color: var(--color-fg-47);
 	font-style: italic;
 	font-size: 9pt;
 	text-decoration: none;
@@ -782,7 +690,7 @@ li input.comment_folder_button {
 li .comment_folder {
 	display: inline-block;
 	font-size: 9pt;
-	color: var(--color-comment_folder);
+	color: var(--color-fg-33);
 	letter-spacing: 0.1em;
 	width: 1.5em;
  	cursor: pointer;
@@ -827,7 +735,7 @@ li.comments_subtree {
 li .comment_parent_tree_line {
 	position: absolute;
 	left: 54px;
-	border-left: 1px dotted var(--color-comment-tree-line-stroke);
+	border-left: 1px dotted var(--color-fg-shape);
 	top: 30px;
 	bottom: 0;
 }
@@ -843,7 +751,7 @@ li .comment_parent_tree_line.no_children {
 li .comment_siblings_tree_line {
 	position: absolute;
 	left: 28px;
-	border-left: 1px dotted var(--color-comment-tree-line-stroke);
+	border-left: 1px dotted var(--color-fg-shape);
 	top: 2em;
 	bottom: 0;
 }
@@ -858,7 +766,7 @@ div.comment:target div.voters {
 }
 
 li .byline {
-	color: var(--color-byline);
+	color: var(--color-fg-47);
 	font-size: 9.5pt;
 }
 li .byline > img.avatar {
@@ -879,7 +787,7 @@ li.story span.byline {
 	margin-left: 0.5em;
 }
 li .byline a {
-	color: var(--color-byline);
+	color: var(--color-fg-47);
 	text-decoration: none;
 }
 /* preserve selection made elsewhere when clicking */
@@ -892,20 +800,20 @@ li .byline a.comment_replier {
 }
 span.new_user, a.new_user,
 li .byline a.new_user {
-	color: var(--color-byline-new_user);
+	color: var(--color-fg-affirmative);
 }
 span.inactive_user, a.inactive_user,
 li .byline a.inactive_user,
 .inactive_tag {
-	color: var(--color-byline-inactive_user);
+	color: var(--color-fg-50);
 	text-decoration: line-through;
 }
 span.user_is_author, a.user_is_author,
 li .byline a.user_is_author {
-	color: var(--color-byline-author);
+	color: var(--color-fg-author);
 }
 li .byline a.story_has_suggestions {
-	color: var(--color-byline-author);
+	color: var(--color-fg-author);
 }
 
 li.story.hidden {
@@ -915,14 +823,14 @@ ol.show_hidden li.story.hidden {
 	opacity: 1.0 !important;
 }
 li.story.saved a.saver {
-	color: var(--color-saver-saved);
+	color: var(--color-fg-affirmative);
 }
 
 li.story.expired {
 	opacity: 0.6;
 }
 li.story.expired a {
-	color: var(--color-story-expired-link) !important;
+	color: var(--color-fg-50) !important;
 }
 
 li div.details,
@@ -935,7 +843,7 @@ div.story_content {
 	margin-bottom: 1em;
 }
 ol.stories.list div.story_content {
-	color: var(--color-stories-list-story_content);
+	color: var(--color-fg-53);
 	max-height: 2.6em;
 	margin: 0.25em 40px 0.25em 0;
 	overflow: hidden;
@@ -952,7 +860,7 @@ div.page_link_buttons {
 	margin-left: 40px;
 }
 div.morelink a {
-	color: var(--color-morelink-link);
+	color: var(--color-fg-60);
 	font-weight: bold;
 	text-decoration: none;
 }
@@ -962,9 +870,9 @@ div.page_link_buttons {
 }
 div.page_link_buttons a,
 div.page_link_buttons span {
-	border: 1px solid var(--color-button-border);
-	background-color: var(--color-button-background);
-	color: var(--color-page_link_buttons-item);
+	border: 1px solid var(--color-box-border);
+	background-color: var(--color-button-bg);
+	color: var(--color-fg-60);
 	padding: 0.25em 0.5em;
 	font-weight: bold;
 	text-decoration: none;
@@ -1011,14 +919,14 @@ div.story_text blockquote {
 	font-style: italic;
 	margin: 0.25em 0 0 0.5em;
 	padding: 0 0 0 1em;
-	border-left: 2px solid var(--color-blockquote);
+	border-left: 2px solid var(--color-fg-50);
 }
 
 /* un-italicize italics inside a blockquote */
 div.comment_text blockquote em, 
 div.markdown_help blockquote em, 
 div.story_text blockquote em {
-    font-style: normal
+	font-style: normal
 }
 
 div#collapsed_story_text div.story_text blockquote {
@@ -1052,23 +960,23 @@ div.comment_text code {
 #flag_why {
 	position: absolute;
 	width: 100px;
-	border: 1px solid var(--color-flag_why-border);
+	border: 1px solid var(--color-box-border);
 	border-bottom: 0;
 	z-index: 15;
 }
 #flag_why a {
-	background-color: var(--color-flag_why-background);
-	color: var(--color-flag_why);
-	border-bottom: 1px solid var(--color-flag_why-border);
+	background-color: var(--color-box-bg);
+	color: var(--color-fg-67);
+	border-bottom: 1px solid var(--color-box-border);
 	display: block;
 	padding: 3px;
 	font-size: 9pt;
 }
 #flag_why a:hover {
-	background-color: var(--color-flag_why-background-dimmed);
+	background-color: var(--color-box-bg-shaded);
 }
 #flag_why a.cancelreason {
-	background-color: var(--color-flag_why-background-dimmed);
+	background-color: var(--color-box-bg-shaded);
 	font-size: 8pt;
 }
 
@@ -1085,8 +993,8 @@ div.comment_text code {
 
 
 div.markdown_help {
-	background-color: var(--color-form-disabled-background);
-	border: 1px solid var(--color-form-border);
+	background-color: var(--color-box-bg-shaded);
+	border: 1px solid var(--color-box-border);
 	padding: 0 1em;
 	margin-top: 0.5em;
 }
@@ -1095,7 +1003,7 @@ div.markdown_help_label {
 	float: right;
 	font-size: 9pt;
 	line-height: 2em;
-	color: var(--color-markdown_help-label);
+	color: var(--color-fg-33);
 	text-decoration: underline;
 	cursor: pointer;
 }
@@ -1150,8 +1058,8 @@ div.comment_form_container textarea {
 }
 
 span.comment_unread {
-    color: var(--color-comment_unread);
-    font-weight: 600;
+	color: var(--color-fg-accent);
+	font-weight: 600;
 }
 
 /* trees */
@@ -1170,7 +1078,7 @@ span.comment_unread {
 
 .tree:before,
 .tree ul:before {
-	border-left: 1px solid var(--color-tree-line-stroke);
+	border-left: 1px solid var(--color-fg-shape);
 	bottom: 0;
 	content: "";
 	display: block;
@@ -1187,7 +1095,7 @@ span.comment_unread {
 }
 
 .tree li:before {
-	border-top: 1px solid var(--color-tree-line-stroke);
+	border-top: 1px solid var(--color-fg-shape);
 	content: "";
 	display: block;
 	height: 0;
@@ -1199,7 +1107,7 @@ span.comment_unread {
 }
 
 .tree li:last-child:before {
-	background-color: var(--color-background);
+	background-color: var(--color-bg);
 	border-left: 0;
 	bottom: 0;
 	height: auto;
@@ -1212,7 +1120,7 @@ ul.noparent:before {
 }
 
 ul.user_tree {
-	color: var(--color-user_tree);
+	color: var(--color-fg-47);
 }
 
 /* /u/:username/standing */
@@ -1237,10 +1145,10 @@ td.warned div, td.unwarned div {
 /* /mod dashbaord */
 
 .modmodlog .mod td:first-child {
-	border-left: 2pt solid var(--color-modmodlog-row-border-left);
+	border-left: 2pt solid var(--color-fg-accent);
 }
 .nominal {
-	color: var(--color-nominal);
+	color: var(--color-fg-accent);
 	font-size: 2em;
 	text-align: center;
 }
@@ -1248,9 +1156,9 @@ td.warned div, td.unwarned div {
 /* data tables */
 
 table.data th {
-	background-color: var(--color-table-data-header-background);
-	border-bottom: 1px solid var(--color-table-data-header-border);
-	border-top: 1px solid var(--color-table-data-header-border);
+	background-color: var(--color-table-header-bg);
+	border-bottom: 1px solid var(--color-table-header-border);
+	border-top: 1px solid var(--color-table-header-border);
 	text-align: left;
 }
 table.data th img {
@@ -1273,12 +1181,12 @@ table.data tr.bold td {
 }
 
 table.data.zebra tr:nth-child(even) td {
-	background-color: var(--color-table-data-row-background-even);
-	border-bottom: 1px solid var(--color-table-data-row-border);
+	background-color: var(--color-table-row-bg-even);
+	border-bottom: 1px solid var(--color-table-row-border);
 }
 table.data.zebra tr:nth-child(odd) td {
-	background-color: var(--color-table-data-row-background-odd);
-	border-bottom: 1px solid var(--color-table-data-row-border);
+	background-color: var(--color-table-row-bg-odd);
+	border-bottom: 1px solid var(--color-table-row-border);
 }
 table.data tr.nobottom td {
 	border-bottom: 0px;
@@ -1317,7 +1225,7 @@ table.data pre {
 	font-size: 9.5pt;
 	font-weight: normal;
 	font-style: italic;
-	color: var(--color-box-sublegend);
+	color: var(--color-fg-50);
 }
 .box .legend.right {
 	float: right;
@@ -1387,7 +1295,7 @@ table.data pre {
 }
 
 .hint {
-	color: var(--color-hint);
+	color: var(--color-fg-50);
 	font-style: italic;
 	margin-left: 1em;
 }
@@ -1408,17 +1316,17 @@ div.flash-success {
 	position: relative;
 	padding: 7px 15px;
 	margin-bottom: 18px;
-	border-color: var(--color-flash-border-highlight) var(--color-flash-border-highlight) var(--color-flash-border-shadow);
+	border-color: var(--color-shadow-10) var(--color-shadow-10) var(--color-shadow-25);
 	border-width: 1px;
 	border-style: solid;
 	border-radius: 4px;
-	box-shadow: inset 0 1px 0 var(--color-flash-box-shadow);
+	box-shadow: inset 0 1px 0 var(--color-light-25);
 }
 div.flash-error a,
 div.flash-notice a,
 div.flash-success a {
 	font-weight: bold;
-	color: var(--color-flash-link);
+	color: var(--color-fg-75);
 }
 div.flash-error p,
 div.flash-notice p,
@@ -1442,7 +1350,7 @@ div.flash-success {
 }
 div.flash-notice {
 	background-color: var(--color-flash-notice-background);
-	text-shadow: 0 -1px 0 var(--color-flash-notice-text-shadow);
+	text-shadow: 0 -1px 0 var(--color-shadow-25);
 }
 
 div.flash-error h2,
@@ -1455,27 +1363,27 @@ div.flash-success h2 {
 /* select2 deuglification */
 
 .select2-container-multi.select2-container-active .select2-choices {
-	border: 1px solid var(--color-select2-multi-choices-border-active);
+	border: 1px solid var(--color-box-border-focus);
 }
 .select2-container .select2-results .select2-highlighted {
-	background: var(--color-select2-results-item-highlighted-background);
-	color: var(--color-select2-results-item-highlighted);
+	background: var(--color-bg-accent);
+	color: var(--color-box-bg);
 }
 
 .select2-container-multi .select2-choices {
-	border-color: var(--color-select2-multi-choices-border);
-	background-color: var(--color-select2-multi-choices-background);
+	border-color: var(--color-box-border);
+	background-color: var(--color-box-bg);
 	background-image: none;
 	padding-top: 2px;
 }
 
 .select2-container .select2-drop {
-	background-color: var(--color-select2-multi-choices-background);
-	border-color: var(--color-select2-multi-choices-border-active);
+	background-color: var(--color-box-bg);
+	border-color: var(--color-box-border-focus);
 }
 
 .select2-container-multi.select2-container-active .select2-choices {
-    box-shadow        : none;
+	box-shadow        : none;
 }
 
 .select2-container-active .select2-choice,
@@ -1490,22 +1398,22 @@ div.flash-success h2 {
 
 .select2-container .select2-results li em {
 	background: none;
-	color: var(--color-select2-results-item-em);
+	color: var(--color-fg-33);
 	font-style: italic;
 	padding-left: 0.5em;
 }
 
 .select2-container .select2-results .select2-highlighted em {
-	color: var(--color-select2-results-item-highlighted);
+	color: var(--color-box-bg);
 }
 
 /* pushover */
 .pushover_button {
 	box-sizing: border-box;
-	background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABmJLR0QAJQCeAPHNVUx7AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH3wEPAh02ee0QVwAAACZpVFh0Q29tbWVudAAAAAAAQ3JlYXRlZCB3aXRoIEdJTVAgb24gYSBNYWOV5F9bAAABqElEQVQ4y62TvUtbURjGf+fek2vQpMF2ED9QkfpR6VLaDoIEF0UKWQRBQ+yQP6GDU0Xw4y/obOgg6dDSJVS61MlBcXFQB6M1BsF+IES9NnrzcRy8xpvrBwH7bOflfc553+d5jsCF9tiRDwgBEaDXLi8B80AiGQ2Yzn7hIo8Cce5HOBkNfLo6aA7ydAVkgLjdez3BrS8rRbBJEmyU+AyBVVDE1i1SJ6psEmHvfOLktj0SjL/2snKQx8wpNg+LBJt0RjoN+j6bqOvN/ZotWAldtYK5gWpmV84YbPUw2ePlb7bI73+Kep+OLFONkGarXcK7l16+7+V57BW8qJMs7Ob5k4VQm4fVXzlyquyGiHRYBcC+WWQxnSP63AAgtn7O0FNJ9xOd0W+nbkF7pbsytXxOQw30N0t2MgX6Wzy8qtMJL5zy81jdsETaIXnjLL7trkLqGl+2svxI5/mwZt1l6ZJmJ6yEGqkYbveQOioQ2yiz7TbMa0DCWRnuMPBXaXzcsJx23YWEZmc7fJkqxdgzg8xZka/bFhVE2hSuKL+nMswko4GJ//KZxEO/8wVmfpjJTWeCTQAAAABJRU5ErkJggg==) 2px 2px no-repeat, linear-gradient(var(--color-pushover_button-gradient-top), var(--color-pushover_button-gradient-bottom));
-	border: 1px solid var(--color-pushover_button-border);
+	background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABmJLR0QAJQCeAPHNVUx7AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH3wEPAh02ee0QVwAAACZpVFh0Q29tbWVudAAAAAAAQ3JlYXRlZCB3aXRoIEdJTVAgb24gYSBNYWOV5F9bAAABqElEQVQ4y62TvUtbURjGf+fek2vQpMF2ED9QkfpR6VLaDoIEF0UKWQRBQ+yQP6GDU0Xw4y/obOgg6dDSJVS61MlBcXFQB6M1BsF+IES9NnrzcRy8xpvrBwH7bOflfc553+d5jsCF9tiRDwgBEaDXLi8B80AiGQ2Yzn7hIo8Cce5HOBkNfLo6aA7ydAVkgLjdez3BrS8rRbBJEmyU+AyBVVDE1i1SJ6psEmHvfOLktj0SjL/2snKQx8wpNg+LBJt0RjoN+j6bqOvN/ZotWAldtYK5gWpmV84YbPUw2ePlb7bI73+Kep+OLFONkGarXcK7l16+7+V57BW8qJMs7Ob5k4VQm4fVXzlyquyGiHRYBcC+WWQxnSP63AAgtn7O0FNJ9xOd0W+nbkF7pbsytXxOQw30N0t2MgX6Wzy8qtMJL5zy81jdsETaIXnjLL7trkLqGl+2svxI5/mwZt1l6ZJmJ6yEGqkYbveQOioQ2yiz7TbMa0DCWRnuMPBXaXzcsJx23YWEZmc7fJkqxdgzg8xZka/bFhVE2hSuKL+nMswko4GJ//KZxEO/8wVmfpjJTWeCTQAAAABJRU5ErkJggg==) 2px 2px no-repeat, linear-gradient(var(--color-fg-gradient-lit), var(--color-fg-gradient-shadowed));
+	border: 1px solid var(--color-box-border);
 	border-radius: 3px;
-	color: var(--color-pushover_button);
+	color: var(--color-fg-67);
 	display: inline-block;
 	font: 11px/18px "Helvetica Neue",Arial,sans-serif;
 	font-weight: bold;
@@ -1514,7 +1422,7 @@ div.flash-success h2 {
 	padding-left: 20px;
 	padding-right: 5px;
 	overflow: hidden;
-	text-shadow: 0px 1px 0px var(--color-pushover_button-text-shadow);
+	text-shadow: 0px 1px 0px var(--color-bg-50);
 	text-decoration: none;
 	vertical-align: middle;
 }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -14,14 +14,15 @@
 	--palette-shadow: 0, 0, 0;
 
 	/* blends of foreground color over the background */
-	--opacity-contrast-75: 94%;
-	--opacity-contrast-67: 84%;
-	--opacity-contrast-60: 75%;
-	--opacity-contrast-53: 67%;
-	--opacity-contrast-50: 63%;
-	--opacity-contrast-47: 59%;
-	--opacity-contrast-40: 50%;
-	--opacity-contrast-33: 41%;
+	--opacity-contrast-13: 94%;
+	--opacity-contrast-10: 84%;
+	--opacity-contrast-7-5: 75%;
+	--opacity-contrast-6: 67%;
+	--opacity-contrast-5: 63%;
+	--opacity-contrast-4-5: 59%; /* WCAG AA minimum 4.5:1 text contrast */
+	--opacity-contrast-3-5: 50%;
+	--opacity-contrast-2-75: 41%;
+
 	--opacity-gradient-lit: 0%;
 	--opacity-gradient-shadowed: 13%;
 
@@ -77,14 +78,15 @@
 		--palette-shadow: 0, 0, 0;
 
 		/* blends of foreground color over the background */
-		--opacity-contrast-75: 95%; /* 12.87, 13.03, 13.15, links in flash banners */
-		--opacity-contrast-67: 85%; /* 9.75, 9.89, 9.98, most text in a box */
-		--opacity-contrast-60: 76%; /* 7.60, 7.60, 7.54, table page links*/
-		--opacity-contrast-53: 69%; /* 5.85, 5.97, 6.02, uncolored text links */
-		--opacity-contrast-50: 64%; /* 5.12, 5.29, 5.13, disabled, expired */
-		--opacity-contrast-47: 61%; /* 4.49!, 4.62, 4.70, byline */
-		--opacity-contrast-40: 54%; /* 3.55!, 3.60!, 3.70!, footer link */
-		--opacity-contrast-33: 46%; /* 2.78!, 2.79!, 2.78!, faint text */
+		--opacity-contrast-13: 95%;
+		--opacity-contrast-10: 85%;
+		--opacity-contrast-7-5: 76%;
+		--opacity-contrast-6: 69%;
+		--opacity-contrast-5: 64%;
+		--opacity-contrast-4-5: 61%; /* WCAG AA minimum 4.5:1 text contrast */
+		--opacity-contrast-3-5: 54%;
+		--opacity-contrast-2-75: 46%;
+
 		--opacity-gradient-lit: 13%;
 		--opacity-gradient-shadowed: 3%;
 
@@ -147,14 +149,15 @@ html {
 	--color-bg-50: rgba(var(--palette-bg), 50%);
 
 	--color-fg: rgb(var(--palette-fg)); /* primary text */
-	--color-fg-75: rgba(var(--palette-fg), var(--opacity-contrast-75)); /* links in flash banners */
-	--color-fg-67: rgba(var(--palette-fg), var(--opacity-contrast-67)); /* most text in a box */
-	--color-fg-60: rgba(var(--palette-fg), var(--opacity-contrast-60)); /* table page links */
-	--color-fg-53: rgba(var(--palette-fg), var(--opacity-contrast-53)); /* uncolored text links */
-	--color-fg-50: rgba(var(--palette-fg), var(--opacity-contrast-50)); /* disabled, expired */
-	--color-fg-47: rgba(var(--palette-fg), var(--opacity-contrast-47)); /* byline */
-	--color-fg-40: rgba(var(--palette-fg), var(--opacity-contrast-40)); /* footer link */
-	--color-fg-33: rgba(var(--palette-fg), var(--opacity-contrast-33)); /* faint text */
+	--color-fg-contrast-13: rgba(var(--palette-fg), var(--opacity-contrast-13));
+	--color-fg-contrast-10: rgba(var(--palette-fg), var(--opacity-contrast-10));
+	--color-fg-contrast-7-5: rgba(var(--palette-fg), var(--opacity-contrast-7-5));
+	--color-fg-contrast-6: rgba(var(--palette-fg), var(--opacity-contrast-6));
+	--color-fg-contrast-5: rgba(var(--palette-fg), var(--opacity-contrast-5));
+	--color-fg-contrast-4-5: rgba(var(--palette-fg), var(--opacity-contrast-4-5));
+	--color-fg-contrast-3-5: rgba(var(--palette-fg), var(--opacity-contrast-3-5));
+	--color-fg-contrast-2-75: rgba(var(--palette-fg), var(--opacity-contrast-2-75));
+
 	--color-fg-gradient-lit: rgba(var(--palette-fg), var(--opacity-gradient-lit));
 	--color-fg-gradient-shadowed: rgba(var(--palette-fg), var(--opacity-gradient-shadowed)); /* d7d7d7 */
 
@@ -223,7 +226,7 @@ a.tag {
 	background-color: var(--color-tag-bg);
 	border: 1px solid var(--color-tag-border);
 	border-radius: 5px;
-	color: var(--color-fg-67);
+	color: var(--color-fg-contrast-10);
 	font-size: 8pt;
 	margin-left: 0.25em;
 	padding: 0px 0.4em 1px 0.4em;
@@ -234,7 +237,7 @@ a.tag {
 a.tag_is_media {
 	background-color: var(--color-tag-media-bg);
 	border-color: var(--color-tag-media-border);
-	color: var(--color-fg-67);
+	color: var(--color-fg-contrast-10);
 }
 
 a.tag_meta {
@@ -261,12 +264,12 @@ span.hat span.crown {
 }
 
 span.hat span.crown, span.hat a {
-	color: var(--color-fg-53);
+	color: var(--color-fg-contrast-6);
 	text-decoration: none;
 }
 
 span.na {
-	color: var(--color-fg-50);
+	color: var(--color-fg-contrast-5);
 	font-style: italic;
 }
 
@@ -284,7 +287,7 @@ input,
 button,
 select,
 textarea {
-	color: var(--color-fg-67);
+	color: var(--color-fg-contrast-10);
 	background-color: var(--color-box-bg);
 	padding: 3px 5px;
 }
@@ -317,7 +320,7 @@ textarea:focus {
 	outline: 0;
 }
 textarea::placeholder {
-	color: var(--color-fg-60);
+	color: var(--color-fg-contrast-7-5);
 }
 
 input[type="submit"]:focus,
@@ -328,11 +331,11 @@ button:focus {
 
 /* these must be separate */
 ::-webkit-input-placeholder {
-	color: var(--color-fg-50);
+	color: var(--color-fg-contrast-5);
 	font-style: italic;
 }
 :-moz-placeholder {
-	color: var(--color-fg-50);
+	color: var(--color-fg-contrast-5);
 	font-style: italic;
 }
 
@@ -363,7 +366,7 @@ button:hover,
 input[type="button"]:hover,
 input[type="reset"]:hover,
 input[type="submit"]:hover {
-	color: var(--color-fg-67);
+	color: var(--color-fg-contrast-10);
 	text-decoration: none;
 	background-color: var(--color-button-bg-shaded);
 }
@@ -386,7 +389,7 @@ input:disabled,
 textarea:disabled,
 button:disabled {
 	background-color: var(--color-box-bg-shaded);
-	color: var(--color-fg-50);
+	color: var(--color-fg-contrast-5);
 }
 
 a.button,
@@ -457,7 +460,7 @@ div#inside {
 }
 
 .headerlinks a {
-	color: var(--color-fg-53);
+	color: var(--color-fg-contrast-6);
 	text-decoration: none;
 	padding-right: 0.75em;
 }
@@ -493,7 +496,7 @@ div#footer {
 	padding-right: 10px;
 }
 div#footer a {
-	color: var(--color-fg-40);
+	color: var(--color-fg-contrast-3-5);
 	text-decoration: none;
 	padding-left: 0.75em;
 }
@@ -562,7 +565,7 @@ div.voters {
 }
 
 div.voters div.score {
-	color: var(--color-fg-33);
+	color: var(--color-fg-contrast-2-75);
 	font-size: 9pt;
 	margin-top: 1px;
 	margin-bottom: -3px;
@@ -631,7 +634,7 @@ ol.stories li.story div.story_liner {
 }
 
 .comment a {
-	color: var(--color-fg-60);
+	color: var(--color-fg-contrast-7-5);
 }
 
 ol.stories li:first-child div.story_liner {
@@ -671,7 +674,7 @@ li .link a {
 }
 
 li.story .description_present {
-	color: var(--color-fg-50);
+	color: var(--color-fg-contrast-5);
 	padding-left: 0.25em;
 	text-decoration: none;
 	vertical-align: middle;
@@ -686,7 +689,7 @@ li .tags {
 }
 
 li .domain {
-	color: var(--color-fg-47);
+	color: var(--color-fg-contrast-4-5);
 	font-style: italic;
 	font-size: 9pt;
 	text-decoration: none;
@@ -708,7 +711,7 @@ li input.comment_folder_button {
 li .comment_folder {
 	display: inline-block;
 	font-size: 9pt;
-	color: var(--color-fg-33);
+	color: var(--color-fg-contrast-2-75);
 	letter-spacing: 0.1em;
 	width: 1.5em;
  	cursor: pointer;
@@ -784,7 +787,7 @@ div.comment:target div.voters {
 }
 
 li .byline {
-	color: var(--color-fg-47);
+	color: var(--color-fg-contrast-4-5);
 	font-size: 9.5pt;
 }
 li .byline > img.avatar {
@@ -805,7 +808,7 @@ li.story span.byline {
 	margin-left: 0.5em;
 }
 li .byline a {
-	color: var(--color-fg-47);
+	color: var(--color-fg-contrast-4-5);
 	text-decoration: none;
 }
 /* preserve selection made elsewhere when clicking */
@@ -823,7 +826,7 @@ li .byline a.new_user {
 span.inactive_user, a.inactive_user,
 li .byline a.inactive_user,
 .inactive_tag {
-	color: var(--color-fg-50);
+	color: var(--color-fg-contrast-5);
 	text-decoration: line-through;
 }
 span.user_is_author, a.user_is_author,
@@ -848,7 +851,7 @@ li.story.expired {
 	opacity: 0.6;
 }
 li.story.expired a {
-	color: var(--color-fg-50) !important;
+	color: var(--color-fg-contrast-5) !important;
 }
 
 li div.details,
@@ -861,7 +864,7 @@ div.story_content {
 	margin-bottom: 1em;
 }
 ol.stories.list div.story_content {
-	color: var(--color-fg-53);
+	color: var(--color-fg-contrast-6);
 	max-height: 2.6em;
 	margin: 0.25em 40px 0.25em 0;
 	overflow: hidden;
@@ -878,7 +881,7 @@ div.page_link_buttons {
 	margin-left: 40px;
 }
 div.morelink a {
-	color: var(--color-fg-60);
+	color: var(--color-fg-contrast-7-5);
 	font-weight: bold;
 	text-decoration: none;
 }
@@ -890,7 +893,7 @@ div.page_link_buttons a,
 div.page_link_buttons span {
 	border: 1px solid var(--color-box-border);
 	background-color: var(--color-button-bg);
-	color: var(--color-fg-60);
+	color: var(--color-fg-contrast-7-5);
 	padding: 0.25em 0.5em;
 	font-weight: bold;
 	text-decoration: none;
@@ -937,7 +940,7 @@ div.story_text blockquote {
 	font-style: italic;
 	margin: 0.25em 0 0 0.5em;
 	padding: 0 0 0 1em;
-	border-left: 2px solid var(--color-fg-50);
+	border-left: 2px solid var(--color-fg-contrast-5);
 }
 
 /* un-italicize italics inside a blockquote */
@@ -984,7 +987,7 @@ div.comment_text code {
 }
 #flag_why a {
 	background-color: var(--color-box-bg);
-	color: var(--color-fg-67);
+	color: var(--color-fg-contrast-10);
 	border-bottom: 1px solid var(--color-box-border);
 	display: block;
 	padding: 3px;
@@ -1021,7 +1024,7 @@ div.markdown_help_label {
 	float: right;
 	font-size: 9pt;
 	line-height: 2em;
-	color: var(--color-fg-33);
+	color: var(--color-fg-contrast-2-75);
 	text-decoration: underline;
 	cursor: pointer;
 }
@@ -1138,7 +1141,7 @@ ul.noparent:before {
 }
 
 ul.user_tree {
-	color: var(--color-fg-47);
+	color: var(--color-fg-contrast-4-5);
 }
 
 /* /u/:username/standing */
@@ -1243,7 +1246,7 @@ table.data pre {
 	font-size: 9.5pt;
 	font-weight: normal;
 	font-style: italic;
-	color: var(--color-fg-50);
+	color: var(--color-fg-contrast-5);
 }
 .box .legend.right {
 	float: right;
@@ -1313,7 +1316,7 @@ table.data pre {
 }
 
 .hint {
-	color: var(--color-fg-50);
+	color: var(--color-fg-contrast-5);
 	font-style: italic;
 	margin-left: 1em;
 }
@@ -1344,7 +1347,7 @@ div.flash-error a,
 div.flash-notice a,
 div.flash-success a {
 	font-weight: bold;
-	color: var(--color-fg-75);
+	color: var(--color-fg-contrast-13);
 }
 div.flash-error p,
 div.flash-notice p,
@@ -1416,7 +1419,7 @@ div.flash-success h2 {
 
 .select2-container .select2-results li em {
 	background: none;
-	color: var(--color-fg-33);
+	color: var(--color-fg-contrast-2-75);
 	font-style: italic;
 	padding-left: 0.5em;
 }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1413,7 +1413,7 @@ div.flash-success h2 {
 	background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABmJLR0QAJQCeAPHNVUx7AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH3wEPAh02ee0QVwAAACZpVFh0Q29tbWVudAAAAAAAQ3JlYXRlZCB3aXRoIEdJTVAgb24gYSBNYWOV5F9bAAABqElEQVQ4y62TvUtbURjGf+fek2vQpMF2ED9QkfpR6VLaDoIEF0UKWQRBQ+yQP6GDU0Xw4y/obOgg6dDSJVS61MlBcXFQB6M1BsF+IES9NnrzcRy8xpvrBwH7bOflfc553+d5jsCF9tiRDwgBEaDXLi8B80AiGQ2Yzn7hIo8Cce5HOBkNfLo6aA7ydAVkgLjdez3BrS8rRbBJEmyU+AyBVVDE1i1SJ6psEmHvfOLktj0SjL/2snKQx8wpNg+LBJt0RjoN+j6bqOvN/ZotWAldtYK5gWpmV84YbPUw2ePlb7bI73+Kep+OLFONkGarXcK7l16+7+V57BW8qJMs7Ob5k4VQm4fVXzlyquyGiHRYBcC+WWQxnSP63AAgtn7O0FNJ9xOd0W+nbkF7pbsytXxOQw30N0t2MgX6Wzy8qtMJL5zy81jdsETaIXnjLL7trkLqGl+2svxI5/mwZt1l6ZJmJ6yEGqkYbveQOioQ2yiz7TbMa0DCWRnuMPBXaXzcsJx23YWEZmc7fJkqxdgzg8xZka/bFhVE2hSuKL+nMswko4GJ//KZxEO/8wVmfpjJTWeCTQAAAABJRU5ErkJggg==) 2px 2px no-repeat, linear-gradient(var(--color-fg-gradient-lit), var(--color-fg-gradient-shadowed));
 	border: 1px solid var(--color-box-border);
 	border-radius: 3px;
-	color: var(--color-fg-67);
+	color: var(--color-fg);
 	display: inline-block;
 	font: 11px/18px "Helvetica Neue",Arial,sans-serif;
 	font-weight: bold;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,6 +13,15 @@
 	--palette-light: 255, 255, 255;
 	--palette-shadow: 0, 0, 0;
 
+	/* blends of foreground color over the background */
+	--opacity-contrast-75: 94%;
+	--opacity-contrast-67: 84%;
+	--opacity-contrast-60: 75%;
+	--opacity-contrast-53: 67%;
+	--opacity-contrast-50: 63%;
+	--opacity-contrast-47: 59%;
+	--opacity-contrast-40: 50%;
+	--opacity-contrast-33: 41%;
 	--opacity-gradient-lit: 0%;
 	--opacity-gradient-shadowed: 13%;
 
@@ -67,6 +76,15 @@
 		--palette-light: 255, 255, 255;
 		--palette-shadow: 0, 0, 0;
 
+		/* blends of foreground color over the background */
+		--opacity-contrast-75: 95%; /* 12.87, 13.03, 13.15, links in flash banners */
+		--opacity-contrast-67: 85%; /* 9.75, 9.89, 9.98, most text in a box */
+		--opacity-contrast-60: 76%; /* 7.60, 7.60, 7.54, table page links*/
+		--opacity-contrast-53: 69%; /* 5.85, 5.97, 6.02, uncolored text links */
+		--opacity-contrast-50: 64%; /* 5.12, 5.29, 5.13, disabled, expired */
+		--opacity-contrast-47: 61%; /* 4.49!, 4.62, 4.70, byline */
+		--opacity-contrast-40: 54%; /* 3.55!, 3.60!, 3.70!, footer link */
+		--opacity-contrast-33: 46%; /* 2.78!, 2.79!, 2.78!, faint text */
 		--opacity-gradient-lit: 13%;
 		--opacity-gradient-shadowed: 3%;
 
@@ -128,15 +146,15 @@ html {
 	--color-bg: rgb(var(--palette-bg));
 	--color-bg-50: rgba(var(--palette-bg), 50%);
 
-	--color-fg: rgb(var(--palette-fg)); /* 272727, 14.90, 272727, 14.90, dadada, 14.99, primary text */
-	--color-fg-75: rgba(var(--palette-fg), 94%); /* 313131, 12.87, 313131, 13.03, links in flash banners */
-	--color-fg-67: rgba(var(--palette-fg), 83%); /* 444444, 9.75, 444444, 9.75, most text in a box */
-	--color-fg-60: rgba(var(--palette-fg), 75%); /* 545454, 7.60, 545454, 7.60, table page links*/
-	--color-fg-53: rgba(var(--palette-fg), 67%); /* 646464, 5.85, 636363, 5.97, uncolored text links */
-	--color-fg-50: rgba(var(--palette-fg), 63%); /* 6d6d6d, 5.12, 6b6b6b, 5.29, disabled, expired */
-	--color-fg-47: rgba(var(--palette-fg), 58%); /* 767676, 4.49!, 767676, 4.56, byline */
-	--color-fg-40: rgba(var(--palette-fg), 50%); /* 888888, 3.55!, 868686, 3.60!, footer link */
-	--color-fg-33: rgba(var(--palette-fg), 41%); /* 9a9a9a, 2.78!, 9a9a9a, 2.79!, faint text */
+	--color-fg: rgb(var(--palette-fg)); /* primary text */
+	--color-fg-75: rgba(var(--palette-fg), var(--opacity-contrast-75)); /* links in flash banners */
+	--color-fg-67: rgba(var(--palette-fg), var(--opacity-contrast-67)); /* most text in a box */
+	--color-fg-60: rgba(var(--palette-fg), var(--opacity-contrast-60)); /* table page links */
+	--color-fg-53: rgba(var(--palette-fg), var(--opacity-contrast-53)); /* uncolored text links */
+	--color-fg-50: rgba(var(--palette-fg), var(--opacity-contrast-50)); /* disabled, expired */
+	--color-fg-47: rgba(var(--palette-fg), var(--opacity-contrast-47)); /* byline */
+	--color-fg-40: rgba(var(--palette-fg), var(--opacity-contrast-40)); /* footer link */
+	--color-fg-33: rgba(var(--palette-fg), var(--opacity-contrast-33)); /* faint text */
 	--color-fg-gradient-lit: rgba(var(--palette-fg), var(--opacity-gradient-lit));
 	--color-fg-gradient-shadowed: rgba(var(--palette-fg), var(--opacity-gradient-shadowed)); /* d7d7d7 */
 

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1341,15 +1341,15 @@ div.flash-success div {
 	line-height: 28px;
 }
 div.flash-error {
-	background-color: var(--color-flash-error-background);
+	background-color: var(--color-flash-bg-error);
 	text-shadow: none;
 }
 div.flash-success {
-	background-color: var(--color-flash-success-background);
+	background-color: var(--color-flash-bg-success);
 	text-shadow: none;
 }
 div.flash-notice {
-	background-color: var(--color-flash-notice-background);
+	background-color: var(--color-flash-bg-notice);
 	text-shadow: 0 -1px 0 var(--color-shadow-25);
 }
 

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -22,16 +22,23 @@
     --color-form-border: #cccccc;
     --color-form-border-focus: #888888;
     --color-form-background: #ffffff;
+	--color-form-placeholder: #aaa;
+    --color-textarea-disabled: #f0f0f0;
+
+    --color-input-disabled-background: #e9e9e9;
+    --color-input-disabled: gray;
+    --color-input-destructive: darkred;
 
     --color-button: #333333;
     --color-button-border: #cccccc;
+    --color-button-border-bottom: #bbb;
+    --color-button-border-focus: #888;
     --color-button-hover: #333333;
     --color-button-background: #fafafa;
     --color-button-background-hover: #e6e6e6;
 
-    --color-table-background-header: #eaeaea;
-    --color-table-background-odd: #f8f8f8;
-    --color-table-background-even: #f5f5f5;
+	--color-select-focus-border: rgba(160,160,160,.8);
+	--color-select-focus: #303030;
 
     --color-tag: #555555;
     --color-tag-background: #fffcd7;
@@ -39,6 +46,15 @@
     --color-tag-media: #555555;
     --color-tag-media-background: #ddebf9;
     --color-tag-media-border: #b2ccf0;
+    --color-tag_meta-background: #eee;
+    --color-tag_meta-border: #c8c8c8;
+
+	--color-hat-border-bottom: #bbb;
+	--color-hat-crown-background: #ddd;
+	--color-hat-crown-border: #eee;
+	--color-hat-link: #777;
+
+	--color-na: gray;
 
     --color-header: #777777;
     --color-header-lobsters: #333333;
@@ -46,11 +62,94 @@
 
     --color-markdown_help-background: #f4f4f4;
     --color-markdown_help-border: #e0e0e0;
+    --color-markdown_help-label: #aaa;
 
     --color-flag_why: #555555;
     --color-flag_why-background: #ffffff;
     --color-flag_why-background-hover: #eeeeee;
     --color-flag_why-background-cancel: #eeeeee;
+	--color-flag_why-border: #ccc;
+
+	--color-new_messages: #ac130d;
+
+	--color-footer-link: #aaa;
+
+	--color-gravatar-border: #fff;
+	--color-gravatar-shadow: rgba(0, 0, 0, 0.8);
+
+	--color-voters-score: #aaa;
+	--color-voters-upvoter-fill: #bbb;
+	--color-voters-upvoter-fill-upvoted: #ac130d;
+
+	--color-comment-link: #666;
+	--color-comment-target: #fffcd7;
+
+	--color-story-description_present: gray;
+
+	--color-domain: #888;
+
+	--color-comment_folder: #aaa;
+
+	--color-comment-tree-line-stroke: #bbb;
+
+	--color-byline: #888;
+	--color-byline-new_user: green;
+	--color-byline-inactive_user: gray;
+	--color-byline-highlight: #6081bd;
+
+	--color-saver-saved: green;
+	--color-story-expired-link: gray;
+	--color-stories-list-story_content: #777;
+
+	--color-morelink-link: #666;
+	--color-page_link_buttons-item-border: #d0d0d0;
+	--color-page_link_buttons-item-background: #f3f3f3;
+	--color-page_link_buttons-item: #666;
+
+	--color-blockquote: gray;
+
+	--color-comment_unread: #ac130d;
+
+	--color-tree-line-stroke: #bbb;
+	--color-user_tree: #888;
+
+	--color-modmodlog-row-border-left: #ac130d;
+
+	--color-nominal: #ac130d;
+
+    --color-table-data-header-background: #eaeaea;
+	--color-table-data-header-border: #cacaca;
+    --color-table-data-row-background-even: #f8f8f8;
+    --color-table-data-row-background-odd: #f5f5f5;
+    --color-table-data-row-border: #eaeaea;
+
+	--color-box-sublegend: gray;
+
+	--color-hint: gray;
+
+	--color-flash-border-highlight: rgba(0, 0, 0, 0.1);
+	--color-flash-border-shadow: rgba(0, 0, 0, 0.25);
+	--color-flash-box-shadow: rgba(255, 255, 255, 0.25);
+	--color-flash-link: #404040;
+	--color-flash-paragraph-link: #ffffff;
+	--color-flash-error-background: #fdcfcc;
+	--color-flash-success-background: #dff0d8;
+	--color-flash-notice-background: #339bb9;
+	--color-flash-notice-text-shadow: rgba(0, 0, 0, 0.25);
+
+	--color-select2-multi-choices-border: #ccc;
+	--color-select2-multi-choices-border-active: rgba(160,160,160,.8);
+	--color-select2-single-choice-border: #aaa;
+	--color-select2-results-item-highlighted-background: darkred;
+	--color-select2-results-item-highlighted: #fff;
+	--color-select2-results-item-em: #aaa;
+
+	--color-pushover_button-background: #eee;
+	--color-pushover_button-gradient-top: #fff;
+	--color-pushover_button-gradient-bottom: #dedede;
+	--color-pushover_button-border: #ccc;
+	--color-pushover_button: #333;
+	--color-pushover_button-text-shadow: rgba(255, 255, 255, 0.5);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -85,6 +184,8 @@
     --color-tag-media: #555555;
     --color-tag-media-background: #ddebf9;
     --color-tag-media-border: #b2ccf0;
+    --color-tag_meta-background: #eee;
+    --color-tag_meta-border: #c8c8c8;
 
     --color-header: #777777;
     --color-header-lobsters: #aaaaaa;
@@ -159,20 +260,20 @@ a.tag_is_media {
 }
 
 a.tag_meta {
-	background-color: #eee;
-	border-color: #c8c8c8;
+	background-color: var(--color-tag_meta-background);
+	border-color: var(--color-tag_meta-border);
 }
 
 span.hat {
-	border-bottom: 6px solid #bbb;
+	border-bottom: 6px solid var(--color-hat-border-bottom);
 	border-radius: 4px;
 	padding: 1px 8px;
 	vertical-align: super;
 	white-space: nowrap;
 }
 span.hat span.crown {
-	background-color: #ddd;
-	border: 1px solid #eee;
+	background-color: var(--color-hat-crown-background);
+	border: 1px solid var(--color-hat-crown-border);
 	border-bottom: 0;
 	border-radius: 5px 5px 0px 0px;
 	font-size: 8pt;
@@ -182,12 +283,12 @@ span.hat span.crown {
 }
 
 span.hat span.crown, span.hat a {
-	color: #777;
+	color: var(--color-hat-link);
 	text-decoration: none;
 }
 
 span.na {
-	color: gray;
+	color: var(--color-na);
 	font-style: italic;
 }
 
@@ -229,7 +330,7 @@ input[type="checkbox"] {
 	margin-top: 0.5em;
 }
 select {
-	border: 1px solid #ccc;
+	border: 1px solid var(--color-form-border);
 }
 input:focus,
 textarea:focus {
@@ -238,27 +339,27 @@ textarea:focus {
 	outline: 0;
 }
 textarea::placeholder {
-	color: #333;
-        opacity: 0.8;
+	color: var(--color);
+	opacity: 0.8;
 }
 textarea:disabled {
-	background-color: #f0f0f0;
+	background-color: var(--color-form-disabled);
 }
 
 
 input[type="submit"]:focus,
 button:focus {
-	border-color: #888;
-	outline: 1px solid #888;
+	border-color: var(--color-button-border-focus);
+	outline: 1px solid var(--color-button-border-focus);
 }
 
 /* these must be separate */
 ::-webkit-input-placeholder {
-	color: #aaa;
+	color: var(--color-form-placeholder);
 	font-style: italic;
 }
 :-moz-placeholder {
-	color: #aaa;
+	color: var(--color-form-placeholder);
 	font-style: italic;
 }
 
@@ -269,7 +370,7 @@ input[type="submit"],
 div.select2-choices,
 a.button {
 	background-color: var(--color-button-background);
-	border-bottom-color: #bbb;
+	border-bottom-color: var(--color-button-border-bottom);
 	border: 1px solid var(--color-button-border);
 	color: var(--color-button);
 	cursor: pointer;
@@ -299,8 +400,8 @@ select {
 	min-width: 100px;
 }
 select:focus {
-	border-color: rgba(160,160,160,.8);
-	color: #303030;
+	border-color: var(--color-select-focus-border);
+	color: var(--color-select-focus);
 	outline: 0;
 }
 select::-moz-focus-inner {
@@ -310,15 +411,15 @@ select::-moz-focus-inner {
 
 input:disabled,
 button:disabled {
-	background-color: #e9e9e9;
-	color: gray;
+	background-color: var(--color-input-disabled-background);
+	color: var(--color-input-disabled);
 }
 
 a.button,
 button.deletion,
 input.deletion {
-  color: darkred;
-  border: 1px solid darkred;
+  color: var(--color-input-destructive);
+  border: 1px solid var(--color-input-destructive);
 }
 
 .totp_code::-webkit-inner-spin-button,
@@ -402,7 +503,7 @@ div#inside {
 }
 
 #header a.new_messages {
-	color: #ac130d;
+	color: var(--color-new_messages);
 }
 
 div#leader {
@@ -418,7 +519,7 @@ div#footer {
 	padding-right: 10px;
 }
 div#footer a {
-	color: #999;
+	color: var(--color-footer-link);
 	text-decoration: none;
 	padding-left: 0.75em;
 }
@@ -426,9 +527,9 @@ div#footer a {
 
 /* other specifics */
 div#gravatar {
-	border: 2px solid #fff;
+	border: 2px solid var(--color-gravatar-border);
 	border-radius: 100% 100%;
-	box-shadow: 0 1px 4px rgba(0, 0, 0, 0.8);
+	box-shadow: 0 1px 4px var(--color-gravatar-shadow);
 	float: right;
 	height: 100px;
 	width: 100px;
@@ -487,7 +588,7 @@ div.voters {
 }
 
 div.voters div.score {
-	color: #aaa;
+	color: var(--color-voters-score);
 	font-size: 9pt;
 	margin-top: 1px;
 	margin-bottom: -3px;
@@ -501,7 +602,7 @@ li.story div.voters div.score {
 
 div.voters .upvoter,
 div.voters .flagger {
-	border-color: transparent transparent #bbb transparent;
+	border-color: transparent transparent var(--color-voters-upvoter-fill) transparent;
 	border-style: solid;
 	border-width: 6px;
 	text-decoration: none;
@@ -515,7 +616,7 @@ div.voters .flagger {
 
 div.voters .upvoter:hover,
 .upvoted div.voters .upvoter {
-	border-bottom-color: #ac130d;
+	border-bottom-color: var(--color-voters-upvoter-fill-upvoted);
 }
 
 div.voters .upvoter {
@@ -556,7 +657,7 @@ ol.stories li.story div.story_liner {
 }
 
 .comment a {
-	color: #666;
+	color: var(--color-comment-link);
 }
 
 ol.stories li:first-child div.story_liner {
@@ -581,7 +682,7 @@ li div.details {
 }
 
 .comment:target, li:target, p:target {
-	background-color: #fffcd7;
+	background-color: var(--color-comment-target);
 	border-radius: 8px;
 }
 
@@ -596,7 +697,7 @@ li .link a {
 }
 
 li.story .description_present {
-	color: gray;
+	color: var(--color-story-description_present);
 	padding-left: 0.25em;
 	text-decoration: none;
 	vertical-align: middle;
@@ -611,7 +712,7 @@ li .tags {
 }
 
 li .domain {
-	color: #888;
+	color: var(--color-domain);
 	font-style: italic;
 	font-size: 9pt;
 	text-decoration: none;
@@ -633,7 +734,7 @@ li input.comment_folder_button {
 li .comment_folder {
 	display: inline-block;
 	font-size: 9pt;
-	color: #aaa;
+	color: var(--color-comment_folder);
 	letter-spacing: 0.1em;
 	width: 1.5em;
  	cursor: pointer;
@@ -678,7 +779,7 @@ li.comments_subtree {
 li .comment_parent_tree_line {
 	position: absolute;
 	left: 54px;
-	border-left: 1px dotted #bbb;
+	border-left: 1px dotted var(--color-comment-tree-line-stroke);
 	top: 30px;
 	bottom: 0;
 }
@@ -694,7 +795,7 @@ li .comment_parent_tree_line.no_children {
 li .comment_siblings_tree_line {
 	position: absolute;
 	left: 28px;
-	border-left: 1px dotted #bbb;
+	border-left: 1px dotted var(--color-comment-tree-line-stroke);
 	top: 2em;
 	bottom: 0;
 }
@@ -709,7 +810,7 @@ div.comment:target div.voters {
 }
 
 li .byline {
-	color: #888;
+	color: var(--color-byline);
 	font-size: 9.5pt;
 }
 li .byline > img.avatar {
@@ -730,7 +831,7 @@ li.story span.byline {
 	margin-left: 0.5em;
 }
 li .byline a {
-	color: #888;
+	color: var(--color-byline);
 	text-decoration: none;
 }
 /* preserve selection made elsewhere when clicking */
@@ -743,20 +844,20 @@ li .byline a.comment_replier {
 }
 span.new_user, a.new_user,
 li .byline a.new_user {
-	color: green;
+	color: var(--color-byline-new_user);
 }
 span.inactive_user, a.inactive_user,
 li .byline a.inactive_user,
 .inactive_tag {
-	color: gray;
+	color: var(--color-byline-inactive_user);
 	text-decoration: line-through;
 }
 span.user_is_author, a.user_is_author,
 li .byline a.user_is_author {
-	color: #6081bd;
+	color: var(--color-byline-highlight);
 }
 li .byline a.story_has_suggestions {
-	color: #6081bd;
+	color: var(--color-byline-highlight);
 }
 
 li.story.hidden {
@@ -766,14 +867,14 @@ ol.show_hidden li.story.hidden {
 	opacity: 1.0 !important;
 }
 li.story.saved a.saver {
-	color: green;
+	color: var(--color-saver-saved);
 }
 
 li.story.expired {
 	opacity: 0.6;
 }
 li.story.expired a {
-	color: gray !important;
+	color: var(--color-story-expired-link) !important;
 }
 
 li div.details,
@@ -786,7 +887,7 @@ div.story_content {
 	margin-bottom: 1em;
 }
 ol.stories.list div.story_content {
-	color: #777;
+	color: var(--color-stories-list-story_content);
 	max-height: 2.6em;
 	margin: 0.25em 40px 0.25em 0;
 	overflow: hidden;
@@ -803,7 +904,7 @@ div.page_link_buttons {
 	margin-left: 40px;
 }
 div.morelink a {
-	color: #666;
+	color: var(--color-morelink-link);
 	font-weight: bold;
 	text-decoration: none;
 }
@@ -813,9 +914,9 @@ div.page_link_buttons {
 }
 div.page_link_buttons a,
 div.page_link_buttons span {
-	border: 1px solid #d0d0d0;
-	background-color: #f3f3f3;
-	color: #666;
+	border: 1px solid var(--color-page_link_buttons-item-border);
+	background-color: var(--color-page_link_buttons-item-background);
+	color: var(--color-page_link_buttons-item);
 	padding: 0.25em 0.5em;
 	font-weight: bold;
 	text-decoration: none;
@@ -862,7 +963,7 @@ div.story_text blockquote {
 	font-style: italic;
 	margin: 0.25em 0 0 0.5em;
 	padding: 0 0 0 1em;
-	border-left: 2px solid gray;
+	border-left: 2px solid var(--color-blockquote);
 }
 
 /* un-italicize italics inside a blockquote */
@@ -903,14 +1004,14 @@ div.comment_text code {
 #flag_why {
 	position: absolute;
 	width: 100px;
-	border: 1px solid #ccc;
+	border: 1px solid var(--color-flag_why-border);
 	border-bottom: 0;
 	z-index: 15;
 }
 #flag_why a {
 	background-color: var(--color-flag_why-background);
 	color: var(--color-flag_why);
-	border-bottom: 1px solid #ccc;
+	border-bottom: 1px solid var(--color-flag_why-border);
 	display: block;
 	padding: 3px;
 	font-size: 9pt;
@@ -946,7 +1047,7 @@ div.markdown_help_label {
 	float: right;
 	font-size: 9pt;
 	line-height: 2em;
-	color: #aaa;
+	color: var(--color-markdown_help-label);
 	text-decoration: underline;
 	cursor: pointer;
 }
@@ -1001,7 +1102,7 @@ div.comment_form_container textarea {
 }
 
 span.comment_unread {
-    color: #ac130d;
+    color: var(--color-comment_unread);
     font-weight: 600;
 }
 
@@ -1021,7 +1122,7 @@ span.comment_unread {
 
 .tree:before,
 .tree ul:before {
-	border-left: 1px solid #bbb;
+	border-left: 1px solid var(--color-tree-line-stroke);
 	bottom: 0;
 	content: "";
 	display: block;
@@ -1038,7 +1139,7 @@ span.comment_unread {
 }
 
 .tree li:before {
-	border-top: 1px solid #bbb;
+	border-top: 1px solid var(--color-tree-line-stroke);
 	content: "";
 	display: block;
 	height: 0;
@@ -1050,7 +1151,7 @@ span.comment_unread {
 }
 
 .tree li:last-child:before {
-	background-color: #fefefe;
+	background-color: var(--color-background);
 	border-left: 0;
 	bottom: 0;
 	height: auto;
@@ -1063,7 +1164,7 @@ ul.noparent:before {
 }
 
 ul.user_tree {
-	color: #888;
+	color: var(--color-user_tree);
 }
 
 /* /u/:username/standing */
@@ -1088,10 +1189,10 @@ td.warned div, td.unwarned div {
 /* /mod dashbaord */
 
 .modmodlog .mod td:first-child {
-	border-left: 2pt solid #ac130d;
+	border-left: 2pt solid var(--color-modmodlog-row-border-left);
 }
 .nominal {
-	color: #ac130d;
+	color: var(--color-nominal);
 	font-size: 2em;
 	text-align: center;
 }
@@ -1099,9 +1200,9 @@ td.warned div, td.unwarned div {
 /* data tables */
 
 table.data th {
-	background-color: var(--color-table-background-header);
-	border-bottom: 1px solid #cacaca;
-	border-top: 1px solid #cacaca;
+	background-color: var(--color-table-data-header-background);
+	border-bottom: 1px solid var(--color-table-data-header-border);
+	border-top: 1px solid var(--color-table-data-header-border);
 	text-align: left;
 }
 table.data th img {
@@ -1124,12 +1225,12 @@ table.data tr.bold td {
 }
 
 table.data.zebra tr:nth-child(even) td {
-	background-color: var(--color-table-background-odd);
-	border-bottom: 1px solid #eaeaea;
+	background-color: var(--color-table-data-row-background-even);
+	border-bottom: 1px solid var(--color-table-data-row-border);
 }
 table.data.zebra tr:nth-child(odd) td {
-	background-color: var(--color-table-background-even);
-	border-bottom: 1px solid #eaeaea;
+	background-color: var(--color-table-data-row-background-odd);
+	border-bottom: 1px solid var(--color-table-data-row-border);
 }
 table.data tr.nobottom td {
 	border-bottom: 0px;
@@ -1168,7 +1269,7 @@ table.data pre {
 	font-size: 9.5pt;
 	font-weight: normal;
 	font-style: italic;
-	color: gray;
+	color: var(--color-box-sublegend);
 }
 .box .legend.right {
 	float: right;
@@ -1238,7 +1339,7 @@ table.data pre {
 }
 
 .hint {
-	color: gray;
+	color: var(--color-hint);
 	font-style: italic;
 	margin-left: 1em;
 }
@@ -1259,22 +1360,22 @@ div.flash-success {
 	position: relative;
 	padding: 7px 15px;
 	margin-bottom: 18px;
-	border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
+	border-color: var(--color-flash-border-highlight) var(--color-flash-border-highlight) var(--color-flash-border-shadow);
 	border-width: 1px;
 	border-style: solid;
 	border-radius: 4px;
-	box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25);
+	box-shadow: inset 0 1px 0 var(--color-flash-box-shadow);
 }
 div.flash-error a,
 div.flash-notice a,
 div.flash-success a {
 	font-weight: bold;
-	color: #404040;
+	color: var(--color-flash-link);
 }
 div.flash-error p a,
 div.flash-notice p a,
 div.flash-success p a {
-	color: #ffffff;
+	color: var(--color-flash-paragraph-link);
 }
 div.flash-error p,
 div.flash-notice p,
@@ -1289,16 +1390,16 @@ div.flash-success div {
 	line-height: 28px;
 }
 div.flash-error {
-	background-color: #fdcfcc;
+	background-color: var(--color-flash-error-background);
 	text-shadow: none;
 }
 div.flash-success {
-	background-color: #dff0d8;
+	background-color: var(--color-flash-success-background);
 	text-shadow: none;
 }
 div.flash-notice {
-	background-color: #339bb9;
-	text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
+	background-color: var(--color-flash-notice-background);
+	text-shadow: 0 -1px 0 var(--color-flash-notice-text-shadow);
 }
 
 div.flash-error h2,
@@ -1311,15 +1412,15 @@ div.flash-success h2 {
 /* select2 deuglification */
 
 .select2-container-multi.select2-container-active .select2-choices {
-	border: 1px solid rgba(160,160,160,.8);
+	border: 1px solid var(--color-select2-multi-choices-border-active);
 }
 .select2-container .select2-results .select2-highlighted {
-	background: darkred;
-	color: #fff;
+	background: var(--color-select2-results-item-highlighted-background);
+	color: var(--color-select2-results-item-highlighted);
 }
 
 .select2-container-multi .select2-choices {
-	border-color: #ccc;
+	border-color: var(--color-select2-multi-choices-border);
 	background-image: none;
 	padding-top: 2px;
 }
@@ -1334,14 +1435,14 @@ div.flash-success h2 {
 }
 
 .select2-dropdown-open .select2-choice {
-	border: 1px solid #aaa;
+	border: 1px solid var(--color-select2-single-choice-border);
 	border-bottom-color: transparent;
 	box-shadow        : none;
 }
 
 .select2-container .select2-results li em {
 	background: none;
-	color: #aaa;
+	color: var(--color-select2-results-item-em);
 	font-style: italic;
 	padding-left: 0.5em;
 }
@@ -1350,11 +1451,11 @@ div.flash-success h2 {
 /* pushover */
 .pushover_button {
 	box-sizing: border-box;
-	background-color: #eee;
-	background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABmJLR0QAJQCeAPHNVUx7AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH3wEPAh02ee0QVwAAACZpVFh0Q29tbWVudAAAAAAAQ3JlYXRlZCB3aXRoIEdJTVAgb24gYSBNYWOV5F9bAAABqElEQVQ4y62TvUtbURjGf+fek2vQpMF2ED9QkfpR6VLaDoIEF0UKWQRBQ+yQP6GDU0Xw4y/obOgg6dDSJVS61MlBcXFQB6M1BsF+IES9NnrzcRy8xpvrBwH7bOflfc553+d5jsCF9tiRDwgBEaDXLi8B80AiGQ2Yzn7hIo8Cce5HOBkNfLo6aA7ydAVkgLjdez3BrS8rRbBJEmyU+AyBVVDE1i1SJ6psEmHvfOLktj0SjL/2snKQx8wpNg+LBJt0RjoN+j6bqOvN/ZotWAldtYK5gWpmV84YbPUw2ePlb7bI73+Kep+OLFONkGarXcK7l16+7+V57BW8qJMs7Ob5k4VQm4fVXzlyquyGiHRYBcC+WWQxnSP63AAgtn7O0FNJ9xOd0W+nbkF7pbsytXxOQw30N0t2MgX6Wzy8qtMJL5zy81jdsETaIXnjLL7trkLqGl+2svxI5/mwZt1l6ZJmJ6yEGqkYbveQOioQ2yiz7TbMa0DCWRnuMPBXaXzcsJx23YWEZmc7fJkqxdgzg8xZka/bFhVE2hSuKL+nMswko4GJ//KZxEO/8wVmfpjJTWeCTQAAAABJRU5ErkJggg==) 2px 2px no-repeat, linear-gradient(#FFF, #DEDEDE);
-	border: 1px solid #CCC;
+	background-color: var(--color-pushover_button-background);
+	background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABmJLR0QAJQCeAPHNVUx7AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH3wEPAh02ee0QVwAAACZpVFh0Q29tbWVudAAAAAAAQ3JlYXRlZCB3aXRoIEdJTVAgb24gYSBNYWOV5F9bAAABqElEQVQ4y62TvUtbURjGf+fek2vQpMF2ED9QkfpR6VLaDoIEF0UKWQRBQ+yQP6GDU0Xw4y/obOgg6dDSJVS61MlBcXFQB6M1BsF+IES9NnrzcRy8xpvrBwH7bOflfc553+d5jsCF9tiRDwgBEaDXLi8B80AiGQ2Yzn7hIo8Cce5HOBkNfLo6aA7ydAVkgLjdez3BrS8rRbBJEmyU+AyBVVDE1i1SJ6psEmHvfOLktj0SjL/2snKQx8wpNg+LBJt0RjoN+j6bqOvN/ZotWAldtYK5gWpmV84YbPUw2ePlb7bI73+Kep+OLFONkGarXcK7l16+7+V57BW8qJMs7Ob5k4VQm4fVXzlyquyGiHRYBcC+WWQxnSP63AAgtn7O0FNJ9xOd0W+nbkF7pbsytXxOQw30N0t2MgX6Wzy8qtMJL5zy81jdsETaIXnjLL7trkLqGl+2svxI5/mwZt1l6ZJmJ6yEGqkYbveQOioQ2yiz7TbMa0DCWRnuMPBXaXzcsJx23YWEZmc7fJkqxdgzg8xZka/bFhVE2hSuKL+nMswko4GJ//KZxEO/8wVmfpjJTWeCTQAAAABJRU5ErkJggg==) 2px 2px no-repeat, linear-gradient(var(--color-pushover_button-gradient-top), var(--color-pushover_button-gradient-bottom));
+	border: 1px solid var(--color-pushover_button-border);
 	border-radius: 3px;
-	color: #333;
+	color: var(--color-pushover_button);
 	display: inline-block;
 	font: 11px/18px "Helvetica Neue",Arial,sans-serif;
 	font-weight: bold;
@@ -1363,7 +1464,7 @@ div.flash-success h2 {
 	padding-left: 20px;
 	padding-right: 5px;
 	overflow: hidden;
-	text-shadow: 0px 1px 0px rgba(255, 255, 255, 0.5);
+	text-shadow: 0px 1px 0px var(--color-pushover_button-text-shadow);
 	text-decoration: none;
 	vertical-align: middle;
 }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -20,8 +20,6 @@
 	--opacity-contrast-6: 67%;
 	--opacity-contrast-5: 63%;
 	--opacity-contrast-4-5: 59%; /* WCAG AA minimum 4.5:1 text contrast */
-	--opacity-contrast-3-5: 50%;
-	--opacity-contrast-2-75: 41%;
 
 	--opacity-gradient-lit: 0%;
 	--opacity-gradient-shadowed: 13%;
@@ -84,8 +82,6 @@
 		--opacity-contrast-6: 69%;
 		--opacity-contrast-5: 64%;
 		--opacity-contrast-4-5: 61%; /* WCAG AA minimum 4.5:1 text contrast */
-		--opacity-contrast-3-5: 54%;
-		--opacity-contrast-2-75: 46%;
 
 		--opacity-gradient-lit: 13%;
 		--opacity-gradient-shadowed: 3%;
@@ -155,8 +151,6 @@ html {
 	--color-fg-contrast-6: rgba(var(--palette-fg), var(--opacity-contrast-6));
 	--color-fg-contrast-5: rgba(var(--palette-fg), var(--opacity-contrast-5));
 	--color-fg-contrast-4-5: rgba(var(--palette-fg), var(--opacity-contrast-4-5));
-	--color-fg-contrast-3-5: rgba(var(--palette-fg), var(--opacity-contrast-3-5));
-	--color-fg-contrast-2-75: rgba(var(--palette-fg), var(--opacity-contrast-2-75));
 
 	--color-fg-gradient-lit: rgba(var(--palette-fg), var(--opacity-gradient-lit));
 	--color-fg-gradient-shadowed: rgba(var(--palette-fg), var(--opacity-gradient-shadowed)); /* d7d7d7 */
@@ -496,7 +490,7 @@ div#footer {
 	padding-right: 10px;
 }
 div#footer a {
-	color: var(--color-fg-contrast-3-5);
+	color: var(--color-fg-contrast-4-5);
 	text-decoration: none;
 	padding-left: 0.75em;
 }
@@ -565,7 +559,7 @@ div.voters {
 }
 
 div.voters div.score {
-	color: var(--color-fg-contrast-2-75);
+	color: var(--color-fg-contrast-4-5);
 	font-size: 9pt;
 	margin-top: 1px;
 	margin-bottom: -3px;
@@ -711,7 +705,7 @@ li input.comment_folder_button {
 li .comment_folder {
 	display: inline-block;
 	font-size: 9pt;
-	color: var(--color-fg-contrast-2-75);
+	color: var(--color-fg-contrast-4-5);
 	letter-spacing: 0.1em;
 	width: 1.5em;
  	cursor: pointer;
@@ -1024,7 +1018,7 @@ div.markdown_help_label {
 	float: right;
 	font-size: 9pt;
 	line-height: 2em;
-	color: var(--color-fg-contrast-2-75);
+	color: var(--color-fg-contrast-4-5);
 	text-decoration: underline;
 	cursor: pointer;
 }
@@ -1419,7 +1413,7 @@ div.flash-success h2 {
 
 .select2-container .select2-results li em {
 	background: none;
-	color: var(--color-fg-contrast-2-75);
+	color: var(--color-fg-contrast-4-5);
 	font-style: italic;
 	padding-left: 0.5em;
 }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -56,9 +56,10 @@
 
 	--color-na: gray;
 
-    --color-header: #777777;
-    --color-header-lobsters: #333333;
     --color-header-title: #333333;
+    --color-header-link: #777777;
+    --color-header-link-cur_url: #333333;
+	--color-header-link-new_messages: #ac130d;
 
     --color-markdown_help-background: #f4f4f4;
     --color-markdown_help-border: #e0e0e0;
@@ -69,8 +70,6 @@
     --color-flag_why-background-hover: #eeeeee;
     --color-flag_why-background-cancel: #eeeeee;
 	--color-flag_why-border: #ccc;
-
-	--color-new_messages: #ac130d;
 
 	--color-footer-link: #aaa;
 
@@ -187,9 +186,10 @@
     --color-tag_meta-background: #eee;
     --color-tag_meta-border: #c8c8c8;
 
-    --color-header: #777777;
-    --color-header-lobsters: #aaaaaa;
     --color-header-title: #aaaaaa;
+    --color-header-link: #777777;
+    --color-header-link-cur_url: #aaaaaa;
+	--color-header-link-new_messages: #ac130d;
 
     --color-markdown_help-border: #777777;
     --color-markdown_help-background: #222222;
@@ -483,7 +483,7 @@ div#inside {
 }
 
 .headerlinks a {
-	color: var(--color-header);
+	color: var(--color-header-link);
 	text-decoration: none;
 	padding-right: 0.75em;
 }
@@ -499,11 +499,11 @@ div#inside {
 }
 
 #header a.cur_url {
-	color: var(--color-header-lobsters);
+	color: var(--color-header-link-cur_url);
 }
 
 #header a.new_messages {
-	color: var(--color-new_messages);
+	color: var(--color-header-link-new_messages);
 }
 
 div#leader {

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -9,7 +9,7 @@
 :root {
 	/* main monochrome */
 	--palette-bg: 254, 254, 254;
-	--palette-fg: 0, 0, 0;
+	--palette-fg: 51, 51, 51;
 	--palette-light: 255, 255, 255;
 	--palette-shadow: 0, 0, 0;
 
@@ -128,17 +128,18 @@ html {
 	--color-bg: rgb(var(--palette-bg));
 	--color-bg-50: rgba(var(--palette-bg), 50%);
 
-	--color-fg: rgba(var(--palette-fg), 80%); /* primary text */
-	--color-fg-75: rgba(var(--palette-fg), 75%); /* links in flash banners */
-	--color-fg-67: rgba(var(--palette-fg), 67%); /* most text in a box */
-	--color-fg-60: rgba(var(--palette-fg), 60%); /* table page links */
-	--color-fg-53: rgba(var(--palette-fg), 53%); /* uncolored text links */
-	--color-fg-50: rgba(var(--palette-fg), 50%); /* disabled, expired */
-	--color-fg-47: rgba(var(--palette-fg), 47%); /* byline */
-	--color-fg-40: rgba(var(--palette-fg), 40%); /* footer link */
-	--color-fg-33: rgba(var(--palette-fg), 33%); /* faint text */
+	/* c1c1c1 on dark mode. 88% gives d9d9d9, same contrast as light mode. */
+	--color-fg: rgb(var(--palette-fg)); /* 272727, 14.90, 272727, 14.90, primary text */
+	--color-fg-75: rgba(var(--palette-fg), 94%); /* 313131, 12.87, 313131, 13.03, links in flash banners */
+	--color-fg-67: rgba(var(--palette-fg), 83%); /* 444444, 9.75, 444444, 9.75, most text in a box */
+	--color-fg-60: rgba(var(--palette-fg), 75%); /* 545454, 7.60, 545454, 7.60, table page links*/
+	--color-fg-53: rgba(var(--palette-fg), 67%); /* 646464, 5.85, 636363, 5.97, uncolored text links */
+	--color-fg-50: rgba(var(--palette-fg), 63%); /* 6d6d6d, 5.12, 6b6b6b, 5.29, disabled, expired */
+	--color-fg-47: rgba(var(--palette-fg), 58%); /* 767676, 4.49!, 767676, 4.56, byline */
+	--color-fg-40: rgba(var(--palette-fg), 50%); /* 888888, 3.55!, 868686, 3.60!, footer link */
+	--color-fg-33: rgba(var(--palette-fg), 41%); /* 9a9a9a, 2.78!, 9a9a9a, 2.79!, faint text */
 	--color-fg-gradient-lit: rgba(var(--palette-fg), var(--opacity-gradient-lit));
-	--color-fg-gradient-shadowed: rgba(var(--palette-fg), var(--opacity-gradient-shadowed));
+	--color-fg-gradient-shadowed: rgba(var(--palette-fg), var(--opacity-gradient-shadowed)); /* d7d7d7 */
 
 	--color-light-25: rgba(var(--palette-light), 25%);
 

--- a/app/assets/stylesheets/local/lobsters.css
+++ b/app/assets/stylesheets/local/lobsters.css
@@ -1,10 +1,29 @@
+:root {
+    --color-link-tag-special: #555555;
+    --color-link-tag-special-background: #f9ddde;
+    --color-link-tag-special-border: #f0b2b8;
+
+    --color-link-tag-sysop: #555555;
+}
+
+@media (prefers-color-scheme: dark) {
+:root {
+    --color-link-tag-special: #555555;
+    --color-link-tag-special-background: #f9ddde;
+    --color-link-tag-special-border: #f0b2b8;
+
+    --color-link-tag-sysop: #555555;
+}
+}
+
 li .byline a.story_has_suggestions {
 	color: #bd6060;
 }
 
 a.tag_announce, a.tag_ask, a.tag_show, a.tag_interview {
-	background-color: #f9ddde;
-	border-color: #f0b2b8;
+	background-color: var(--color-link-tag-special-background);
+	border-color: var(--color-link-tag-special-border);
+    color: var(--color-link-tag-special);
 }
 
 span.hat_openbsd_developer span.crown {
@@ -14,6 +33,7 @@ span.hat_openbsd_developer span.crown {
 
 span.hat_sysop {
 	border-color: #bbb2b2;
+    color: var(--color-link-tag-sysop);
 }
 span.hat_sysop span.crown {
 	background-color: #ddc7c7;

--- a/app/assets/stylesheets/local/lobsters.css
+++ b/app/assets/stylesheets/local/lobsters.css
@@ -1,37 +1,29 @@
 :root {
-    --color-link-tag-special: #555555;
-    --color-link-tag-special-background: #f9ddde;
-    --color-link-tag-special-border: #f0b2b8;
+    --color-lobsters-link-tag-special: #555555;
+    --color-lobsters-link-tag-special-background: #f9ddde;
+    --color-lobsters-link-tag-special-border: #f0b2b8;
 
-    --color-hat-sysop: #555555;
-	--color-hat-sysop-border: #bbb2b2;
-	--color-hat-sysop-crown-background: #ddc7c7;
+    --color-lobsters-hat-sysop: #555555;
+	--color-lobsters-hat-sysop-border: #bbb2b2;
+	--color-lobsters-hat-sysop-crown-background: #ddc7c7;
 
-	--color-byline-has_suggestions: #bd6060;
+	--color-lobsters-byline-has_suggestions: #bd6060;
 }
 
 @media (prefers-color-scheme: dark) {
-:root {
-    --color-link-tag-special: #555555;
-    --color-link-tag-special-background: #f9ddde;
-    --color-link-tag-special-border: #f0b2b8;
-
-    --color-hat-sysop: #555555;
-	--color-hat-sysop-border: #bbb2b2;
-	--color-hat-sysop-crown-background: #ddc7c7;
-
-	--color-byline-has_suggestions: #bd6060;
-}
+	:root {
+		/* todo */
+	}
 }
 
 li .byline a.story_has_suggestions {
-	color: var(--color-byline-has_suggestions);
+	color: var(--color-lobsters-byline-has_suggestions);
 }
 
 a.tag_announce, a.tag_ask, a.tag_show, a.tag_interview {
-	background-color: var(--color-link-tag-special-background);
-	border-color: var(--color-link-tag-special-border);
-    color: var(--color-link-tag-special);
+	background-color: var(--color-lobsters-link-tag-special-background);
+	border-color: var(--color-lobsters-link-tag-special-border);
+    color: var(--color-lobsters-link-tag-special);
 }
 
 span.hat_openbsd_developer span.crown {
@@ -40,11 +32,11 @@ span.hat_openbsd_developer span.crown {
 }
 
 span.hat_sysop {
-	border-color: var(--color-hat-sysop-border);
-    color: var(--color-hat-sysop);
+	border-color: var(--color-lobsters-hat-sysop-border);
+    color: var(--color-lobsters-hat-sysop);
 }
 span.hat_sysop span.crown {
-	background-color: var(--color-hat-sysop-crown-background);
+	background-color: var(--color-lobsters-hat-sysop-crown-background);
 }
 
 #l_holder {

--- a/app/assets/stylesheets/local/lobsters.css
+++ b/app/assets/stylesheets/local/lobsters.css
@@ -1,4 +1,4 @@
-:root {
+html {
     --color-lobsters-link-tag-special: #555555;
     --color-lobsters-link-tag-special-background: #f9ddde;
     --color-lobsters-link-tag-special-border: #f0b2b8;
@@ -8,12 +8,6 @@
 	--color-lobsters-hat-sysop-crown-background: #ddc7c7;
 
 	--color-lobsters-byline-has_suggestions: #bd6060;
-}
-
-@media (prefers-color-scheme: dark) {
-	:root {
-		/* todo */
-	}
 }
 
 li .byline a.story_has_suggestions {

--- a/app/assets/stylesheets/local/lobsters.css
+++ b/app/assets/stylesheets/local/lobsters.css
@@ -17,8 +17,8 @@
 		--color-lobsters-tag-special-bg: #3b1719;
 		--color-lobsters-tag-special-border: #611a21;
 
-		--color-lobsters-hat-sysop-crown-fill: #271d1d;
-		--color-lobsters-hat-sysop-brim-stroke: #4e3939;
+		--color-lobsters-hat-sysop-crown-fill: #362727;
+		--color-lobsters-hat-sysop-brim-stroke: #241a1a;
 	}
 }
 

--- a/app/assets/stylesheets/local/lobsters.css
+++ b/app/assets/stylesheets/local/lobsters.css
@@ -1,23 +1,35 @@
-html {
-    --color-lobsters-link-tag-special: #555555;
-    --color-lobsters-link-tag-special-background: #f9ddde;
-    --color-lobsters-link-tag-special-border: #f0b2b8;
+/* light mode */
+:root {
+	--color-lobsters-fg-has-suggestions: #bd6060;
 
-    --color-lobsters-hat-sysop: #555555;
-	--color-lobsters-hat-sysop-border: #bbb2b2;
-	--color-lobsters-hat-sysop-crown-background: #ddc7c7;
+	--color-lobsters-tag-special-bg: #f9ddde;
+	--color-lobsters-tag-special-border: #f0b2b8;
 
-	--color-lobsters-byline-has_suggestions: #bd6060;
+	--color-lobsters-hat-sysop-crown-fill: #ddc7c7;
+	--color-lobsters-hat-sysop-brim-stroke: #bbb2b2;
+}
+
+/* dark mode */
+@media (prefers-color-scheme: dark) {
+	:root {
+		--color-lobsters-fg-has-suggestions: #df7171;
+
+		--color-lobsters-tag-special-bg: #3b1719;
+		--color-lobsters-tag-special-border: #611a21;
+
+		--color-lobsters-hat-sysop-crown-fill: #271d1d;
+		--color-lobsters-hat-sysop-brim-stroke: #4e3939;
+	}
 }
 
 li .byline a.story_has_suggestions {
-	color: var(--color-lobsters-byline-has_suggestions);
+	color: var(--color-lobsters-fg-has-suggestions);
 }
 
 a.tag_announce, a.tag_ask, a.tag_show, a.tag_interview {
-	background-color: var(--color-lobsters-link-tag-special-background);
-	border-color: var(--color-lobsters-link-tag-special-border);
-    color: var(--color-lobsters-link-tag-special);
+	background-color: var(--color-lobsters-tag-special-bg);
+	border-color: var(--color-lobsters-tag-special-border);
+	color: var(--color-fg-67);
 }
 
 span.hat_openbsd_developer span.crown {
@@ -26,11 +38,11 @@ span.hat_openbsd_developer span.crown {
 }
 
 span.hat_sysop {
-	border-color: var(--color-lobsters-hat-sysop-border);
-    color: var(--color-lobsters-hat-sysop);
+	border-color: var(--color-lobsters-hat-sysop-brim-stroke);
+	color: var(--color-fg-67);
 }
 span.hat_sysop span.crown {
-	background-color: var(--color-lobsters-hat-sysop-crown-background);
+	background-color: var(--color-lobsters-hat-sysop-crown-fill);
 }
 
 #l_holder {

--- a/app/assets/stylesheets/local/lobsters.css
+++ b/app/assets/stylesheets/local/lobsters.css
@@ -3,7 +3,11 @@
     --color-link-tag-special-background: #f9ddde;
     --color-link-tag-special-border: #f0b2b8;
 
-    --color-link-tag-sysop: #555555;
+    --color-hat-sysop: #555555;
+	--color-hat-sysop-border: #bbb2b2;
+	--color-hat-sysop-crown-background: #ddc7c7;
+
+	--color-byline-has_suggestions: #bd6060;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -12,12 +16,16 @@
     --color-link-tag-special-background: #f9ddde;
     --color-link-tag-special-border: #f0b2b8;
 
-    --color-link-tag-sysop: #555555;
+    --color-hat-sysop: #555555;
+	--color-hat-sysop-border: #bbb2b2;
+	--color-hat-sysop-crown-background: #ddc7c7;
+
+	--color-byline-has_suggestions: #bd6060;
 }
 }
 
 li .byline a.story_has_suggestions {
-	color: #bd6060;
+	color: var(--color-byline-has_suggestions);
 }
 
 a.tag_announce, a.tag_ask, a.tag_show, a.tag_interview {
@@ -32,11 +40,11 @@ span.hat_openbsd_developer span.crown {
 }
 
 span.hat_sysop {
-	border-color: #bbb2b2;
-    color: var(--color-link-tag-sysop);
+	border-color: var(--color-hat-sysop-border);
+    color: var(--color-hat-sysop);
 }
 span.hat_sysop span.crown {
-	background-color: #ddc7c7;
+	background-color: var(--color-hat-sysop-crown-background);
 }
 
 #l_holder {

--- a/app/assets/stylesheets/mobile.css
+++ b/app/assets/stylesheets/mobile.css
@@ -1,15 +1,22 @@
 @media only screen and (max-width: 480px) {
-	html {
-		--color-mobile-header-background: #eee;
-		--color-mobile-header-border-bottom: #ccc;
+	/* light mode */
+	:root {
+		--color-mobile-story-border: #e0e0e0;
+		--color-mobile-story-liner-bg: #fbfbfb;
+		--color-mobile-story-comments-bg: #e8e8e8;
+		--color-mobile-story-comments-bubble-fill: #ccc;
+		--color-mobile-story-comments-bubble-fill-zero: #d8d8d8;
+	}
 
-		--color-mobile-story-border-bottom: #e0e0e0;
-		--color-mobile-story-story_liner-background: #fbfbfb;
-		--color-mobile-story-mobile_comments-background: #e8e8e8;
-		--color-mobile-story-mobile_comments-bubble: #ccc;
-		--color-mobile-story-mobile_comments: #333;
-		--color-mobile-story-mobile_comments-zero-bubble: #d8d8d8;
-		--color-mobile-story-mobile_comments-zero: #999;
+	/* dark mode */
+	@media (prefers-color-scheme: dark) {
+		:root {
+			--color-mobile-story-border: #141414;
+			--color-mobile-story-liner-bg: #000;
+			--color-mobile-story-comments-bg: #080808;
+			--color-mobile-story-comments-bubble-fill: #141414;
+			--color-mobile-story-comments-bubble-fill-zero: #0e0e0e;
+		}
 	}
 
 	html {
@@ -25,8 +32,8 @@
 	div#leader {
 		margin: 0;
 		padding: 8px 5px;
-		background-color: var(--color-mobile-header-background);
-		border-bottom: 1px solid var(--color-mobile-header-border-bottom);
+		background-color: var(--color-box-bg-shaded);
+		border-bottom: 1px solid var(--color-box-border);
 	}
 	div#leader {
 		padding: 8px;
@@ -138,18 +145,18 @@
 	}
 
 	ol.stories.list li.story {
-		border-bottom: 1px solid var(--color-mobile-story-border-bottom);
+		border-bottom: 1px solid var(--color-mobile-story-border);
 		display: table;
 	}
 	ol.stories.list li.story div.story_liner {
-		background-color: var(--color-mobile-story-story_liner-background);
+		background-color: var(--color-mobile-story-liner-bg);
 		display: table-cell;
 		padding-top: 0.5em;
 		padding-bottom: 0.75em;
 		width: 100%;
 	}
 	ol.stories.list li.story .mobile_comments {
-		background-color: var(--color-mobile-story-mobile_comments-background);
+		background-color: var(--color-mobile-story-comments-bg);
 		display: table-cell !important;
 		font-size: 11pt;
 		min-width: 40px;
@@ -160,7 +167,7 @@
 	ol.stories.list li.story .mobile_comments span:before {
 		border-style: solid;
 		border-width: 0px 6px 3px 0px;
-		border-color: var(--color-mobile-story-mobile_comments-bubble);
+		border-color: var(--color-mobile-story-comments-bubble-fill);
 		border-bottom-right-radius: 13px;
 		bottom: -10px;
 		content: "";
@@ -173,7 +180,7 @@
 	}
 	ol.stories.list li.story .mobile_comments span:after {
 		border-bottom-right-radius: 10px;
-		border-color: var(--color-mobile-story-mobile_comments-bubble);
+		border-color: var(--color-mobile-story-comments-bubble-fill);
 		border-style: solid;
 		border-width: 0px 3px 3px 0px;
 		bottom: -10px;
@@ -186,10 +193,10 @@
 		z-index: 10;
 	}
 	ol.stories.list li.story .mobile_comments span {
-		background-color: var(--color-mobile-story-mobile_comments-bubble);
-		border: 1px solid var(--color-mobile-story-mobile_comments-bubble);
+		background-color: var(--color-mobile-story-comments-bubble-fill);
+		border: 1px solid var(--color-mobile-story-comments-bubble-fill);
 		border-radius: 5px;
-		color: var(--color-mobile-story-mobile_comments);
+		color: var(--color-fg);
 		display: block;
 		font-size: 9pt;
 		margin: 0 0.5em;
@@ -202,13 +209,13 @@
 		outline: 0;
 	}
 	ol.stories.list li.story .mobile_comments.zero span {
-		background-color: var(--color-mobile-story-mobile_comments-zero-bubble);
-		color: var(--color-mobile-story-mobile_comments-zero);
+		background-color: var(--color-mobile-story-comments-bubble-fill-zero);
+		color: var(--color-fg-33);
 	}
 	ol.stories.list li.story .mobile_comments.zero span,
 	ol.stories.list li.story .mobile_comments.zero span:before,
 	ol.stories.list li.story .mobile_comments.zero span:after {
-		border-color: var(--color-mobile-story-mobile_comments-zero-bubble);
+		border-color: var(--color-mobile-story-comments-bubble-fill-zero);
 	}
 	ol.stories.list li.story .comments_label {
 		display: none;

--- a/app/assets/stylesheets/mobile.css
+++ b/app/assets/stylesheets/mobile.css
@@ -210,7 +210,7 @@
 	}
 	ol.stories.list li.story .mobile_comments.zero span {
 		background-color: var(--color-mobile-story-comments-bubble-fill-zero);
-		color: var(--color-fg-33);
+		color: var(--color-fg-contrast-2-75);
 	}
 	ol.stories.list li.story .mobile_comments.zero span,
 	ol.stories.list li.story .mobile_comments.zero span:before,

--- a/app/assets/stylesheets/mobile.css
+++ b/app/assets/stylesheets/mobile.css
@@ -1,4 +1,38 @@
 @media only screen and (max-width: 480px) {
+	:root {
+		--color-header-background: #eee;
+		--color-header-border-bottom: #ccc;
+
+		--color-upvoter-border-bottom-hover: #bbb;
+		--color-upvoter-border-bottom: #ac130d;
+
+		--color-story-border-bottom: #e0e0e0;
+		--color-story-story_liner-background: #fbfbfb;
+		--color-story-mobile_comments-background: #e8e8e8;
+		--color-story-mobile_comments-bubble: #ccc;
+		--color-story-mobile_comments: #333;
+		--color-story-mobile_comments-zero-bubble: #d8d8d8;
+		--color-story-mobile_comments-zero: #999;
+	}
+
+	@media (prefers-color-scheme: dark) {
+		:root {
+			--color-header-background: #eee;
+			--color-header-border-bottom: #ccc;
+
+			--color-upvoter-border-bottom-hover: #bbb;
+			--color-upvoter-border-bottom: #ac130d;
+
+			--color-story-border-bottom: #e0e0e0;
+			--color-story-story_liner-background: #fbfbfb;
+			--color-story-mobile_comments-background: #e8e8e8;
+			--color-story-mobile_comments-bubble: #ccc;
+			--color-story-mobile_comments: #333;
+			--color-story-mobile_comments-zero-bubble: #d8d8d8;
+			--color-story-mobile_comments-zero: #999;
+		}
+	}
+
 	html {
 		-webkit-text-size-adjust: none;
 	}
@@ -12,8 +46,8 @@
 	div#leader {
 		margin: 0;
 		padding: 8px 5px;
-		background-color: #eee;
-		border-bottom: 1px solid #ccc;
+		background-color: var(--color-header-background);
+		border-bottom: 1px solid var(--color-header-border-bottom);
 	}
 	div#leader {
 		padding: 8px;
@@ -114,10 +148,10 @@
 	/* explicitly reset color when not upvoted, since previously-upvoted arrow
 	 * will still be triggering :hover until next tap */
 	div.voters .upvoter:hover {
-		border-bottom-color: #bbb;
+		border-bottom-color: var(--color-upvoter-border-bottom-hover);
 	}
 	.upvoted div.voters .upvoter {
-		border-bottom-color: #ac130d;
+		border-bottom-color: var(--color-upvoter-border-bottom);
 	}
 
 	ol.stories.list {
@@ -125,18 +159,18 @@
 	}
 
 	ol.stories.list li.story {
-		border-bottom: 1px solid #e0e0e0;
+		border-bottom: 1px solid var(--color-story-border-bottom);
 		display: table;
 	}
 	ol.stories.list li.story div.story_liner {
-		background-color: #fbfbfb;
+		background-color: var(--color-story-story_liner-background);
 		display: table-cell;
 		padding-top: 0.5em;
 		padding-bottom: 0.75em;
 		width: 100%;
 	}
 	ol.stories.list li.story .mobile_comments {
-		background-color: #e8e8e8;
+		background-color: var(--color-story-mobile_comments-background);
 		display: table-cell !important;
 		font-size: 11pt;
 		min-width: 40px;
@@ -147,7 +181,7 @@
 	ol.stories.list li.story .mobile_comments span:before {
 		border-style: solid;
 		border-width: 0px 6px 3px 0px;
-		border-color: #ccc;
+		border-color: var(--color-story-mobile_comments-bubble);
 		border-bottom-right-radius: 13px;
 		bottom: -10px;
 		content: "";
@@ -160,7 +194,7 @@
 	}
 	ol.stories.list li.story .mobile_comments span:after {
 		border-bottom-right-radius: 10px;
-		border-color: #ccc;
+		border-color: var(--color-story-mobile_comments-bubble);
 		border-style: solid;
 		border-width: 0px 3px 3px 0px;
 		bottom: -10px;
@@ -173,10 +207,10 @@
 		z-index: 10;
 	}
 	ol.stories.list li.story .mobile_comments span {
-		background-color: #ccc;
-		border: 1px solid #ccc;
+		background-color: var(--color-story-mobile_comments-bubble);
+		border: 1px solid var(--color-story-mobile_comments-bubble);
 		border-radius: 5px;
-		color: #333;
+		color: var(--color-story-mobile_comments);
 		display: block;
 		font-size: 9pt;
 		margin: 0 0.5em;
@@ -189,16 +223,13 @@
 		outline: 0;
 	}
 	ol.stories.list li.story .mobile_comments.zero span {
-		color: gray;
-	}
-	ol.stories.list li.story .mobile_comments.zero span {
-		background-color: #d8d8d8;
-		color: #999;
+		background-color: var(--color-story-mobile_comments-zero-bubble);
+		color: var(--color-story-mobile_comments-zero);
 	}
 	ol.stories.list li.story .mobile_comments.zero span,
 	ol.stories.list li.story .mobile_comments.zero span:before,
 	ol.stories.list li.story .mobile_comments.zero span:after {
-		border-color: #d8d8d8;
+		border-color: var(--color-story-mobile_comments-zero-bubble);
 	}
 	ol.stories.list li.story .comments_label {
 		display: none;

--- a/app/assets/stylesheets/mobile.css
+++ b/app/assets/stylesheets/mobile.css
@@ -11,11 +11,11 @@
 	/* dark mode */
 	@media (prefers-color-scheme: dark) {
 		:root {
-			--color-mobile-story-border: #141414;
+			--color-mobile-story-border: #1c1c1c;
 			--color-mobile-story-liner-bg: #000;
-			--color-mobile-story-comments-bg: #080808;
-			--color-mobile-story-comments-bubble-fill: #141414;
-			--color-mobile-story-comments-bubble-fill-zero: #0e0e0e;
+			--color-mobile-story-comments-bg: #0c0c0c;
+			--color-mobile-story-comments-bubble-fill: #282828;
+			--color-mobile-story-comments-bubble-fill-zero: #1c1c1c;
 		}
 	}
 

--- a/app/assets/stylesheets/mobile.css
+++ b/app/assets/stylesheets/mobile.css
@@ -127,10 +127,10 @@
 	/* explicitly reset color when not upvoted, since previously-upvoted arrow
 	 * will still be triggering :hover until next tap */
 	div.voters .upvoter:hover {
-		border-bottom-color: var(--color-voters-upvoter-fill);
+		border-bottom-color: var(--color-fg-shape);
 	}
 	.upvoted div.voters .upvoter {
-		border-bottom-color: var(--color-voters-upvoter-fill-upvoted);
+		border-bottom-color: var(--color-fg-accent);
 	}
 
 	ol.stories.list {

--- a/app/assets/stylesheets/mobile.css
+++ b/app/assets/stylesheets/mobile.css
@@ -210,7 +210,7 @@
 	}
 	ol.stories.list li.story .mobile_comments.zero span {
 		background-color: var(--color-mobile-story-comments-bubble-fill-zero);
-		color: var(--color-fg-contrast-2-75);
+		color: var(--color-fg-contrast-4-5);
 	}
 	ol.stories.list li.story .mobile_comments.zero span,
 	ol.stories.list li.story .mobile_comments.zero span:before,

--- a/app/assets/stylesheets/mobile.css
+++ b/app/assets/stylesheets/mobile.css
@@ -1,29 +1,20 @@
 @media only screen and (max-width: 480px) {
 	:root {
-		--color-header-background: #eee;
-		--color-header-border-bottom: #ccc;
+		--color-mobile-header-background: #eee;
+		--color-mobile-header-border-bottom: #ccc;
 
-		--color-story-border-bottom: #e0e0e0;
-		--color-story-story_liner-background: #fbfbfb;
-		--color-story-mobile_comments-background: #e8e8e8;
-		--color-story-mobile_comments-bubble: #ccc;
-		--color-story-mobile_comments: #333;
-		--color-story-mobile_comments-zero-bubble: #d8d8d8;
-		--color-story-mobile_comments-zero: #999;
+		--color-mobile-story-border-bottom: #e0e0e0;
+		--color-mobile-story-story_liner-background: #fbfbfb;
+		--color-mobile-story-mobile_comments-background: #e8e8e8;
+		--color-mobile-story-mobile_comments-bubble: #ccc;
+		--color-mobile-story-mobile_comments: #333;
+		--color-mobile-story-mobile_comments-zero-bubble: #d8d8d8;
+		--color-mobile-story-mobile_comments-zero: #999;
 	}
 
 	@media (prefers-color-scheme: dark) {
 		:root {
-			--color-header-background: #eee;
-			--color-header-border-bottom: #ccc;
-
-			--color-story-border-bottom: #e0e0e0;
-			--color-story-story_liner-background: #fbfbfb;
-			--color-story-mobile_comments-background: #e8e8e8;
-			--color-story-mobile_comments-bubble: #ccc;
-			--color-story-mobile_comments: #333;
-			--color-story-mobile_comments-zero-bubble: #d8d8d8;
-			--color-story-mobile_comments-zero: #999;
+			/* todo */
 		}
 	}
 
@@ -40,8 +31,8 @@
 	div#leader {
 		margin: 0;
 		padding: 8px 5px;
-		background-color: var(--color-header-background);
-		border-bottom: 1px solid var(--color-header-border-bottom);
+		background-color: var(--color-mobile-header-background);
+		border-bottom: 1px solid var(--color-mobile-header-border-bottom);
 	}
 	div#leader {
 		padding: 8px;
@@ -153,18 +144,18 @@
 	}
 
 	ol.stories.list li.story {
-		border-bottom: 1px solid var(--color-story-border-bottom);
+		border-bottom: 1px solid var(--color-mobile-story-border-bottom);
 		display: table;
 	}
 	ol.stories.list li.story div.story_liner {
-		background-color: var(--color-story-story_liner-background);
+		background-color: var(--color-mobile-story-story_liner-background);
 		display: table-cell;
 		padding-top: 0.5em;
 		padding-bottom: 0.75em;
 		width: 100%;
 	}
 	ol.stories.list li.story .mobile_comments {
-		background-color: var(--color-story-mobile_comments-background);
+		background-color: var(--color-mobile-story-mobile_comments-background);
 		display: table-cell !important;
 		font-size: 11pt;
 		min-width: 40px;
@@ -175,7 +166,7 @@
 	ol.stories.list li.story .mobile_comments span:before {
 		border-style: solid;
 		border-width: 0px 6px 3px 0px;
-		border-color: var(--color-story-mobile_comments-bubble);
+		border-color: var(--color-mobile-story-mobile_comments-bubble);
 		border-bottom-right-radius: 13px;
 		bottom: -10px;
 		content: "";
@@ -188,7 +179,7 @@
 	}
 	ol.stories.list li.story .mobile_comments span:after {
 		border-bottom-right-radius: 10px;
-		border-color: var(--color-story-mobile_comments-bubble);
+		border-color: var(--color-mobile-story-mobile_comments-bubble);
 		border-style: solid;
 		border-width: 0px 3px 3px 0px;
 		bottom: -10px;
@@ -201,10 +192,10 @@
 		z-index: 10;
 	}
 	ol.stories.list li.story .mobile_comments span {
-		background-color: var(--color-story-mobile_comments-bubble);
-		border: 1px solid var(--color-story-mobile_comments-bubble);
+		background-color: var(--color-mobile-story-mobile_comments-bubble);
+		border: 1px solid var(--color-mobile-story-mobile_comments-bubble);
 		border-radius: 5px;
-		color: var(--color-story-mobile_comments);
+		color: var(--color-mobile-story-mobile_comments);
 		display: block;
 		font-size: 9pt;
 		margin: 0 0.5em;
@@ -217,13 +208,13 @@
 		outline: 0;
 	}
 	ol.stories.list li.story .mobile_comments.zero span {
-		background-color: var(--color-story-mobile_comments-zero-bubble);
-		color: var(--color-story-mobile_comments-zero);
+		background-color: var(--color-mobile-story-mobile_comments-zero-bubble);
+		color: var(--color-mobile-story-mobile_comments-zero);
 	}
 	ol.stories.list li.story .mobile_comments.zero span,
 	ol.stories.list li.story .mobile_comments.zero span:before,
 	ol.stories.list li.story .mobile_comments.zero span:after {
-		border-color: var(--color-story-mobile_comments-zero-bubble);
+		border-color: var(--color-mobile-story-mobile_comments-zero-bubble);
 	}
 	ol.stories.list li.story .comments_label {
 		display: none;

--- a/app/assets/stylesheets/mobile.css
+++ b/app/assets/stylesheets/mobile.css
@@ -3,9 +3,6 @@
 		--color-header-background: #eee;
 		--color-header-border-bottom: #ccc;
 
-		--color-upvoter-border-bottom-hover: #bbb;
-		--color-upvoter-border-bottom: #ac130d;
-
 		--color-story-border-bottom: #e0e0e0;
 		--color-story-story_liner-background: #fbfbfb;
 		--color-story-mobile_comments-background: #e8e8e8;
@@ -19,9 +16,6 @@
 		:root {
 			--color-header-background: #eee;
 			--color-header-border-bottom: #ccc;
-
-			--color-upvoter-border-bottom-hover: #bbb;
-			--color-upvoter-border-bottom: #ac130d;
 
 			--color-story-border-bottom: #e0e0e0;
 			--color-story-story_liner-background: #fbfbfb;
@@ -148,10 +142,10 @@
 	/* explicitly reset color when not upvoted, since previously-upvoted arrow
 	 * will still be triggering :hover until next tap */
 	div.voters .upvoter:hover {
-		border-bottom-color: var(--color-upvoter-border-bottom-hover);
+		border-bottom-color: var(--color-voters-upvoter-fill);
 	}
 	.upvoted div.voters .upvoter {
-		border-bottom-color: var(--color-upvoter-border-bottom);
+		border-bottom-color: var(--color-voters-upvoter-fill-upvoted);
 	}
 
 	ol.stories.list {

--- a/app/assets/stylesheets/mobile.css
+++ b/app/assets/stylesheets/mobile.css
@@ -1,5 +1,5 @@
 @media only screen and (max-width: 480px) {
-	:root {
+	html {
 		--color-mobile-header-background: #eee;
 		--color-mobile-header-border-bottom: #ccc;
 
@@ -10,12 +10,6 @@
 		--color-mobile-story-mobile_comments: #333;
 		--color-mobile-story-mobile_comments-zero-bubble: #d8d8d8;
 		--color-mobile-story-mobile_comments-zero: #999;
-	}
-
-	@media (prefers-color-scheme: dark) {
-		:root {
-			/* todo */
-		}
 	}
 
 	html {

--- a/app/views/home/about.html.erb
+++ b/app/views/home/about.html.erb
@@ -318,21 +318,6 @@
   </p></li>
 
   <li><p>
-    If you prefer to read Lobsters on a dark background instead of a light one, there are a few options. You could install the
-    <a href="https://darkreader.org/">Dark Reader extension</a>;
-    or an extension to add your own CSS to sites like <a href="https://add0n.com/stylus.html">Stylus</a> or <a href="https://github.com/openstyles/stylus/wiki/Usercss">UserCSS</a> (<a href="https://en.wikipedia.org/wiki/Stylish#Privacy_issues">never Stylish</a>). Themes:
-    <a href="https://openusercss.org/theme/5cc5ad28ad27da0c0016cf3c">1</a>
-    <a href="https://openusercss.org/theme/5cc5ab1ead27da0c0016cf3a">2</a>
-    <a href="https://openusercss.org/theme/5cc5aeb3ad27da0c0016cf3d">3</a>
-    <a href="https://openusercss.org/theme/5cc5ac10ad27da0c0016cf3b">4</a>.
-    Discussion:
-    <a href="https://github.com/lobsters/lobsters/issues/404">1</a>
-    <a href="https://github.com/lobsters/lobsters/issues/637">2</a>
-    <a href="https://lobste.rs/s/om839j/dark_light_mode">3</a>
-    <a href="https://lobste.rs/s/iaajwb/dark_theme_for_lobsters">4</a>
-  </p></li>
-
-  <li><p>
     If you prefer the article links or comment links to open a new tab instead of navigating in your current tab you can add
     <a href="https://greasyfork.org/en/scripts/392307-lobste-rs-open-in-new-tab">a client-side script</a> to do so.
     (<a href="https://lobste.rs/s/0g48hl/open_links_articles_new_tab">Discussion</a>)


### PR DESCRIPTION
Based on @soc's work in #823. Closes #637.

Dark mode is activated by the `prefers-color-scheme: dark` media query, usually when the operating system's UI is set to dark mode. An overriding user setting is out of scope for now.

I tried to minimize the number of distinct values that must be specified for each display mode. The tradeoff is that most foreground text is rendered with alpha blending via `rgba()`. That's about the only way you can get many apparent brightnesses of a base color without having more explicit colors per display mode or adding a dependency like Sass. I'm particularly interested in whether there is a performance impact on your browser.

As for palette choices, I followed my understanding of [dark mode guidance for macOS](https://developer.apple.com/videos/play/wwdc2018/210/?time=345). I went with pure black for the background in order to accommodate users whose eyes have already adjusted to a dark room and then get the most potential contrast per lumen. Foreground colors like blue links and lobster red are a little brighter and paler for contrast. Inset areas like form fields are a bit brighter than the background, which is also true of light mode. By contrast, while buttons darken on hover in light mode, they brighten in dark mode.

#### Samples

![light](https://user-images.githubusercontent.com/602569/134824867-23568d87-c7e3-4ee5-b5f1-a4db20cd69ea.png) ![dark](https://user-images.githubusercontent.com/602569/134824869-c5ff7576-5ede-4e9d-ab69-2c4033e54e8b.png)

![mobile-light](https://user-images.githubusercontent.com/602569/134824873-283f287b-e6d0-4916-9140-ec5d163c82f0.jpg) ![mobile-dark](https://user-images.githubusercontent.com/602569/134824871-67a567de-c4a7-4ede-b94b-b91e9bc21260.jpg)

#### Effects on light mode

I did change a few colors in light mode because it made sense at the time:
- Blue background of notice flash banner made paler like error and success cases
- Paginating footer number buttons and markdown help box set to reuse colors from regular form fields and buttons
- Form field placeholders given a little bit more contrast, closer to textarea placeholder contrast

Finally, in pursuit of WCAG AA contrast, I increased contrast on all text I could find that had a contrast ratio beneath 4.5:1. (284d1da)

Before: ![footer-before](https://user-images.githubusercontent.com/602569/134824935-7a02cca5-2a49-4d5e-a640-a7dbecc8bf9d.png) ![vote-count-before](https://user-images.githubusercontent.com/602569/134824939-ec0b4f4b-364b-40de-8fd7-66a74f788d6e.png)

After: ![footer-after](https://user-images.githubusercontent.com/602569/134824950-52fdb6bb-b2f1-48f0-b79d-774f84b7236d.png) ![vote-count-after](https://user-images.githubusercontent.com/602569/134824952-d06cab53-bb6a-4138-ac61-deed75d034f2.png)