### PR TITLE
Refactoring and removing jQuery from the vote function 

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -185,12 +185,6 @@ class _LobstersFunction {
       }
       flaggingDropDown.append(a);
     });
-
-    on('click', '#flag_dropdown a', (event) => {
-      if (event.target.getAttribute('data') != '')
-        onChooseWhy(event.target.getAttribute('data'));
-      return false;
-    });
   }
 
   checkStoryDuplicate(form) {
@@ -516,6 +510,9 @@ onPageLoad(() => {
   });
 
   on('click', '#flag_dropdown a', (event) => {
+    if (event.target.getAttribute('data') != '') {
+      Lobster.voteStory(parentSelector(event.target, '.story'), -1,  event.target.getAttribute('data'));
+    }
     document.querySelector("#flag_dropdown").remove();
     document.querySelector("#modal_backdrop").remove();
     document.querySelector('.flag-wrapper').remove();

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -130,23 +130,23 @@ class _LobstersFunction {
     document.location = "/login?return=" + encodeURIComponent(document.location);
   }
 
-  modalFlaggingDropDown(flaggedItemType, voterEl) {
+  modalFlaggingDropDown(flaggedItemType, voterEl, reasons) {
     if (!Lobsters.curUser)
       return Lobster.bounceToLogin();
 
-      const li = parentSelector(voterEl, '.story, .comment');
-      if (li.classList.contains('flagged')) {
-        /* already upvoted, neutralize */
-        if (li.classList.contains('story')) {
+    const li = parentSelector(voterEl, '.story, .comment');
+    if (li.classList.contains('flagged')) {
+      /* already upvoted, neutralize */
+      if (li.classList.contains('story')) {
         Lobster.voteStory(voterEl, -1, null);
-        } else {
-          Lobster.voteComment(voterEl, -1, null);
-        }
-        return
+      } else {
+        Lobster.voteComment(voterEl, -1, null);
       }
+      return
+    }
 
     if (document.querySelector("#flag_dropdown") || document.querySelector('#modal_backdrop')) {
-      Lobster.modalRemoval()
+      Lobster.removeFlagModal()
     }
 
     const modalDiv = document.createElement("div");
@@ -155,30 +155,21 @@ class _LobstersFunction {
 
     const flaggingDropDown = document.createElement('div');
     flaggingDropDown.setAttribute('id', 'flag_dropdown');
-    const flaggingWrapper = document.createElement('span');
-    flaggingWrapper.setAttribute('class', 'flag-wrapper')
-    flaggingWrapper.style.position = 'relative';
-    flaggingWrapper.style.maxWidth = '1 px';
-    flaggingWrapper.style.maxHeight = '1 px';
-    flaggingWrapper.appendChild(flaggingDropDown);
-    voterEl.after(flaggingWrapper);
-
-    let reasons;
-    if (flaggedItemType == "comment") {
-      reasons = Lobster.commentFlagReasons;
-    } else {
-      reasons = Lobster.storyFlagReasons;
-    }
+    const flagWrapper = document.createElement('span');
+    flagWrapper.setAttribute('id', 'flag_wrapper')
+    flagWrapper.style.position = 'relative';
+    flagWrapper.style.maxWidth = '1 px';
+    flagWrapper.style.maxHeight = '1 px';
+    flagWrapper.appendChild(flaggingDropDown);
+    voterEl.after(flagWrapper);
 
     Object.keys(reasons).map(function(k, v) {
       let a = document.createElement('a')
       a.textContent = reasons[k]
       a.setAttribute('data', k)
+      a.setAttribute('href', '#')
       if (k === ''){
-        a.setAttribute('href', '#' )
         a.classList.add('cancel-reason')
-      } else {
-        a.setAttribute('href', '#')
       }
       flaggingDropDown.append(a);
     });
@@ -263,10 +254,10 @@ class _LobstersFunction {
     fetchWithCSRF("/stories/" + li.getAttribute("data-shortid") + "/" + act, {method: 'post'});
   }
 
-  modalRemoval() {
-    document.querySelector("#flag_dropdown").remove();
-    document.querySelector("#modal_backdrop").remove();
-    document.querySelector('.flag-wrapper').remove();
+  removeFlagModal() {
+    document.getElementById("flag_dropdown").remove();
+    document.getElementById("modal_backdrop").remove();
+    document.querySelector('#flag_wrapper').remove();
   }
 
   postComment(form) {
@@ -460,9 +451,7 @@ class _LobstersFunction {
       }
       li.classList.remove("upvoted");
       li.classList.add("flagged");
-      if (li.parentElement.querySelector('.comment_folder_button')) {
-        li.parentElement.querySelector('.comment_folder_button').setAttribute("checked", true);
-      };
+      li.parentElement.querySelector('.comment_folder_button').setAttribute("checked", true);
       showScore = false;
       score--;
       action = "flag";
@@ -472,16 +461,16 @@ class _LobstersFunction {
     } else {
       scoreDiv.innerHTML = '~';
     }
-    if (action == "upvote" || action == "unvote") {
-      if (li.querySelector(".reason")) {
-        li.querySelector(".reason").innerHTML = ""
-      };
 
-      if (action == "unvote" && point < 0)
-        li.querySelector(".flagger").textContent = "flag";
-      } else if (action == "flag") {
-        li.querySelector(".flagger").textContent = "unflag";
-        li.querySelector(".reason").innerHTML = "| " + Lobster.commentFlagReasons[reason].toLowerCase();
+    if (action == "upvote" || action == "unvote") {
+      li.querySelector(".reason").innerHTML = ""
+    }
+
+    if (action == "unvote" && point < 0) {
+      li.querySelector(".flagger").textContent = "flag";
+    } else if (action == "flag") {
+      li.querySelector(".flagger").textContent = "unflag";
+      li.querySelector(".reason").innerHTML = "| " + Lobster.commentFlagReasons[reason].toLowerCase();
     }
 
     fetchWithCSRF("/comments/" + li.getAttribute("data-shortid") + "/" + action, {
@@ -503,7 +492,7 @@ onPageLoad(() => {
   });
 
   on('click', '#modal_backdrop', () => {
-    Lobster.modalRemoval()
+    Lobster.removeFlagModal()
   })
 
   // Account Settings Functions
@@ -535,7 +524,7 @@ onPageLoad(() => {
     if (event.target.getAttribute('data') != '') {
       Lobster.voteStory(parentSelector(event.target, '.story'), -1,  event.target.getAttribute('data'));
     }
-    Lobster.modalRemoval()
+    Lobster.removeFlagModal()
   });
 
   on('click', '#story_fetch_title', (event) => {
@@ -549,7 +538,8 @@ onPageLoad(() => {
 
   on('click', 'li.story a.flagger', (event) => {
     event.preventDefault();
-    Lobster.modalFlaggingDropDown("story", event.target);
+    const reasons = Lobster.storyFlagReasons;
+    Lobster.modalFlaggingDropDown("story", event.target, reasons);
   });
 
   on('click', 'li.story a.hider', (event) => {
@@ -586,7 +576,6 @@ onPageLoad(() => {
     }
 
     // check for dupe if there's a URL, but not when editing existing
-
     if (document.getElementById('story_url') &&
       document.querySelector('input[name="_method"]') &&
       (document.querySelector('input[name="_method"]').getAttribute('value') !== 'put')) {
@@ -650,14 +639,15 @@ onPageLoad(() => {
 
   on('click', '.comment a.flagger', (event) => {
     event.preventDefault();
-    Lobster.modalFlaggingDropDown("comment", event.target);
+    const reasons = Lobster.commentFlagReasons
+    Lobster.modalFlaggingDropDown("comment", event.target, reasons);
   });
 
   on('click', '.comment #flag_dropdown a', (event) => {
     if (event.target.getAttribute('data') != '') {
       Lobster.voteComment(parentSelector(event.target, '.comment'), -1,  event.target.getAttribute('data'));
     }
-    Lobster.modalRemoval()
+    Lobster.removeFlagModal()
   });
 
   on("click", '.comment a.upvoter', (event) => {

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -123,33 +123,7 @@ var _Lobsters = Class.extend({
 var Lobsters = new _Lobsters();
 
 $(document).ready(function() {
-
   Lobsters.runSelect2();
-
-  $(document).on("blur", "#story_url", function() {
-    var url_tags = {
-      "\.pdf$": "pdf",
-      "[\/\.]((youtube|vimeo)\.com|youtu\.be|twitch.tv)\/": "video",
-      "[\/\.](slideshare\.net|speakerdeck\.com)\/": "slides",
-      "[\/\.](soundcloud\.com)\/": "audio",
-    };
-
-    for (var u in url_tags) {
-      var tag = url_tags[u];
-
-      if ($("#story_url").val().match(new RegExp(u, "i"))) {
-        var ta = $("#story_tags_a").data("select2");
-        if (ta.getVal().indexOf(tag) < 0)
-          ta.addSelectedChoice({ id: tag });
-      }
-    }
-
-    // check for dupe if there's a URL, but not when editing existing
-    if ($("#story_url").val().length > 0 &&
-        $("#edit_story input[name=_method]").val() !== "put") {
-      Lobster.checkStoryDuplicate(parentSelector(document.getElementById('story_url'), 'form'));
-    }
-  });
 });
 
 const parentSelector = (target, selector) => {
@@ -539,6 +513,34 @@ onPageLoad(() => {
 
   on('click', 'button.story-preview', (event) => {
     Lobster.previewStory(parentSelector(event.target, 'form'));
+  });
+
+  on('focusout', '#story_url', (event) => {
+    let url_tags = {
+      "\.pdf$": "pdf",
+      "[\/\.]((youtube|vimeo)\.com|youtu\.be|twitch.tv)\/": "video",
+      "[\/\.](slideshare\.net|speakerdeck\.com)\/": "slides",
+      "[\/\.](soundcloud\.com)\/": "audio",
+    };
+
+    for (let u in url_tags) {
+      let tag = url_tags[u];
+
+      // can't remove the jquery until I replace select 2
+      if ($("#story_url").val().match(new RegExp(u, "i"))) {
+        var ta = $("#story_tags_a").data("select2");
+        if (ta.getVal().indexOf(tag) < 0)
+          ta.addSelectedChoice({ id: tag });
+      }
+    }
+
+    // check for dupe if there's a URL, but not when editing existing
+
+    if (document.getElementById('story_url') &&
+      document.querySelector('input[name="_method"]') &&
+      (document.querySelector('input[name="_method"]').getAttribute('value') !== 'put')) {
+        Lobster.checkStoryDuplicate(parentSelector(document.getElementById('story_url'), 'form'));
+    }
   });
 
   // Comment Related Functions

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -168,7 +168,7 @@ class _LobstersFunction {
       a.textContent = reasons[k]
       a.setAttribute('data', k)
       a.setAttribute('href', '#')
-      if (k === ''){
+      if (k === '') {
         a.classList.add('cancel-reason')
       }
       flaggingDropDown.append(a);

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -159,6 +159,7 @@ class _LobstersFunction {
     const flaggingDropDown = document.createElement('div');
     flaggingDropDown.setAttribute('id', 'flag_dropdown');
     const flaggingWrapper = document.createElement('span');
+    flaggingWrapper.setAttribute('class', 'flag-wrapper')
     flaggingWrapper.style.position = 'relative';
     flaggingWrapper.style.maxWidth = '1 px';
     flaggingWrapper.style.maxHeight = '1 px';
@@ -517,12 +518,14 @@ onPageLoad(() => {
   on('click', '#flag_dropdown a', (event) => {
     document.querySelector("#flag_dropdown").remove();
     document.querySelector("#modal_backdrop").remove();
+    document.querySelector('.flag-wrapper').remove();
   });
 
   on('click', '#modal_backdrop', (event) => {
     event.preventDefault();
     event.target.remove();
-    document.querySelector("#flag_dropdown").remove();
+    document.querySelector('#flag_dropdown').remove();
+    document.querySelector('.flag-wrapper').remove();
   })
 
   // Account Settings Functions
@@ -578,7 +581,7 @@ onPageLoad(() => {
     Lobster.previewStory(parentSelector(event.target, 'form'));
   });
 
-  on('focusout', '#story_url', (event) => {
+  on('focusout', '#story_url', () => {
     let url_tags = {
       "\.pdf$": "pdf",
       "[\/\.]((youtube|vimeo)\.com|youtu\.be|twitch.tv)\/": "video",

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -333,10 +333,10 @@ class _LobstersFunction {
       body: formData
     }).then (response => {
       response.text().then(text => {
-        previewElement.innerHTML = text;
+        replace(previewElement, text);
+        Lobsters.runSelect2();
       });
     });
-    Lobsters.runSelect2();
   }
 
   runSelect2() {  //requires [] (will actully replace select2)

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -130,7 +130,7 @@ class _LobstersFunction {
     document.location = "/login?return=" + encodeURIComponent(document.location);
   }
 
-  modalFlaggingDropDown(flaggedItem, voterEl, onChooseWhy) {
+  modalFlaggingDropDown(flaggedItemType, voterEl) {
     if (!Lobsters.curUser)
       return Lobster.bounceToLogin();
 
@@ -145,11 +145,8 @@ class _LobstersFunction {
         return
       }
 
-    if (document.querySelector("#flag_dropdown")) {
-      document.querySelector("#flag_dropdown").remove();
-    }
-    if (document.querySelector("#modal_backdrop")) {
-      document.querySelector("#modal_backdrop").remove();
+    if (document.querySelector("#flag_dropdown") || document.querySelector('#modal_backdrop')) {
+      Lobster.modalRemoval()
     }
 
     const modalDiv = document.createElement("div");
@@ -167,7 +164,7 @@ class _LobstersFunction {
     voterEl.after(flaggingWrapper);
 
     let reasons;
-    if (flaggedItem == "comment") {
+    if (flaggedItemType == "comment") {
       reasons = Lobster.commentFlagReasons;
     } else {
       reasons = Lobster.storyFlagReasons;
@@ -249,16 +246,6 @@ class _LobstersFunction {
     Lobster.checkStoryTitle();
   }
 
-  flagComment(voterEl) {
-    Lobster.modalFlaggingDropDown("comment", voterEl, function(k) {
-      Lobster.voteComment(voterEl, -1, k); });
-  }
-
-  flagStory(voterEl) {
-    Lobster.modalFlaggingDropDown("story", voterEl, function(k) {
-      Lobster.voteStory(voterEl, -1, k); });
-  }
-
   hideStory(hiderEl) {
     if (!Lobster.curUser) return Lobster.bounceToLogin();
 
@@ -274,6 +261,12 @@ class _LobstersFunction {
       hiderEl.innerHTML = "unhide";
     }
     fetchWithCSRF("/stories/" + li.getAttribute("data-shortid") + "/" + act, {method: 'post'});
+  }
+
+  modalRemoval() {
+    document.querySelector("#flag_dropdown").remove();
+    document.querySelector("#modal_backdrop").remove();
+    document.querySelector('.flag-wrapper').remove();
   }
 
   postComment(form) {
@@ -509,20 +502,8 @@ onPageLoad(() => {
     parentSelector(event.target, '.markdown_help_toggler').querySelector('.markdown_help').classList.toggle('display-block');
   });
 
-  on('click', '#flag_dropdown a', (event) => {
-    if (event.target.getAttribute('data') != '') {
-      Lobster.voteStory(parentSelector(event.target, '.story'), -1,  event.target.getAttribute('data'));
-    }
-    document.querySelector("#flag_dropdown").remove();
-    document.querySelector("#modal_backdrop").remove();
-    document.querySelector('.flag-wrapper').remove();
-  });
-
-  on('click', '#modal_backdrop', (event) => {
-    event.preventDefault();
-    event.target.remove();
-    document.querySelector('#flag_dropdown').remove();
-    document.querySelector('.flag-wrapper').remove();
+  on('click', '#modal_backdrop', () => {
+    Lobster.modalRemoval()
   })
 
   // Account Settings Functions
@@ -542,13 +523,20 @@ onPageLoad(() => {
 
   // Story Related Functions
 
+  Lobster.checkStoryTitle()
+
   if (document.getElementById('story_url') && !document.getElementById('story_preview').firstElementChild) {
     document.getElementById('story_url').focus()
   }
 
   on('change', '#story_title', Lobster.checkStoryTitle);
 
-  Lobster.checkStoryTitle()
+  on('click', '.story #flag_dropdown a', (event) => {
+    if (event.target.getAttribute('data') != '') {
+      Lobster.voteStory(parentSelector(event.target, '.story'), -1,  event.target.getAttribute('data'));
+    }
+    Lobster.modalRemoval()
+  });
 
   on('click', '#story_fetch_title', (event) => {
     Lobster.fetchURLTitle(event.target);
@@ -561,7 +549,7 @@ onPageLoad(() => {
 
   on('click', 'li.story a.flagger', (event) => {
     event.preventDefault();
-    Lobster.flagStory(event.target);
+    Lobster.modalFlaggingDropDown("story", event.target);
   });
 
   on('click', 'li.story a.hider', (event) => {
@@ -662,7 +650,14 @@ onPageLoad(() => {
 
   on('click', '.comment a.flagger', (event) => {
     event.preventDefault();
-    Lobster.flagComment(event.target);
+    Lobster.modalFlaggingDropDown("comment", event.target);
+  });
+
+  on('click', '.comment #flag_dropdown a', (event) => {
+    if (event.target.getAttribute('data') != '') {
+      Lobster.voteComment(parentSelector(event.target, '.comment'), -1,  event.target.getAttribute('data'));
+    }
+    Lobster.modalRemoval()
   });
 
   on("click", '.comment a.upvoter', (event) => {
@@ -705,7 +700,7 @@ onPageLoad(() => {
       .then(response => {
         response.text().then(text => {
           replace(comment, text);
-        autosize(document.querySelectorAll('textarea'));
+          autosize(document.querySelectorAll('textarea'));
         });
       });
     autosize(document.querySelectorAll('textarea'));

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -134,12 +134,16 @@ class _LobstersFunction {
     if (!Lobsters.curUser)
       return Lobster.bounceToLogin();
 
-    const li = parentSelector(voterEl, '.story, .comment');
-    if (li.classList.contains("flagged")) {
-      /* already upvoted, neutralize */
-      Lobster.vote(flaggedItem, voterEl, -1, null);
-      return;
-    }
+      const li = parentSelector(voterEl, '.story, .comment');
+      if (li.classList.contains('flagged')) {
+        /* already upvoted, neutralize */
+        if (li.classList.contains('story')) {
+        Lobster.voteStory(voterEl, -1, null);
+        } else {
+          Lobster.voteComment(voterEl, -1, null);
+        }
+        return
+      }
 
     if (document.querySelector("#flag_dropdown")) {
       document.querySelector("#flag_dropdown").remove();
@@ -252,12 +256,12 @@ class _LobstersFunction {
 
   flagComment(voterEl) {
     Lobster.modalFlaggingDropDown("comment", voterEl, function(k) {
-      Lobster.vote("comment", voterEl, -1, k); });
+      Lobster.voteComment(voterEl, -1, k); });
   }
 
   flagStory(voterEl) {
     Lobster.modalFlaggingDropDown("story", voterEl, function(k) {
-      Lobster.vote("story", voterEl, -1, k); });
+      Lobster.voteStory(voterEl, -1, k); });
   }
 
   hideStory(hiderEl) {
@@ -347,18 +351,18 @@ class _LobstersFunction {
   }
 
   upvoteComment(voterEl) {
-    Lobster.vote("comment", voterEl, 1);
+    Lobster.voteComment(voterEl, 1);
   }
 
   upvoteStory(voterEl) {
-    Lobster.vote("story", voterEl, 1);
+    Lobster.voteStory(voterEl, 1);
   }
 
-  vote(elementType, voterEl, point, reason) {
+  voteStory(voterEl, point, reason) {
     if (!Lobster.curUser)
       return Lobster.bounceToLogin();
 
-    const li = parentSelector(voterEl, ".story, .comment");
+    const li = parentSelector(voterEl, '.story');
     const scoreDiv = li.querySelector("div.score");
     const formData = new FormData();
     formData.append('reason', reason || '');
@@ -418,13 +422,81 @@ class _LobstersFunction {
         li.querySelector(".flagger").textContent = "flag";
       } else if (action == "flag") {
         li.querySelector(".flagger").textContent = "unflag";
-      if (elementType == "comment") {
-        li.querySelector(".reason").innerHTML = "| " + Lobster.commentFlagReasons[reason].toLowerCase();
-      }
     }
 
-    fetchWithCSRF("/" + (elementType == "story" ? "stories" : elementType + "s") + "/" +
-      li.getAttribute("data-shortid") + "/" + action, {
+    fetchWithCSRF("/stories/" + li.getAttribute("data-shortid") + "/" + action, {
+      method: 'post',
+      body: formData });
+  }
+
+  voteComment(voterEl, point, reason) {
+    if (!Lobster.curUser)
+      return Lobster.bounceToLogin();
+
+    const li = parentSelector(voterEl, ".comment");
+    const scoreDiv = li.querySelector("div.score");
+    const formData = new FormData();
+    formData.append('reason', reason || '');
+    let showScore = true;
+    let score = parseInt(scoreDiv.innerHTML);
+    let action = "";
+
+    if (isNaN(score)) {
+      showScore = false;
+      score = 0;
+    }
+
+    if (li.classList.contains("upvoted") && point > 0) {
+      /* already upvoted, neutralize */
+      li.classList.remove("upvoted");
+      score--;
+      action = "unvote";
+    } else if (li.classList.contains("flagged") && point < 0) {
+      /* already flagged, neutralize */
+      li.classList.remove("flagged");
+      score++;
+      action = "unvote";
+    } else if (point > 0) {
+      if (li.classList.contains("flagged")) {
+        /* Give back the lost flagged point */
+        score++;
+      }
+      li.classList.remove("flagged");
+      li.classList.add("upvoted");
+      score++;
+      action = "upvote";
+    } else if (point < 0) {
+      if (li.classList.contains("upvoted")) {
+        /* Removes the upvote point this user already gave the story*/
+        score--;
+      }
+      li.classList.remove("upvoted");
+      li.classList.add("flagged");
+      if (li.parentElement.querySelector('.comment_folder_button')) {
+        li.parentElement.querySelector('.comment_folder_button').setAttribute("checked", true);
+      };
+      showScore = false;
+      score--;
+      action = "flag";
+    }
+    if (showScore) {
+      scoreDiv.innerHTML = score;
+    } else {
+      scoreDiv.innerHTML = '~';
+    }
+    if (action == "upvote" || action == "unvote") {
+      if (li.querySelector(".reason")) {
+        li.querySelector(".reason").innerHTML = ""
+      };
+
+      if (action == "unvote" && point < 0)
+        li.querySelector(".flagger").textContent = "flag";
+      } else if (action == "flag") {
+        li.querySelector(".flagger").textContent = "unflag";
+        li.querySelector(".reason").innerHTML = "| " + Lobster.commentFlagReasons[reason].toLowerCase();
+    }
+
+    fetchWithCSRF("/comments/" + li.getAttribute("data-shortid") + "/" + action, {
       method: 'post',
       body: formData });
   }

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -7,80 +7,6 @@
 var _Lobsters = Class.extend({
   curUser: null,
 
-  storyFlagReasons: { <%= Vote::STORY_REASONS.map{|k,v|
-      "#{k.inspect}: #{v.inspect}" }.join(", ") %> },
-  commentFlagReasons: { <%= Vote::COMMENT_REASONS.map{|k,v|
-      "#{k.inspect}: #{v.inspect}" }.join(", ") %> },
-
-  _showFlagWhyAt: function(thingType, voterEl, onChooseWhy) {
-    if (!Lobsters.curUser)
-      return Lobster.bounceToLogin();
-
-    var li = $(voterEl).closest(".story, .comment");
-    if (li.hasClass("flagged")) {
-      /* already upvoted, neutralize */
-      Lobster.vote(thingType, voterEl, -1, null);
-      return;
-    }
-
-    if ($("#flag_why"))
-      $("#flag_why").remove();
-    if ($("#flag_why_shadow"))
-      $("#flag_why_shadow").remove();
-
-    var sh = $("<div id=\"flag_why_shadow\"></div>");
-    $(voterEl).after(sh);
-    sh.click(function() {
-      $("#flag_why_shadow").remove();
-      $("#flag_why").remove();
-    });
-
-    var d = $("<div id=\"flag_why\"></div>");
-
-    var reasons;
-    if (thingType == "comment")
-      reasons = Lobsters.commentFlagReasons;
-    else
-      reasons = Lobsters.storyFlagReasons;
-
-    $.each(reasons, function(k, v) {
-      var a = $("<a href=\"#\"" + (k == "" ? " class=\"cancelreason\"" : "") +
-        ">" + v + "</a>");
-
-      a.click(function() {
-        $("#flag_why").remove();
-        $("#flag_why_shadow").remove();
-
-        if (k != "")
-          onChooseWhy(k);
-
-        return false;
-      });
-
-      d.append(a);
-    });
-
-    if (thingType == "story") {
-      $(voterEl).closest("li").after(d);
-      d.position({
-        my: "left top",
-        at: "left bottom",
-        offset: "-2 -2",
-        of: $(voterEl),
-        collision: "none",
-      });
-      d.css("left", $(voterEl).position().left);
-    } else {
-      // place flag menu outside of the comment to avoid inheriting opacity
-      var voterPos = $(voterEl).position();
-      d.appendTo($(voterEl).parent());
-      d.css({
-        left: voterPos.left,
-        top: voterPos.top + $(voterEl).outerHeight()
-      });
-    }
-  },
-
   runSelect2: function() {
     $("#story_tags_a").select2({
     formatSelection: function(what) {
@@ -204,6 +130,62 @@ class _LobstersFunction {
     document.location = "/login?return=" + encodeURIComponent(document.location);
   }
 
+  modalFlaggingDropDown(flaggedItem, voterEl, onChooseWhy) {
+    if (!Lobsters.curUser)
+      return Lobster.bounceToLogin();
+
+    const li = parentSelector(voterEl, '.story, .comment');
+    if (li.classList.contains("flagged")) {
+      /* already upvoted, neutralize */
+      Lobster.vote(flaggedItem, voterEl, -1, null);
+      return;
+    }
+
+    if (document.querySelector("#flag_dropdown")) {
+      document.querySelector("#flag_dropdown").remove();
+    }
+    if (document.querySelector("#modal_backdrop")) {
+      document.querySelector("#modal_backdrop").remove();
+    }
+
+    const modalDiv = document.createElement("div");
+    modalDiv.setAttribute('id', 'modal_backdrop');
+    // voterEl.after(modalDiv);
+    document.body.appendChild(modalDiv);
+
+    const flaggingDropDown = document.createElement('div');
+    flaggingDropDown.setAttribute('id', 'flag_dropdown');
+    document.body.appendChild(flaggingDropDown);
+    flaggingDropDown.style.top = "" + (voterEl.getBoundingClientRect().bottom + window.pageYOffset + 2) + "px";
+    flaggingDropDown.style.left = "" + (voterEl.getBoundingClientRect().left + window.pageXOffset) + "px";
+
+    let reasons;
+    if (flaggedItem == "comment") {
+      reasons = Lobster.commentFlagReasons;
+    } else {
+      reasons = Lobster.storyFlagReasons;
+    }
+
+    Object.keys(reasons).map(function(k, v) {
+      let a = document.createElement('a')
+      a.textContent = reasons[k]
+      a.setAttribute('data', k)
+      if (k === ''){
+        a.setAttribute('href', '#' )
+        a.classList.add('cancel-reason')
+      } else {
+        a.setAttribute('href', '#')
+      }
+      flaggingDropDown.append(a);
+    });
+
+    on('click', '#flag_dropdown a', (event) => {
+      if (event.target.getAttribute('data') != '')
+        onChooseWhy(event.target.getAttribute('data'));
+      return false;
+    });
+  }
+
   checkStoryDuplicate(form) {
     const formData = new FormData(form);
     const action = '/stories/check_url_dupe';
@@ -267,12 +249,12 @@ class _LobstersFunction {
   }
 
   flagComment(voterEl) {
-    Lobsters._showFlagWhyAt("comment", voterEl, function(k) {
+    Lobster.modalFlaggingDropDown("comment", voterEl, function(k) {
       Lobster.vote("comment", voterEl, -1, k); });
   }
 
   flagStory(voterEl) {
-    Lobsters._showFlagWhyAt("story", voterEl, function(k) {
+    Lobster.modalFlaggingDropDown("story", voterEl, function(k) {
       Lobster.vote("story", voterEl, -1, k); });
   }
 
@@ -360,10 +342,6 @@ class _LobstersFunction {
       saverEl.innerHTML = "unsave";
     }
     fetchWithCSRF("/stories/" + li.getAttribute("data-shortid") + "/" + act, {method: 'post'});
-  }
-
-  _showFlagWhyAt(thingType, voterEl, onChooseWhy) {
-
   }
 
   upvoteComment(voterEl) {
@@ -461,6 +439,17 @@ onPageLoad(() => {
   on('click', '.markdown_help_label', (event) => {
     parentSelector(event.target, '.markdown_help_toggler').querySelector('.markdown_help').classList.toggle('display-block');
   });
+
+  on('click', '#flag_dropdown a', (event) => {
+    document.querySelector("#flag_dropdown").remove();
+    document.querySelector("#modal_backdrop").remove();
+  });
+
+  on('click', '#modal_backdrop', (event) => {
+    event.preventDefault();
+    event.target.remove();
+    document.querySelector("#flag_dropdown").remove();
+  })
 
   // Account Settings Functions
 

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -374,7 +374,7 @@ class _LobstersFunction {
     Lobster.vote("story", voterEl, 1);
   }
 
-  vote(thingType, voterEl, point, reason) {
+  vote(elementType, voterEl, point, reason) {
     if (!Lobster.curUser)
       return Lobster.bounceToLogin();
 
@@ -438,12 +438,12 @@ class _LobstersFunction {
         li.querySelector(".flagger").textContent = "flag";
       } else if (action == "flag") {
         li.querySelector(".flagger").textContent = "unflag";
-      if (thingType == "comment") {
+      if (elementType == "comment") {
         li.querySelector(".reason").innerHTML = "| " + Lobster.commentFlagReasons[reason].toLowerCase();
       }
     }
 
-    fetchWithCSRF("/" + (thingType == "story" ? "stories" : thingType + "s") + "/" +
+    fetchWithCSRF("/" + (elementType == "story" ? "stories" : elementType + "s") + "/" +
       li.getAttribute("data-shortid") + "/" + action, {
       method: 'post',
       body: formData });

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -505,6 +505,10 @@ onPageLoad(() => {
 
   // Story Related Functions
 
+  if (document.getElementById('story_url') && !document.getElementById('story_preview').firstElementChild) {
+    document.getElementById('story_url').focus()
+  }
+
   on('change', '#story_title', Lobster.checkStoryTitle);
 
   Lobster.checkStoryTitle()

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -150,14 +150,16 @@ class _LobstersFunction {
 
     const modalDiv = document.createElement("div");
     modalDiv.setAttribute('id', 'modal_backdrop');
-    // voterEl.after(modalDiv);
     document.body.appendChild(modalDiv);
 
     const flaggingDropDown = document.createElement('div');
     flaggingDropDown.setAttribute('id', 'flag_dropdown');
-    document.body.appendChild(flaggingDropDown);
-    flaggingDropDown.style.top = "" + (voterEl.getBoundingClientRect().bottom + window.pageYOffset + 2) + "px";
-    flaggingDropDown.style.left = "" + (voterEl.getBoundingClientRect().left + window.pageXOffset) + "px";
+    const flaggingWrapper = document.createElement('span');
+    flaggingWrapper.style.position = 'relative';
+    flaggingWrapper.style.maxWidth = '1 px';
+    flaggingWrapper.style.maxHeight = '1 px';
+    flaggingWrapper.appendChild(flaggingDropDown);
+    voterEl.after(flaggingWrapper);
 
     let reasons;
     if (flaggedItem == "comment") {

--- a/app/assets/stylesheets/application.css.erb
+++ b/app/assets/stylesheets/application.css.erb
@@ -1017,15 +1017,15 @@ div.comment_text code {
 }
 
 
-#flag_why, .archive-dropdown {
+#flag_dropdown, .archive-dropdown {
 	position: absolute;
-	left: 50%;
+  left: 50%;
 	width: 100px;
 	border: 1px solid var(--color-box-border);
 	border-bottom: 0;
 	z-index: 15;
 }
-#flag_why a, .archive-dropdown a {
+#flag_dropdown a, .archive-dropdown a {
 	background-color: var(--color-box-bg);
 	border-bottom: 1px solid var(--color-box-border);
 	color: var(--color-fg-contrast-10);
@@ -1034,15 +1034,15 @@ div.comment_text code {
 	padding: 3px;
 	text-decoration: underline;
 }
-#flag_why a:hover, .archive-dropdown a:hover {
+#flag_dropdown a:hover, .archive-dropdown a:hover {
 	background-color: var(--color-box-bg-shaded);
 }
-#flag_why a.cancelreason {
+#flag_dropdown a.cancel-reason {
 	background-color: var(--color-box-bg-shaded);
 	font-size: 8pt;
 }
 
-#flag_why_shadow {
+#modal_backdrop {
 	position: fixed;
 	width: 100%;
 	height: 100%;
@@ -1053,7 +1053,7 @@ div.comment_text code {
 	z-index: 1;
 }
 
-/* archive; dropdown styling is with #flag_why to match it */
+/* archive; dropdown styling is with #flag_dropdown to match it */
 .archive_button {
 	display: none;
 }

--- a/app/assets/stylesheets/application.css.erb
+++ b/app/assets/stylesheets/application.css.erb
@@ -1570,7 +1570,7 @@ div.flash-success h2 {
 	}
 	header#nav {
 		background-color: var(--color-box-bg-shaded);
-		border-bottom:: 1px solid var(--color-box-border);
+		border-bottom: 1px solid var(--color-box-border);
 		flex-flow: row nowrap;
 		height: 44px;
 		min-width: 100%;

--- a/app/assets/stylesheets/application.css.erb
+++ b/app/assets/stylesheets/application.css.erb
@@ -1019,7 +1019,7 @@ div.comment_text code {
 
 #flag_dropdown, .archive-dropdown {
 	position: absolute;
-  left: 50%;
+  left: -1.5rem;
 	width: 100px;
 	border: 1px solid var(--color-box-border);
 	border-bottom: 0;

--- a/app/views/stories/new.html.erb
+++ b/app/views/stories/new.html.erb
@@ -31,11 +31,3 @@
     <%= render :template => "stories/show" %>
   <% end %>
 </div>
-
-<script>
-  $(document).ready(function() {
-    <% if !@story.previewing %>
-      $("#story_url").focus();
-    <% end %>
-  });
-</script>


### PR DESCRIPTION
The vote function was used for both stories & comments to process both voting them up & flagging them.  This allowed for a lot of bugs and required onClick event functions to be created within the function, instead of as an onPageLoad event.
This pull request is step 1 of a 2 step process to split the voting into separate functions for stories or comments.  It will also reduce the chance of errors by reducing the number of params passed. Instead the functions will internally know if they are handling a story or comment, rather than searching the DOM to determine what type of element it is handling .

This will double some of the code but remove complexity and chance for errors. I can later reduce some of the duplication in the follow up pull request.

This pull request includes:

Functions that have removed jQuery:
- auto adding tags when people post from sites like youtube (Still needs work due to select2)
- flagging stories & comments

Other fixes:
- removing html script tags and changing them to an onPageLoad function
- prevented select2 from running before the fetch request resolved
- a typo in the css
- Split voting and flagging into comments & stories rather than one really large function that does all four. 
    - This removes the 'story'/'comment' param from the function and all of the gates to determine which of the two it is trying to process.  This makes it much easier to fix future bugs.
    - This will fix future bugs related to flagging and an event trigger that currently get created when you click the flag button.
-  Created a function to handle all of the flagging & modal removal.
