### PR TITLE
Fixes comment flag bug, closes #1062

### DIFF
--- a/app/assets/stylesheets/application.css.erb
+++ b/app/assets/stylesheets/application.css.erb
@@ -1018,7 +1018,7 @@ div.comment_text code {
 
 
 #flag_why, .archive-dropdown {
-	position: fixed;
+	position: absolute;
 	left: 50%;
 	width: 100px;
 	border: 1px solid var(--color-box-border);


### PR DESCRIPTION
Closes #1062

<img width="1084" alt="Screen Shot 2022-03-29 at 4 32 17 PM" src="https://user-images.githubusercontent.com/2836167/160710873-3b2f8cb8-f425-415e-9863-fbcb7e754421.png">

I don't really know what I'm doing. I just switched the position options around in the affected CSS until it looked okay. I would like people to be able to flag my comments more effectively, though, so here's a fix 🎁