### PR TITLE
Dark mode revision

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -14,6 +14,7 @@
 	--palette-shadow: 0, 0, 0;
 
 	/* blends of foreground color over the background */
+	--opacity-contrast-15: 100%;
 	--opacity-contrast-13: 94%;
 	--opacity-contrast-10: 84%;
 	--opacity-contrast-7-5: 75%;
@@ -76,6 +77,7 @@
 		--palette-shadow: 0, 0, 0;
 
 		/* blends of foreground color over the background */
+		--opacity-contrast-15: 100%;
 		--opacity-contrast-13: 95%;
 		--opacity-contrast-10: 85%;
 		--opacity-contrast-7-5: 76%;
@@ -144,7 +146,7 @@ html {
 	--color-bg: rgb(var(--palette-bg));
 	--color-bg-50: rgba(var(--palette-bg), 50%);
 
-	--color-fg: rgb(var(--palette-fg)); /* primary text */
+	--color-fg: rgba(var(--palette-fg), var(--opacity-contrast-15)); /* primary text */
 	--color-fg-contrast-13: rgba(var(--palette-fg), var(--opacity-contrast-13));
 	--color-fg-contrast-10: rgba(var(--palette-fg), var(--opacity-contrast-10));
 	--color-fg-contrast-7-5: rgba(var(--palette-fg), var(--opacity-contrast-7-5));

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -121,9 +121,9 @@
 		--color-tag-meta-bg: #2c2c2c;
 		--color-tag-meta-border: #484848;
 
-		--color-hat-crown-fill: #333;
-		--color-hat-crown-stroke: #181818;
-		--color-hat-brim-stroke: #222;
+		--color-hat-crown-fill: #3b3b3b;
+		--color-hat-crown-stroke: #202020;
+		--color-hat-brim-stroke: #2a2a2a;
 
 		--color-flash-bg-error: #451714;
 		--color-flash-bg-success: #273820;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -100,19 +100,19 @@
 		--palette-fg-shape: 80, 80, 80;
 
 		/* explicit view colors */
-		--color-box-bg: #080808;
-		--color-box-bg-shaded: #141414;
-		--color-box-border: #242424;
+		--color-box-bg: #141414;
+		--color-box-bg-shaded: #202020;
+		--color-box-border: #303030;
 		--color-box-border-focus: #808080;
 
-		--color-button-bg: #0c0c0c;
-		--color-button-bg-shaded: #181818;
+		--color-button-bg: #181818;
+		--color-button-bg-shaded: #242424;
 
-		--color-table-header-bg: #1d1d1d;
-		--color-table-header-border: #373737;
-		--color-table-row-bg-even: #0f0f0f;
-		--color-table-row-bg-odd: #121212;
-		--color-table-row-border: #1d1d1d;
+		--color-table-header-bg: #262626;
+		--color-table-header-border: #404040;
+		--color-table-row-bg-even: #181818;
+		--color-table-row-bg-odd: #1b1b1b;
+		--color-table-row-border: #262626;
 
 		--color-tag-bg: #3b320d;
 		--color-tag-border: #665501;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -93,8 +93,8 @@
 		--palette-bg-accent: 253, 78, 72; /* behind dark text */
 		--palette-bg-target: 27, 24, 11;
 
-		--palette-fg-link: 91, 145, 255;
-		--palette-fg-link-visited: 91, 145, 255;
+		--palette-fg-link: 138, 177, 255;
+		--palette-fg-link-visited: 79, 138, 255;
 		--palette-fg-accent: 207, 54, 49; /* red as in lobste.rs */
 		--palette-fg-negative: 190, 45, 45; /* red as in warning */
 		--palette-fg-affirmative: 42, 180, 42;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -30,6 +30,7 @@
 	--palette-bg-target: 255, 252, 215;
 
 	--palette-fg-link: 37, 98, 220;
+	--palette-fg-link-visited: 115, 149, 217;
 	--palette-fg-accent: 172, 19, 13; /* red as in lobste.rs */
 	--palette-fg-negative: 139, 0, 0; /* red as in warning */
 	--palette-fg-affirmative: 0, 128, 0;
@@ -93,6 +94,7 @@
 		--palette-bg-target: 27, 24, 11;
 
 		--palette-fg-link: 91, 145, 255;
+		--palette-fg-link-visited: 91, 145, 255;
 		--palette-fg-accent: 207, 54, 49; /* red as in lobste.rs */
 		--palette-fg-negative: 190, 45, 45; /* red as in warning */
 		--palette-fg-affirmative: 42, 180, 42;
@@ -168,7 +170,7 @@ html {
 	--color-bg-target: rgb(var(--palette-bg-target));
 
 	--color-fg-link: rgb(var(--palette-fg-link));
-	--color-fg-link-visited: rgba(var(--palette-fg-link), 67%);
+	--color-fg-link-visited: rgb(var(--palette-fg-link-visited));
 	--color-fg-accent: rgb(var(--palette-fg-accent));
 	--color-fg-negative: rgb(var(--palette-fg-negative));
 	--color-fg-affirmative: rgb(var(--palette-fg-affirmative));

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -77,8 +77,8 @@
 		--palette-shadow: 0, 0, 0;
 
 		/* blends of foreground color over the background */
-		--opacity-contrast-15: 100%;
-		--opacity-contrast-13: 95%;
+		--opacity-contrast-15: 85%; /* Contrast capped at 10:1 for dark mode */
+		--opacity-contrast-13: 85%; /* Contrast capped at 10:1 for dark mode */
 		--opacity-contrast-10: 85%;
 		--opacity-contrast-7-5: 76%;
 		--opacity-contrast-6: 69%;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -29,8 +29,8 @@
 	--palette-bg-accent: 172, 19, 13; /* behind light text */
 	--palette-bg-target: 255, 252, 215;
 
-	--palette-fg-link: 37, 98, 220;
-	--palette-fg-link-visited: 115, 149, 217;
+	--palette-fg-link: 28, 89, 209;
+	--palette-fg-link-visited: 95, 134, 212;
 	--palette-fg-accent: 172, 19, 13; /* red as in lobste.rs */
 	--palette-fg-negative: 139, 0, 0; /* red as in warning */
 	--palette-fg-affirmative: 0, 128, 0;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -71,16 +71,16 @@
 @media (prefers-color-scheme: dark) {
 	:root {
 		/* main monochrome */
-		--palette-bg: 0, 0, 0;
+		--palette-bg: 12, 12, 12;
 		--palette-fg: 225, 225, 225;
 		--palette-light: 255, 255, 255;
 		--palette-shadow: 0, 0, 0;
 
 		/* blends of foreground color over the background */
-		--opacity-contrast-15: 85%; /* Contrast capped at 10:1 for dark mode */
-		--opacity-contrast-13: 85%; /* Contrast capped at 10:1 for dark mode */
-		--opacity-contrast-10: 85%;
-		--opacity-contrast-7-5: 76%;
+		--opacity-contrast-15: 87%; /* Contrast capped at 10:1 for dark mode */
+		--opacity-contrast-13: 87%; /* Contrast capped at 10:1 for dark mode */
+		--opacity-contrast-10: 87%;
+		--opacity-contrast-7-5: 77%;
 		--opacity-contrast-6: 69%;
 		--opacity-contrast-5: 64%;
 		--opacity-contrast-4-5: 61%; /* WCAG AA minimum 4.5:1 text contrast */

--- a/app/assets/stylesheets/local/lobsters.css
+++ b/app/assets/stylesheets/local/lobsters.css
@@ -17,8 +17,8 @@
 		--color-lobsters-tag-special-bg: #3b1719;
 		--color-lobsters-tag-special-border: #611a21;
 
-		--color-lobsters-hat-sysop-crown-fill: #362727;
-		--color-lobsters-hat-sysop-brim-stroke: #241a1a;
+		--color-lobsters-hat-sysop-crown-fill: #3e2f2f;
+		--color-lobsters-hat-sysop-brim-stroke: #2c2222;
 	}
 }
 

--- a/app/assets/stylesheets/mobile.css
+++ b/app/assets/stylesheets/mobile.css
@@ -12,8 +12,8 @@
 	@media (prefers-color-scheme: dark) {
 		:root {
 			--color-mobile-story-border: #1c1c1c;
-			--color-mobile-story-liner-bg: #000;
-			--color-mobile-story-comments-bg: #0c0c0c;
+			--color-mobile-story-liner-bg: #0c0c0c;
+			--color-mobile-story-comments-bg: #101010;
 			--color-mobile-story-comments-bubble-fill: #282828;
 			--color-mobile-story-comments-bubble-fill-zero: #1c1c1c;
 		}


### PR DESCRIPTION
In response to the [bikeshed thread](https://lobste.rs/s/eg1n75/dark_mode) following #1026, this revision:

- Brightens the dark mode background color just a little, and box/table/hat elements to match.
- Caps dark mode text contrast at 10:1. This is most noticeable on body text which previously was about 15:1.
- Otherwise maintains the same contrast in all of dark mode's uncolored text.
- Closes #1030.
- Darkens the visited link color in light mode to hit WCAG AA minimum 4.5:1 contrast.
- Darkens the unvisited link color in light mode to keep visited links feeling just as distinct.

I think the dark mode link and visited link colors could stand improvement, but wanted to deliver this before stepping away for a long weekend. I suggest merging this if there are no showstopping issues and then taking more feedback, rather than trying to discuss style here where few eyes will be on it. 