### PR TITLE
Fix domain-specific RSS feeds

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,7 +67,17 @@ Rails.application.routes.draw do
   get "/t/:tag" => "home#tagged", :as => "tag"
   get "/t/:tag/page/:page" => "home#tagged"
 
-  get "/domain/:name" => "home#for_domain", :as => "domain", :constraints => { name: /[^\/]+/ }
+  # Why are there two routes for `home#for_domain`?
+  #
+  # By default, Rails omits dots from parameters so that it can use extension
+  # to determine format.  So the `:id` in `foo.json` is `foo`, and JSON is the format.
+  # We need to include dots in domain names, since they have them, but also support
+  # the `.rss` suffix for RSS/Atom feeds.  So we define one route just for HTML and
+  # another, with the extension, specifically for RSS.
+  get "/domain/:name" => "home#for_domain", :as => "domain",
+    :constraints => { name: /[^\/]+/ }, :format => false
+  get "/domain/:name.rss" => "home#for_domain", :as => "domain_rss",
+    :constraints => { name: /[^\/]+/ }, :format => 'rss'
   get "/domain/:name/page/:page" => "home#for_domain", :constraints => { name: /[^\/]+/ }
 
   get "/search" => "search#index"

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -13,6 +13,13 @@ describe HomeController do
       expect(@controller.view_assigns['title']).to include(story.domain.domain)
       expect(@controller.view_assigns['stories']).to include(story)
     end
+
+    context "when accessing RSS feeds" do
+      it "responds to requests" do
+        get :for_domain, params: { name: story.domain.domain }, as: :rss
+        expect(response).to be_successful
+      end
+    end
   end
 
   describe "#upvoted" do


### PR DESCRIPTION
Following on from #1052, which fixed `<meta type=rss>` URL generation. The meta tags point to the right URLs for RSS feeds now, but requests for those feeds respond 404.

Opening this as draft for now, so I can get a CI run and see results. My first commit does not include a fix, just an addition to the spec.