### PR TITLE
Continuing to remove the jQuery #554

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -396,18 +396,6 @@ $(document).ready(function() {
     return false;
   });
 
-  $(document).on("click", "button.comment-cancel", function() {
-    var comment = $(this).closest(".comment");
-    var comment_id = comment.attr("data-shortid");
-    if (comment_id != null && comment_id !== '') {
-      $.get("/comments/" + comment_id + "?show_tree_lines=true", function(data) {
-        comment.replaceWith($.parseHTML(data));
-      });
-    } else {
-      comment.remove();
-    }
-  });
-
   $(document).on("click", "a.comment_deletor", function(event) {
     event.preventDefault();
     if (confirm("Are you sure you want to delete this comment?")) {
@@ -574,6 +562,21 @@ onPageLoad(() => {
   on('keydown', 'textarea#comment', (event) => {
     if ((event.metaKey || event.ctrlKey) && event.keyCode == 13) {
       Lobsters.postComment(parentSelector(event.target, 'form'));
+    }
+  });
+
+  on('click', 'button.comment-cancel', (event) => {
+    const comment = (parentSelector(event.target, '.comment'));
+    const commentId = comment.getAttribute('data-shortid');
+    if (commentId !== null && commentId !== '') {
+      fetch('/comments/' + commentId + '?show_tree_lines=true')
+        .then(response => {
+          return response.text().then((text) => {
+            replace(comment, text);
+          });
+        });
+    } else {
+      comment.remove();
     }
   });
 

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -561,7 +561,7 @@ onPageLoad(() => {
         });
     } else {
       comment.remove();
-    }  
+    }
   });
 
   on('click', 'a.comment_editor', (event) => {

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -391,17 +391,6 @@ $(document).ready(function() {
     return false;
   });
 
-  $(document).on("click", "a.comment_undeletor", function(event) {
-    event.preventDefault();
-    if (confirm("Are you sure you want to undelete this comment?")) {
-      var li = $(this).closest(".comment");
-      $.post("/comments/" + $(li).attr("data-shortid") + "/undelete",
-      function(d) {
-        $(li).replaceWith(d);
-      });
-    }
-  });
-
   $(document).on("click", "a.comment_disownor", function() {
     if (confirm("Are you sure you want to disown this comment?")) {
       var li = $(this).closest(".comment");
@@ -501,11 +490,11 @@ const fetchWithCSRF = (url, params) => {
   return fetch(url, params);
 } 
 
-    const removeExtraInput = (targetElement) => {
-      // This deletion will resovle a bug that creates an extra hidden input when rendering the comment elements.
-       const extraInput2 = targetElement.parentElement.querySelector('.comment_folder_button');
-       extraInput2.remove();
-    }
+const removeExtraInput = (targetElement) => {
+  // This deletion will resovle a bug that creates an extra hidden input when rendering the comment elements.
+  const extraInput2 = targetElement.parentElement.querySelector('.comment_folder_button');
+  extraInput2.remove();
+}
 
 onPageLoad(() => {
 
@@ -589,7 +578,8 @@ onPageLoad(() => {
 
   on('click', 'a.comment_editor', (event) => {
     let comment = parentSelector(event.target, '.comment');
-    fetch('/comments/' + comment.getAttribute('data-shortid') + '/edit')
+    const commentId = comment.getAttribute('data-shortid')
+    fetch('/comments/' + commentId + '/edit')
       .then(response => {
         response.text().then(text => replace(comment, text));
       });  
@@ -599,10 +589,23 @@ onPageLoad(() => {
   on("click", "a.comment_deletor", (event) => {
     event.preventDefault();
     if (confirm("Are you sure you want to delete this comment?")) {
-      const comment = parentSelector(event.target, ".comment");
+      const comment = parentSelector(event.target, '.comment');
       removeExtraInput(comment);
       const commentId = comment.getAttribute('data-shortid');
       fetchWithCSRF('/comments/' + commentId + '/delete',{method: 'post'})
+        .then(response => {
+          response.text().then(text => replace(comment, text));
+        });
+    }
+  });
+
+  on('click', 'a.comment_undeletor', (event) => {
+    event.preventDefault();
+    if (confirm("Are uou sure you want to undelete this comment?")) {
+      const comment = parentSelector(event.target, '.comment');
+      removeExtraInput(comment);
+      const commentId = comment.getAttribute('data-shortid');
+      fetchWithCSRF('/comments/' + commentId + '/undelete', {method: 'post'})
         .then(response => {
           response.text().then(text => replace(comment, text));
         });

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -515,12 +515,13 @@ const onPageLoad = (callback) => {
 const replace = (oldElement, newHTMLString) => {
   const placeHolder = document.createElement('div');
   placeHolder.insertAdjacentHTML('afterBegin', newHTMLString);
-  const newElement = placeHolder.firstElementChild;
-  oldElement.replaceWith(newElement);
+  const newElements = placeHolder.childNodes.values();
+  oldElement.replaceWith(...newElements);
 }
 
 onPageLoad(() => {
 
+  // Global Functions
   on('click', '.markdown_help_label', (event) => {
     parentSelector(event.target, '.markdown_help_toggler').querySelector('.markdown_help').classList.toggle('display-block');
   });

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -501,6 +501,12 @@ const fetchWithCSRF = (url, params) => {
   return fetch(url, params);
 } 
 
+    const removeExtraInput = (targetElement) => {
+      // This deletion will resovle a bug that creates an extra hidden input when rendering the comment elements.
+       const extraInput2 = targetElement.parentElement.querySelector('.comment_folder_button');
+       extraInput2.remove();
+    }
+
 onPageLoad(() => {
 
   // Global Functions
@@ -586,13 +592,15 @@ onPageLoad(() => {
     fetch('/comments/' + comment.getAttribute('data-shortid') + '/edit')
       .then(response => {
         response.text().then(text => replace(comment, text));
-      });   
+      });  
+    removeExtraInput(comment); 
   });
 
   on("click", "a.comment_deletor", (event) => {
     event.preventDefault();
     if (confirm("Are you sure you want to delete this comment?")) {
       const comment = parentSelector(event.target, ".comment");
+      removeExtraInput(comment);
       const commentId = comment.getAttribute('data-shortid');
       fetchWithCSRF('/comments/' + commentId + '/delete',{method: 'post'})
         .then(response => {

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -350,11 +350,6 @@ var Lobsters = new _Lobsters();
 
 $(document).ready(function() {
 
-  $("select[name=message\\[hat_id\\]]").change(function() {
-    $(this).siblings("input[name=message\\[mod_note\\]]")
-      .prop("checked", !!$(this).find('option:selected').data('modnote'));
-  }),
-
   $(document).on("click", "a.comment_replier", function() {
     if (!Lobsters.curUser) {
       Lobsters.bounceToLogin();
@@ -511,6 +506,15 @@ onPageLoad(() => {
   // Global Functions
   on('click', '.markdown_help_label', (event) => {
     parentSelector(event.target, '.markdown_help_toggler').querySelector('.markdown_help').classList.toggle('display-block');
+  });
+
+  // Inbox Related Funtions
+
+  on('change', '#message_hat_id', (event) => {
+    let selectedOption = event.target.options.selectedIndex;
+    if (event.target.options[selectedOption].getAttribute('data-modnote') == 'true') {
+      document.getElementById('message_mod_note').checked = true;
+    } else document.getElementById('message_mod_note').checked = false;
   });
 
   // Story Related Functions

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -471,10 +471,9 @@ const replace = (oldElement, newHTMLString) => {
 
 const fetchWithCSRF = (url, params) => {
   let csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
-  let h = new Headers();
-  h.append('X-CSRF-Token', csrfToken);
   params = params || {};
-  params['headers'] = h;
+  params['headers'] = params['headers'] || new Headers;
+  params['headers'].append('X-CSRF-Token', csrfToken);
   return fetch(url, params);
 } 
 

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -401,18 +401,6 @@ $(document).ready(function() {
     }
   });
 
-  $(document).on("click", "a.comment_moderator", function() {
-    var reason = prompt("Moderation reason:");
-    if (reason == null || reason == "")
-      return false;
-
-    var li = $(this).closest(".comment");
-    $.post("/comments/" + $(li).attr("data-shortid") + "/delete",
-      { reason: reason }, function(d) {
-        $(li).replaceWith(d);
-      });
-  });
-
   Lobsters.runSelect2();
 
   $(document).on("blur", "#story_url", function() {
@@ -610,6 +598,21 @@ onPageLoad(() => {
           response.text().then(text => replace(comment, text));
         });
     }
+  });
+
+  on('click', 'a.comment_moderator', (event) => {
+    const reason = prompt("Moderation reason:");
+    if (reason == null || reason == '') 
+      return false;
+
+    const formData = new FormData();
+    formData.append('reason', reason);
+    const comment = parentSelector(event.target, '.comment');
+    const commentId = comment.getAttribute('data-shortid');
+    fetchWithCSRF('/comments/' + commentId + '/delete', { method: 'post', body: formData })
+      .then(response => {
+        response.text().then(text => replace(comment, text));
+      });
   });
 });
 

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -493,10 +493,8 @@ onPageLoad(() => {
   // Inbox Related Funtions
 
   on('change', '#message_hat_id', (event) => {
-    let selectedOption = event.target.options.selectedIndex;
-    if (event.target.options[selectedOption].getAttribute('data-modnote') == 'true') {
-      document.getElementById('message_mod_note').checked = true;
-    } else document.getElementById('message_mod_note').checked = false;
+    let selectedOption = event.target.selectedOptions[0];
+    document.getElementById('message_mod_note').checked = (selectedOption.getAttribute('data-modnote') === 'true');
   });
 
   // Story Related Functions

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -396,16 +396,6 @@ $(document).ready(function() {
     return false;
   });
 
-  $(document).on("click", "a.comment_deletor", function(event) {
-    event.preventDefault();
-    if (confirm("Are you sure you want to delete this comment?")) {
-      var li = $(this).closest(".comment");
-      $.post("/comments/" + $(li).attr("data-shortid") + "/delete",
-      function(d) {
-        $(li).replaceWith(d);
-      });
-    }
-  });
   $(document).on("click", "a.comment_undeletor", function(event) {
     event.preventDefault();
     if (confirm("Are you sure you want to undelete this comment?")) {
@@ -507,6 +497,15 @@ const replace = (oldElement, newHTMLString) => {
   oldElement.replaceWith(...newElements);
 }
 
+const fetchWithCSRF = (url, params) => {
+  let csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+  let h = new Headers();
+  h.append('X-CSRF-Token', csrfToken);
+  params = params || {};
+  params['headers'] = h;
+  return fetch(url, params);
+} 
+
 onPageLoad(() => {
 
   // Global Functions
@@ -571,9 +570,7 @@ onPageLoad(() => {
     if (commentId !== null && commentId !== '') {
       fetch('/comments/' + commentId + '?show_tree_lines=true')
         .then(response => {
-          return response.text().then((text) => {
-            replace(comment, text);
-          });
+          response.text().then(text => replace(comment, text));
         });
     } else {
       comment.remove();
@@ -584,10 +581,20 @@ onPageLoad(() => {
     let comment = parentSelector(event.target, '.comment');
     fetch('/comments/' + comment.getAttribute('data-shortid') + '/edit')
       .then(response => {
-        return response.text().then(function(text) {
-          replace(comment, text);
+        response.text().then(text => replace(comment, text));
+      });   
+  });
+
+  on("click", "a.comment_deletor", (event) => {
+    event.preventDefault();
+    if (confirm("Are you sure you want to delete this comment?")) {
+      const comment = parentSelector(event.target, ".comment");
+      const commentId = comment.getAttribute('data-shortid');
+      fetchWithCSRF('/comments/' + commentId + '/delete',{method: 'post'})
+        .then(response => {
+          response.text().then(text => replace(comment, text));
         });
-      });
+    }
   });
 });
 

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -467,6 +467,7 @@ const replace = (oldElement, newHTMLString) => {
   placeHolder.insertAdjacentHTML('afterBegin', newHTMLString);
   const newElements = placeHolder.childNodes.values();
   oldElement.replaceWith(...newElements);
+  removeExtraInputs();
 }
 
 const fetchWithCSRF = (url, params) => {
@@ -477,10 +478,12 @@ const fetchWithCSRF = (url, params) => {
   return fetch(url, params);
 } 
 
-const removeExtraInput = (targetElement) => {
+const removeExtraInputs = () => {
   // This deletion will resovle a bug that creates an extra hidden input when rendering the comment elements.
-  const extraInput2 = targetElement.parentElement.querySelector('.comment_folder_button');
-  extraInput2.remove();
+  const extraInputs = document.querySelectorAll('.comment_folder_button + .comment_folder_button');
+  for (const i of extraInputs) {
+    i.remove();
+  }
 }
 
 onPageLoad(() => {
@@ -558,7 +561,7 @@ onPageLoad(() => {
         });
     } else {
       comment.remove();
-    }
+    }  
   });
 
   on('click', 'a.comment_editor', (event) => {
@@ -568,14 +571,12 @@ onPageLoad(() => {
       .then(response => {
         response.text().then(text => replace(comment, text));
       });  
-    removeExtraInput(comment); 
   });
 
   on("click", "a.comment_deletor", (event) => {
     event.preventDefault();
     if (confirm("Are you sure you want to delete this comment?")) {
       const comment = parentSelector(event.target, '.comment');
-      removeExtraInput(comment);
       const commentId = comment.getAttribute('data-shortid');
       fetchWithCSRF('/comments/' + commentId + '/delete',{method: 'post'})
         .then(response => {
@@ -588,7 +589,6 @@ onPageLoad(() => {
     event.preventDefault();
     if (confirm("Are uou sure you want to undelete this comment?")) {
       const comment = parentSelector(event.target, '.comment');
-      removeExtraInput(comment);
       const commentId = comment.getAttribute('data-shortid');
       fetchWithCSRF('/comments/' + commentId + '/undelete', {method: 'post'})
         .then(response => {


### PR DESCRIPTION
This is part two of removing jQuery as a part of #554. 

I added a new function `fetchWithCSRF` which is required for the CSRF token as plain JS requires a little more handling than jQuery to validate requests.

This pull request also adds a `removeExtraInput` function that fixes a bug, in which various calls to the backend result in an additional input being added to the site.  It hasn't been a problem as they are `display: none` so no one has noticed.  However, if you make changes in a particular order on a comment it can become hidden until you reload the page. 

I will post another update next week.