### PR TITLE
Fix #1087: Add unban reason to fake data

### DIFF
--- a/lib/tasks/fake_data.rake
+++ b/lib/tasks/fake_data.rake
@@ -225,7 +225,7 @@ class FakeDataGenerator
       user.ban_by_user_for_reason!(User.moderators.sample,
                                    Faker::Lorem.sentence(word_count: 5))
       if i.even?
-        user.unban_by_user!(User.moderators.sample)
+        user.unban_by_user!(User.moderators.sample, Faker::Lorem.sentence(word_count: 5))
       end
     end
     puts


### PR DESCRIPTION
<!--
Issues and PRs are typically reviewed Wednesday and most weekend mornings.
-->

Generate unban reason for fake data. Was able to successfully run `rails fake_data` afterwards.