### PR TITLE
Use MariaDB instead of MySQL when running tests in GitHub Actions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,8 +5,17 @@ jobs:
     environment: production
     runs-on: ubuntu-latest
 
+    services:
+      mariadb:
+        image: mariadb:10.5
+        env:
+          MARIADB_ROOT_PASSWORD: root
+          MARIADB_DATABASE: lobsters_dev
+        ports:
+          - 3306:3306
+
     env:
-      DATABASE_URL: mysql2://root:root@localhost/lobsters_dev
+      DATABASE_URL: mysql2://root:root@127.0.0.1/lobsters_dev
       RAILS_ENV: test
 
     steps:
@@ -14,13 +23,8 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-      - name: Set up MySQL
-        run: |
-          sudo /etc/init.d/mysql start
       - name: Prepare database
-        run: |
-          ./bin/rails db:create
-          ./bin/rails db:schema:load
+        run: ./bin/rails db:schema:load
       - name: Run tests
         run: bundle exec rspec
       - name: Run linters


### PR DESCRIPTION
This starts a Docker container running MariaDB instead of using the MySQL database that GitHub Actions comes with. This means we can configure which specific version of MariaDB to run.

I opted for MariaDB 10.5 as that was my best guess as to what version was running in the deployed setup, based on it being the version available for the "mariadb-server" package in Debian stable.

The Docker container is configured to create the "lobsters_dev" database automatically, so it shouldn't be necessary to run a command to explicitly create the database anymore.

Fixes #1050.