### PR TITLE
Fix #1049 Can't delete system messages

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -6,7 +6,8 @@ class Message < ApplicationRecord
   belongs_to :author,
              :class_name => "User",
              :foreign_key => "author_user_id",
-             :inverse_of => :sent_messages
+             :inverse_of => :sent_messages,
+             :optional => true
   belongs_to :hat,
              :optional => true
 

--- a/app/models/mod_note.rb
+++ b/app/models/mod_note.rb
@@ -36,13 +36,15 @@ class ModNote < ApplicationRecord
   end
 
   def self.create_from_message(message, moderator)
-    user = moderator.id == message.recipient.id ? message.author : message.recipient
+    user = moderator.id == message.recipient.id && message.author ?
+             message.author : message.recipient
+
     ModNote.create!(
       moderator: moderator,
       user: user,
       created_at: message.created_at,
       note: <<~NOTE
-        *#{message.author.username} #{message.hat ? message.hat.to_txt : ''}-> #{message.recipient.username}*: #{message.subject}
+        *#{message.author ? message.author.username : '(System)'} #{message.hat ? message.hat.to_txt : ''}-> #{message.recipient.username}*: #{message.subject}
 
         #{message.body}
       NOTE

--- a/db/migrate/20220331165136_message_author_nullable.rb
+++ b/db/migrate/20220331165136_message_author_nullable.rb
@@ -1,0 +1,11 @@
+class MessageAuthorNullable < ActiveRecord::Migration[6.1]
+  def up
+    change_column_null :messages, :author_user_id, true
+    Story.connection.execute("UPDATE messages SET author_user_id = NULL WHERE author_user_id = 0")
+  end
+
+  def down
+    Story.connection.execute("UPDATE messages SET author_user_id = 0 WHERE author_user_id IS NULL")
+    change_column_null :messages, :author_user_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_07_033514) do
+ActiveRecord::Schema.define(version: 2022_03_31_165136) do
 
   create_table "categories", charset: "utf8mb4", force: :cascade do |t|
     t.string "category"
@@ -119,7 +119,7 @@ ActiveRecord::Schema.define(version: 2022_02_07_033514) do
 
   create_table "messages", id: { type: :bigint, unsigned: true }, charset: "utf8mb4", force: :cascade do |t|
     t.datetime "created_at"
-    t.bigint "author_user_id", null: false, unsigned: true
+    t.bigint "author_user_id", unsigned: true
     t.bigint "recipient_user_id", null: false, unsigned: true
     t.boolean "has_been_read", default: false
     t.string "subject", limit: 100

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -405,4 +405,40 @@ describe Story do
       end
     end
   end
+
+  describe "suggestions" do
+    it "does not auto-accept suggestion if quorum is not met" do
+      story = create(:story, :title => "hello", :url => "http://example.com/")
+      user = create(:user)
+
+      story.save_suggested_title_for_user!("new title", user)
+
+      expect(story.title).to eq("hello")
+    end
+
+    it "auto-accept suggestion once quorum is met" do
+      story = create(:story, :title => "hello", :url => "http://example.com/")
+      user1 = create(:user)
+      user2 = create(:user)
+
+      story.save_suggested_title_for_user!("new title", user1)
+      story.save_suggested_title_for_user!("new title", user2)
+
+      expect(story.title).to eq("new title")
+    end
+
+    it "notifies story creator upon auto-accepted suggestion" do
+      creator = create(:user)
+      story = create(:story, :user => creator, :title => "hello", :url => "http://example.com/")
+      user1 = create(:user)
+      user2 = create(:user)
+
+      expect(creator.received_messages.length).to eq(0)
+
+      story.save_suggested_title_for_user!("new title", user1)
+      story.save_suggested_title_for_user!("new title", user2)
+
+      expect(creator.received_messages.length).to eq(1)
+    end
+  end
 end

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -438,7 +438,7 @@ describe Story do
       story.save_suggested_title_for_user!("new title", user1)
       story.save_suggested_title_for_user!("new title", user2)
 
-      expect(creator.received_messages.length).to eq(1)
+      expect(creator.reload.received_messages.length).to eq(1)
     end
   end
 end


### PR DESCRIPTION
This also fixes a (unknown?) bug where users do not receive a message if a suggestion on one of their stories was auto-accepted due to quorum.

I implemented this in a kind of TDD style. As stated above, at the moment, users don't get sent any message if a suggestion was auto-accepted. This is because the created message has no author, which causes an error when the message is saved. So I created a test for that first, then made the `author` field nullable in messages.

**Summary of changes:**
- Add tests for auto-accepting suggestions on stories.
- Make author_user_id nullable in messages.
- Fix mod note creation in case message has no author.