### PR TITLE
fix domain RSS feed HREFs

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -257,8 +257,8 @@ class HomeController < ApplicationController
     @cur_url = domain_path(params[:name])
 
     @rss_link = {
-      title: "RSS 2.0 - For #{@domain}",
-      href: "/domain/#{params[:domain]}.rss",
+      title: "RSS 2.0 - For #{params[:name]}",
+      href: "/domain/#{params[:name]}.rss",
     }
 
     respond_to do |format|


### PR DESCRIPTION
This tiny PR fixes a variable-name error in string interpolation of RSS feed HREFs for domains. I believe this will address an issue I currently see in <https://lobste.rs/domain/writing.kemitchell.com>:

```html
 <link rel="alternate" type="application/rss+xml"
      title="RSS 2.0 - For #&lt;Domain:0x00007ff97040fe40&gt;" href="/domain/.rss" />
```

Note the interpolation of an object reference in the title and the empty string between `/domain` and `.rss`.

Caveat: I receive 404 for `/domain/{hostname}.rss` requests, so it looks like these meta links, while correct, still won't work.

I see code for generating domain-specific RSS feeds in `home_controller.rb`. But I couldn't determine why they aren't being served.