### PR TITLE
Don't confirm email is used on the password reset page.

### DIFF
--- a/app/controllers/login_controller.rb
+++ b/app/controllers/login_controller.rb
@@ -110,7 +110,8 @@ class LoginController < ApplicationController
     @found_user = User.where("email = ? OR username = ?", params[:email], params[:email]).first
 
     if !@found_user
-      flash.now[:error] = "Unknown e-mail address or username."
+      flash.now[:success] = "Password reset instructions have been " <<
+                            "e-mailed to you if this account exists."
       return forgot_password
     end
 
@@ -128,7 +129,8 @@ class LoginController < ApplicationController
 
     @found_user.initiate_password_reset_for_ip(request.remote_ip)
 
-    flash.now[:success] = "Password reset instructions have been e-mailed to you."
+    flash.now[:success] = "Password reset instructions have been " <<
+                          "e-mailed to you if this account exists."
     return index
   end
 


### PR DESCRIPTION
Currently, a user can find out if someone else is a lobste.rs member by trying to reset their password (supposing they know their email). Depending on the resulting message ("Reset instructions have been sent" vs "User not found") you can deduce who the users are. 

With the changes in this PR the same message will be shown regardless of the email's presence in the database.
