### PR TITLE
Include hyphens and underscores in @username links by de-converting …

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -90,7 +90,8 @@ class User < ApplicationRecord
 
   validates :password, :presence => true, :on => :create
 
-  VALID_USERNAME = /[A-Za-z0-9][A-Za-z0-9_-]{0,24}/.freeze
+  VALID_USERNAME_CHARACTER = /[A-Za-z0-9_-]/.freeze
+  VALID_USERNAME = /[A-Za-z0-9]#{VALID_USERNAME_CHARACTER}{0,24}/.freeze
   validates :username,
             :format => { :with => /\A#{VALID_USERNAME}\z/ },
             :length => { :maximum => 50 },


### PR DESCRIPTION
…dashes and \<em> tags within username

This addresses #1037.

On further reflection, I'm not sure this is the best approach—see my comment https://github.com/lobsters/lobsters/issues/1037#issuecomment-1024521680