### PR TITLE
fake_data try to add comments to deleted stories

### DIFF
--- a/lib/tasks/fake_data.rake
+++ b/lib/tasks/fake_data.rake
@@ -48,7 +48,9 @@ class FakeDataGenerator
       end
     end
 
-    # User-deleted stories
+    # User-deleted stories. The stories are created here and deleted after
+    # adding comments.
+    deleted_stories = []
     (@stories_count / 10).times do
       user = users[Random.rand(@users_count-1)]
       title = Faker::Lorem.sentence(word_count: 3)
@@ -56,12 +58,12 @@ class FakeDataGenerator
       tag_name = title.split(' ').first.downcase
       tag = Tag.find_by tag: tag_name
       tag ||= Tag.create! tag: tag_name, category: category
-      Story.create! user: user,
+      deleted_story = Story.create! user: user,
         title: title,
         tags_a: [tag.tag],
         description: Faker::Lorem.paragraphs(number: 1),
-        is_deleted: true,
         editor: user
+      deleted_stories << deleted_story
     end
 
     # Comments
@@ -78,6 +80,11 @@ class FakeDataGenerator
             parent_comment_id: c.id
         end
       end
+    end
+
+    # Delete the stories marked for deletion before adding comments.
+    deleted_stories.each do |story|
+      story.update(is_deleted: true)
     end
 
     # Hats


### PR DESCRIPTION
Following error happens when running `fake_data` task, following the instruction in README.md.

> ActiveRecord::RecordInvalid: Validation failed: Story is no longer accepting comments.

The fix is do not create deleted stories with is_deleted: true
immediately, but delete them after adding comments.
