### PR TITLE
Add additional tracking query parameters 

### DIFF
--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -880,7 +880,7 @@ class Story < ApplicationRecord
     if (match = u.match(/\A([^\?]+)\?(.+)\z/))
       params = match[2].split(/[&\?]/)
       # utm_ is google and many others; sk is medium
-      params.reject! {|p| p.match(/^utm_(source|medium|campaign|term|content)=|^sk=|^fbclid=/) }
+      params.reject! {|p| p.match(/^utm_(source|medium|campaign|term|content|referrer)=|^sk=|^gclid=|^fbclid=/) }
       u = match[1] << (params.any?? "?" << params.join("&") : "")
     end
 


### PR DESCRIPTION
Sourced from:

https://support.google.com/google-ads/answer/9744275?hl=en

https://support.google.com/optimize/answer/6361119?hl=en#zippy=%2Cexample-parameters-in-redirect-destination-dont-conflict

<!--
Issues and PRs are typically reviewed Wednesday and most weekend mornings.
-->
