### PR TITLE
Update the Gemfile.lock for the current iteration

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,7 +109,7 @@ GEM
       i18n (>= 1.6, < 2)
     ffi (1.15.4)
     flamegraph (0.9.5)
-    globalid (0.5.2)
+    globalid (1.0.0)
       activesupport (>= 5.0)
     good_migrations (0.1.0)
       activerecord (>= 3.1)
@@ -117,7 +117,7 @@ GEM
     hashdiff (1.0.1)
     hashery (2.1.2)
     htmlentities (4.3.4)
-    i18n (1.8.10)
+    i18n (1.8.11)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
     jquery-rails (4.4.0)
@@ -128,7 +128,7 @@ GEM
     listen (3.7.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    loofah (2.12.0)
+    loofah (2.13.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -338,4 +338,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.1.4
+   2.2.33


### PR DESCRIPTION
The referenced version of rails `6.0.3.3` relies on `mimemagic (0.3.5)` which has been pulled from available downloads. This updates the lock file to reference rails `6.0.3.7` which no longer contains mimemagic as a dependency.

Resolves #989