### PR TITLE
HTML related fixes for the tag list page.

### DIFF
--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -36,11 +36,9 @@
   <% end %>
 
   <% if is_admin %>
-    <div>
-      <%= link_to 'Create New Tag', new_tag_path %>
-    </div>
-    <div>
+    <p>
+      <%= link_to 'Create New Tag', new_tag_path %><br/>
       <%= link_to 'Create New Category', new_category_path %>
-    </div>
+    </p>
   <% end %>
 </div>

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -31,8 +31,8 @@
         <% end %>
         </span>
         </li>
-      <% end %>
-    </ol>
+      </ol>
+    <% end %>
   <% end %>
 
   <% if is_admin %>


### PR DESCRIPTION
This PR contains two minor HTML related fixes for the tag list (`/tags`).

* Fix unexpected nested `<ol>` elements for tag list.
  <img width="720" alt="Screenshot 2022-08-04 23 13 31" src="https://user-images.githubusercontent.com/8158163/182883146-82686838-b27b-4e53-890f-a61a0a58f9b9.png">

* Use `<p>` instead of `<div>` for admin actions area at the bottom of the tag list to provide extra vertical margins.
  <img width="720" alt="Screenshot 2022-08-04 23 18 03" src="https://user-images.githubusercontent.com/8158163/182884091-2117f7eb-9e4f-40ee-bc72-45d6a28533b9.png">

