### PR TITLE
Continuing to remove the jQuery #554 part III

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -472,12 +472,82 @@ const fetchWithCSRF = (url, params) => {
 } 
 
 const removeExtraInputs = () => {
-  // This deletion will resovle a bug that creates an extra hidden input when rendering the comment elements.
+  // This deletion will resovle a bug that creates an extra hidden input when rendering the comment elements.<<<<<<< HEAD
   const extraInputs = document.querySelectorAll('.comment_folder_button + .comment_folder_button');
   for (const i of extraInputs) {
     i.remove();
   }
 }
+
+class _LobstersFunction {
+  constructor () {
+    this.curUser = 'will';  //done
+  }
+
+  bounceToLogin() { //requires []
+
+  }
+
+  checkStoryDuplicate(form) { //requires []
+
+  }
+
+  checkStoryTitle() { //requires []
+
+  }
+
+  fetchURLTitle(button, urlField, titleField) { //requires [checkStoryTitle]
+
+  }
+
+  flagComment(voterEl) { //requires [_showFlagWhyAt, vote]
+
+  }
+
+  flagStory(voterEl) { //requires [_showFlagWhyAt, vote]
+
+  }
+
+  hideStory(hiderEl) { //requires [bounceToLogin]
+
+  }
+
+  postComment(form) { //requires []
+    
+  }
+
+  previewComment(form) { //requires []
+
+  }
+
+  previewStory(form) { //requires [runSelect2]
+
+  }
+
+  runSelect2() {  //requires [] (will actully replace select2)
+
+  }
+
+  saveStory(saverEl) {  //requires [bounceToLogin, ]
+
+  }
+
+  _showFlagWhyAt(thingType, voterEl, onChooseWhy) { // requires [bounceToLogin, vote]
+
+  }
+
+  upvoteComment(voterEl) {  //requires [vote]
+
+  }
+
+  upvoteStory(voterEl) {  //requires [vote]
+  }
+
+  vote(thingType, voterEl, point, reason) {  // requires [bounceToLogin, comentFlagReasons]
+  }
+}
+
+const Lobster = new _LobstersFunction();
 
 onPageLoad(() => {
 
@@ -490,7 +560,6 @@ onPageLoad(() => {
 
   on('focusout', '#user_homepage', (event) => {
     const homePage = event.target
-    console.log("homepage", homePage)
     if (homePage.value.trim() !== '' && !homePage.value.match('^[a-z]+:\/\/'))
       homePage.value = 'https://' + homePage.value
   })

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -224,7 +224,7 @@ var _Lobsters = Class.extend({
     });
   },
 
-  checkStoryDuplicate: function(form) { 
+  checkStoryDuplicate: function(form) {
     // if this includes { '_method': 'PUT' }, the router maps it as
     // StoriesController#update with story_id 'check_url_dupe'
     // Creates an error where it will delete other errors on blur. e.g. no title/tags error.
@@ -454,7 +454,7 @@ const fetchWithCSRF = (url, params) => {
 } 
 
 const removeExtraInputs = () => {
-  // This deletion will resovle a bug that creates an extra hidden input when rendering the comment elements.<<<<<<< HEAD
+  // This deletion will resovle a bug that creates an extra hidden input when rendering the comment elements.
   const extraInputs = document.querySelectorAll('.comment_folder_button + .comment_folder_button');
   for (const i of extraInputs) {
     i.remove();
@@ -494,10 +494,11 @@ class _LobstersFunction {
 
   }
 
-  postComment(form) { 
+  postComment(form) {
     const formData = new FormData(form);
+    const action = form.getAttribute('action');
     formData.append('show_tree_lines', true);
-    fetch ('/comments', {
+    fetchWithCSRF (action, {
       method: 'POST',
       headers: new Headers({'X-Requested-With': 'XMLHttpRequest'}),
       body: formData

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -242,9 +242,10 @@ var _Lobsters = Class.extend({
     });
   },
 
-  checkStoryDuplicate: function(form) {
+  checkStoryDuplicate: function(form) { 
     // if this includes { '_method': 'PUT' }, the router maps it as
     // StoriesController#update with story_id 'check_url_dupe'
+    // Creates an error where it will delete other errors on blur. e.g. no title/tags error.
     var params = $(form).serializeArray().filter((e) => e.name !== '_method');
     $.post("/stories/check_url_dupe", params, function(formErrorsHtml) {
       $(form).find(".form_errors_header").html(formErrorsHtml);
@@ -427,8 +428,7 @@ $(document).ready(function() {
       Lobsters.checkStoryDuplicate($(this).parents("form").first());
     }
   });
-
-  $(document).on("blur change", "#story_title", Lobsters.checkStoryTitle);
+  
   $(document).ready(Lobsters.checkStoryTitle);
 
   $(document).on("blur", "#user_homepage", function() {
@@ -501,6 +501,11 @@ onPageLoad(() => {
   });
 
   // Story Related Functions
+
+  on('blur change', '#story_title', (event) => {
+    Lobsters.checkStoryTitle(event.target);
+  });
+
   on('click', 'li.story a.upvoter', (event) => {
     event.preventDefault();
     Lobsters.upvoteStory(event.target);

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -205,24 +205,6 @@ var _Lobsters = Class.extend({
       action, { reason: reason });
   },
 
-  postComment: function(form) {
-    var params = $(form).serializeArray();
-    params.push({"name": "show_tree_lines", "value": "true"});
-
-    $.post($(form).attr("action"), params, function(data) {
-      // Clear form: Firefox will keep form values on reload (e.g. F5), which isn't too useful if
-      // it's already posted.
-      $(form).find('textarea').val('')
-
-      if ($(form).find("#parent_comment_short_id").length) {
-        // reply to comment
-        $(form).closest(".comments_subtree")
-          .find(".comment_parent_tree_line:first").removeClass("no_children");
-      }
-      $(form).closest(".comment").replaceWith($.parseHTML(data));
-    });
-  },
-
   previewComment: function(form) {
     var params = $(form).serializeArray();
     params.push({"name": "preview", "value": "true"});
@@ -512,8 +494,17 @@ class _LobstersFunction {
 
   }
 
-  postComment(form) { //requires []
-    
+  postComment(form) { 
+    const formData = new FormData(form);
+    formData.append('show_tree_lines', true);
+    fetch ('/comments', {
+      method: 'POST',
+      headers: new Headers({'X-Requested-With': 'XMLHttpRequest'}),
+      body: formData
+    })
+      .then(response => {
+        response.text().then(text => replace(form.parentElement, text));
+      })
   }
 
   previewComment(form) { //requires []
@@ -620,7 +611,7 @@ onPageLoad(() => {
   
   on('submit', '.comment_form_container form', (event) => {
     event.preventDefault();
-    Lobsters.postComment(event.target);
+    Lobster.postComment(event.target);
   });
 
   on('keydown', 'textarea#comment', (event) => {

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -428,8 +428,6 @@ $(document).ready(function() {
       Lobsters.checkStoryDuplicate($(this).parents("form").first());
     }
   });
-  
-  $(document).ready(Lobsters.checkStoryTitle);
 
   $(document).on("blur", "#user_homepage", function() {
     if (this.value.trim() !== '' && !this.value.match('^[a-z]+:\/\/'))
@@ -505,6 +503,8 @@ onPageLoad(() => {
   on('blur change', '#story_title', (event) => {
     Lobsters.checkStoryTitle(event.target);
   });
+
+  Lobsters.checkStoryTitle()
 
   on('click', 'li.story a.upvoter', (event) => {
     event.preventDefault();

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -428,11 +428,6 @@ $(document).ready(function() {
       Lobsters.checkStoryDuplicate($(this).parents("form").first());
     }
   });
-
-  $(document).on("blur", "#user_homepage", function() {
-    if (this.value.trim() !== '' && !this.value.match('^[a-z]+:\/\/'))
-      this.value = 'http://' + this.value;
-  });
 });
 
 const parentSelector = (target, selector) => {
@@ -490,6 +485,15 @@ onPageLoad(() => {
   on('click', '.markdown_help_label', (event) => {
     parentSelector(event.target, '.markdown_help_toggler').querySelector('.markdown_help').classList.toggle('display-block');
   });
+
+  // Account Settings Functions
+
+  on('focusout', '#user_homepage', (event) => {
+    const homePage = event.target
+    console.log("homepage", homePage)
+    if (homePage.value.trim() !== '' && !homePage.value.match('^[a-z]+:\/\/'))
+      homePage.value = 'https://' + homePage.value
+  })
 
   // Inbox Related Funtions
 


### PR DESCRIPTION
Part 3 in the removal of jQuery.

I created the new Lobster class to replace the Lobsters class and make the transition easier. I pre-generated the functions that I need to replace and made notes as to which functions rely on other functions.

I identified and labeled a bug in the `checkStoryDuplicate` function.  I won't fix it until I rewrite the function to remove the jQuery. 

Removed jQuery from:

- Posting comments
- Account page Homepage URL entry
- The call to `checkStoryTitle`

Noted problems with this pull request:
- I put a bug into the post comment function when you edit/update a comment.  I added another commit to fix that issue.