### PR TITLE
Fix js bugs in the story functions from removing the jQuery

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -217,12 +217,13 @@ class _LobstersFunction {
     const title_field = document.getElementById('story_title');
     const formData = new FormData();
     const old_text = button.textContent;
-    button.setAttribute("disabled", true);
-    button.textContent = "Fetching...";
-    formData.append('fetch_url', targetUrl);
 
     if (targetUrl == "")
       return;
+
+    button.setAttribute("disabled", true);
+    button.textContent = "Fetching...";
+    formData.append('fetch_url', targetUrl);
 
     fetchWithCSRF('/stories/fetch_url_attributes', {
       method: 'post',
@@ -295,12 +296,12 @@ class _LobstersFunction {
   previewStory(formElement) {
     const formData = new FormData(formElement);
     const previewElement = document.getElementById('inside');
-    fetch('/stories/preview', {
+    fetchWithCSRF('/stories/preview', {
       method: 'post',
       body: formData
     }).then (response => {
       response.text().then(text => {
-        replace(previewElement, text);
+        previewElement.innerHTML = text;
         Lobsters.runSelect2();
       });
     });
@@ -514,7 +515,7 @@ onPageLoad(() => {
 
   Lobster.checkStoryTitle()
 
-  if (document.getElementById('story_url') && !document.getElementById('story_preview').firstElementChild) {
+  if (document.getElementById('story_url') && document.getElementById('story_preview') && !document.getElementById('story_preview').firstElementChild) {
     document.getElementById('story_url').focus()
   }
 
@@ -576,9 +577,9 @@ onPageLoad(() => {
     }
 
     // check for dupe if there's a URL, but not when editing existing
-    if (document.getElementById('story_url') &&
-      document.querySelector('input[name="_method"]') &&
-      (document.querySelector('input[name="_method"]').getAttribute('value') !== 'put')) {
+    if (document.getElementById('story_url').getAttribute('value') !== "" &&
+      (!document.querySelector('input[name="_method"]') ||
+      document.querySelector('input[name="_method"]').getAttribute('value') === 'put')) {
         Lobster.checkStoryDuplicate(parentSelector(document.getElementById('story_url'), 'form'));
     }
   });


### PR DESCRIPTION
This will fix a few bugs that fell into production during the migration away from jQuery.

- fetching the url title when it is blank
- putting a warning up for a duplicate url over 30 days old
- pressing the preview story button a second time

