### PR TITLE
Add 'http://' to homepage only when it lacks a scheme

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -556,7 +556,7 @@ $(document).ready(function() {
   $(document).ready(Lobsters.checkStoryTitle);
 
   $(document).on("blur", "#user_homepage", function() {
-    if (this.value.trim() !== '' && !this.value.match('^https?:\/\/'))
+    if (this.value.trim() !== '' && !this.value.match('^[a-z]+:\/\/'))
       this.value = 'http://' + this.value;
   });
 


### PR DESCRIPTION
Assume that it's HTTP if nothing was specified. Validation happens elsewhere already, so instead of duplicating that here, just add a scheme if it's missing.

Related to #944.