### PR TITLE
Domains update action and banning logic

### DIFF
--- a/app/controllers/domains_controller.rb
+++ b/app/controllers/domains_controller.rb
@@ -1,13 +1,13 @@
 class DomainsController < ApplicationController
   before_action :require_logged_in_admin
   before_action :set_domain, only: [:update, :edit, :unban]
+  before_action :set_reason, only: [:update, :unban]
 
   def edit; end
 
   def update
-    banned_reason = params.dig('domain', 'banned_reason')
-    if banned_reason.present?
-      @domain.ban_by_user_for_reason!(@user, banned_reason)
+    if @banned_reason.present?
+      @domain.ban_by_user_for_reason!(@user, @banned_reason)
     else
       flash[:error] = "You must give a reason for the ban"
     end
@@ -16,7 +16,12 @@ class DomainsController < ApplicationController
   end
 
   def unban
-    @domain.unban_by_user!(@user)
+    if @banned_reason.present?
+      @domain.unban_by_user_for_reason!(@user, @banned_reason)
+    else
+      flash[:error] = "You must give a reason for the unban"
+    end
+
     redirect_to edit_domain_path(name: @domain.domain)
   end
 
@@ -25,4 +30,21 @@ private
   def set_domain
     @domain = Domain.find_by(domain: params[:name])
   end
+
+  def set_reason
+    @banned_reason = params.dig('domain', 'banned_reason')
+  end
+
+  def path_of_form(domain)
+    prms = { name: domain.domain }
+    domain.banned_at ? unban_domain_path(prms) : update_domain_path(prms)
+  end
+
+  helper_method :path_of_form
+
+  def caption_of_button(domain)
+    domain.banned_at ? 'Unban' : 'Ban'
+  end
+
+  helper_method :caption_of_button
 end

--- a/app/controllers/domains_controller.rb
+++ b/app/controllers/domains_controller.rb
@@ -1,6 +1,6 @@
 class DomainsController < ApplicationController
   before_action :require_logged_in_admin
-  before_action :set_domain, only: [:update, :edit]
+  before_action :set_domain, only: [:update, :edit, :unban]
 
   def edit; end
 
@@ -12,12 +12,17 @@ class DomainsController < ApplicationController
       flash[:error] = "You must give a reason for the ban"
     end
 
-    redirect_to edit_domain_path(domain_name: @domain.domain)
+    redirect_to edit_domain_path(name: @domain.domain)
+  end
+
+  def unban
+    @domain.unban_by_user!(@user)
+    redirect_to edit_domain_path(name: @domain.domain)
   end
 
 private
 
   def set_domain
-    @domain = Domain.find_by(domain: params[:domain_name])
+    @domain = Domain.find_by(domain: params[:name])
   end
 end

--- a/app/controllers/domains_controller.rb
+++ b/app/controllers/domains_controller.rb
@@ -1,23 +1,10 @@
 class DomainsController < ApplicationController
   before_action :require_logged_in_admin
-  before_action :set_domain, only: [:update, :edit, :ban]
+  before_action :set_domain, only: [:update, :edit]
 
   def edit; end
 
   def update
-    result_domain_name =
-      if @domain.update(domain_params)
-        flash[:success] = "Domain #{@domain.domain} has been updated"
-        @domain.domain
-      else
-        flash[:error] = "Domain not updated: #{@domain.errors.full_messages.join(', ')}"
-        params[:domain_name]
-      end
-
-    redirect_to edit_domain_path(domain_name: result_domain_name)
-  end
-
-  def ban
     banned_reason = params.dig('domain', 'banned_reason')
     if banned_reason.present?
       @domain.ban_by_user_for_reason!(@user, banned_reason)
@@ -32,9 +19,5 @@ private
 
   def set_domain
     @domain = Domain.find_by(domain: params[:domain_name])
-  end
-
-  def domain_params
-    params.require(:domain).permit(:domain)
   end
 end

--- a/app/controllers/domains_controller.rb
+++ b/app/controllers/domains_controller.rb
@@ -1,0 +1,40 @@
+class DomainsController < ApplicationController
+  before_action :require_logged_in_admin
+  before_action :set_domain, only: [:update, :edit, :ban]
+
+  def edit; end
+
+  def update
+    result_domain_name =
+      if @domain.update(domain_params)
+        flash[:success] = "Domain #{@domain.domain} has been updated"
+        @domain.domain
+      else
+        flash[:error] = "Domain not updated: #{@domain.errors.full_messages.join(', ')}"
+        params[:domain_name]
+      end
+
+    redirect_to edit_domain_path(domain_name: result_domain_name)
+  end
+
+  def ban
+    banned_reason = params.dig('domain', 'banned_reason')
+    if banned_reason.present?
+      @domain.ban_by_user_for_reason!(@user, banned_reason)
+    else
+      flash[:error] = "You must give a reason for the ban"
+    end
+
+    redirect_to edit_domain_path(domain_name: @domain.domain)
+  end
+
+private
+
+  def set_domain
+    @domain = Domain.find_by(domain: params[:domain_name])
+  end
+
+  def domain_params
+    params.require(:domain).permit(:domain)
+  end
+end

--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -9,11 +9,31 @@ class Domain < ApplicationRecord
   validates :domain, presence: true
 
   def ban_by_user_for_reason!(banner, reason)
-    banning_switcher(:on, banner, reason)
+    self.banned_at = Time.current
+    self.banned_by_user_id = banner.id
+    self.banned_reason = reason
+    self.save!
+
+    m = Moderation.new
+    m.moderator_user_id = banner.id
+    m.domain = self
+    m.action = 'Banned'
+    m.reason = reason
+    m.save!
   end
 
-  def unban_by_user!(banner)
-    banning_switcher(:off, banner)
+  def unban_by_user_for_reason!(banner, reason)
+    self.banned_at = nil
+    self.banned_by_user_id = nil
+    self.banned_reason = nil
+    self.save!
+
+    m = Moderation.new
+    m.moderator_user_id = banner.id
+    m.domain = self
+    m.action = 'Unbanned'
+    m.reason = reason
+    m.save!
   end
 
   def banned?
@@ -26,21 +46,5 @@ class Domain < ApplicationRecord
 
   def to_param
     domain
-  end
-
-private
-
-  def banning_switcher(state, banner, reason = nil)
-    self.banned_at = state == :on ? Time.current : nil
-    self.banned_by_user_id = state == :on ? banner.id : nil
-    self.banned_reason = state == :on ? reason : nil
-    self.save!
-
-    m = Moderation.new
-    m.moderator_user_id = banner.id
-    m.domain = self
-    m.action = state == :on ? 'Banned' : 'Unbanned'
-    m.reason = reason
-    m.save!
   end
 end

--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -7,7 +7,6 @@ class Domain < ApplicationRecord
   validates :banned_reason, :length => { :maximum => 200 }
 
   validates :domain, presence: true
-  validates :is_tracker, inclusion: { in: [true, false] }
 
   def ban_by_user_for_reason!(banner, reason)
     self.banned_at = Time.current

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -216,9 +216,6 @@ class Story < ApplicationRecord
     if self.domain.banned?
       ModNote.tattle_on_story_domain!(self, "banned")
       errors.add(:url, "is from banned domain #{self.domain.domain}: #{self.domain.banned_reason}")
-    elsif self.domain.is_tracker
-      ModNote.tattle_on_story_domain!(self, "tracking")
-      errors.add(:url, "is a link shortening or ad tracking domain")
     end
   end
 

--- a/app/views/domains/edit.html.erb
+++ b/app/views/domains/edit.html.erb
@@ -1,0 +1,49 @@
+<div class="box wide">
+  <%= form_with model: @domain, url: update_domain_path, method: :post, local: true do |f| %>
+    <div class="boxline">
+      <%= f.label :domain, 'Domain:', class: 'required' %>
+      <%= f.text_field :domain  %>
+    </div>
+
+    <div class="boxline">
+      <%= f.submit 'Update Domain' %>
+    </div>
+  <% end %>
+
+  <% unless @domain.banned_at %>
+    <%= form_with model: @domain, url: ban_domain_path, method: :post, local: true do |f| %>
+      <div class="boxline">
+        <%= f.label :banned_reason, 'Ban Reason:', class: 'required' %>
+        <%= f.text_field :banned_reason  %>
+      </div>
+
+      <div class="boxline">
+        <%= f.submit 'Ban', class: 'deletion' %>
+      </div>
+    <% end %>
+  <% else %>
+    <label class="required">Status:</label>
+    <span class="d">
+      Banned
+    </span>
+    <br>
+
+    <label class="required">Banned Reason:</label>
+    <span class="d">
+      <%= @domain.banned_reason %>
+    </span>
+    <br>
+
+    <label class="required">Banned At:</label>
+    <span class="d">
+      <%= @domain.banned_at %>
+    </span>
+    <br>
+
+    <label class="required">Banned by User:</label>
+    <span class="d">
+      <%= @domain.banned_by_user.username %>
+    </span>
+
+  <% end %>
+</div>

--- a/app/views/domains/edit.html.erb
+++ b/app/views/domains/edit.html.erb
@@ -1,17 +1,7 @@
 <div class="box wide">
-  <%= form_with model: @domain, url: update_domain_path, method: :post, local: true do |f| %>
-    <div class="boxline">
-      <%= f.label :domain, 'Domain:', class: 'required' %>
-      <%= f.text_field :domain  %>
-    </div>
-
-    <div class="boxline">
-      <%= f.submit 'Update Domain' %>
-    </div>
-  <% end %>
-
+  <h1><%= @domain.domain %></h1>
   <% unless @domain.banned_at %>
-    <%= form_with model: @domain, url: ban_domain_path, method: :post, local: true do |f| %>
+    <%= form_with model: @domain, url: update_domain_path, method: :post, local: true do |f| %>
       <div class="boxline">
         <%= f.label :banned_reason, 'Ban Reason:', class: 'required' %>
         <%= f.text_field :banned_reason  %>

--- a/app/views/domains/edit.html.erb
+++ b/app/views/domains/edit.html.erb
@@ -35,5 +35,7 @@
       <%= @domain.banned_by_user.username %>
     </span>
 
+    <%= button_to 'Unban', unban_domain_path(name: @domain.domain), method: :post, class: 'deletion' %>
+
   <% end %>
 </div>

--- a/app/views/domains/edit.html.erb
+++ b/app/views/domains/edit.html.erb
@@ -1,17 +1,7 @@
 <div class="box wide">
   <h1><%= @domain.domain %></h1>
-  <% unless @domain.banned_at %>
-    <%= form_with model: @domain, url: update_domain_path, method: :post, local: true do |f| %>
-      <div class="boxline">
-        <%= f.label :banned_reason, 'Ban Reason:', class: 'required' %>
-        <%= f.text_field :banned_reason  %>
-      </div>
 
-      <div class="boxline">
-        <%= f.submit 'Ban', class: 'deletion' %>
-      </div>
-    <% end %>
-  <% else %>
+  <% if @domain.banned_at %>
     <label class="required">Status:</label>
     <span class="d">
       Banned
@@ -34,8 +24,16 @@
     <span class="d">
       <%= @domain.banned_by_user.username %>
     </span>
+  <% end %>
 
-    <%= button_to 'Unban', unban_domain_path(name: @domain.domain), method: :post, class: 'deletion' %>
+  <%= form_with model: @domain, url: path_of_form(@domain), method: :post, local: true do |f| %>
+    <div class="boxline">
+      <%= f.label :banned_reason, "#{caption_of_button(@domain)} Reason:", class: 'required' %>
+      <%= f.text_field :banned_reason  %>
+    </div>
 
+    <div class="boxline">
+      <%= f.submit caption_of_button(@domain), class: 'deletion' %>
+    </div>
   <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -178,6 +178,11 @@ Rails.application.routes.draw do
   post "/tags" => "tags#create"
   post "/tags/:tag_name" => "tags#update", :as => "update_tag"
 
+  dm_con = { :domain_name => /[-,0-z\.]+/ }
+  get "/domains/:domain_name" => "domains#edit", :as => "edit_domain", :constraints => dm_con
+  post "/domains/:domain_name" => "domains#update", :as => "update_domain", :constraints => dm_con
+  post "/domains/ban/:domain_name" => "domains#ban", :as => "ban_domain", :constraints => dm_con
+
   get "/categories/new" => "categories#new", :as => "new_category"
   get "/categories/:category_name/edit" => "categories#edit", :as => "edit_category"
   get "/categories/:category" => "home#category", :as => :category

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -181,7 +181,6 @@ Rails.application.routes.draw do
   dm_con = { :domain_name => /[-,0-z\.]+/ }
   get "/domains/:domain_name" => "domains#edit", :as => "edit_domain", :constraints => dm_con
   post "/domains/:domain_name" => "domains#update", :as => "update_domain", :constraints => dm_con
-  post "/domains/ban/:domain_name" => "domains#ban", :as => "ban_domain", :constraints => dm_con
 
   get "/categories/new" => "categories#new", :as => "new_category"
   get "/categories/:category_name/edit" => "categories#edit", :as => "edit_category"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,9 +69,15 @@ Rails.application.routes.draw do
   get "/t/:tag" => "home#multi_tag", :as => "multi_tag"
   get "/t/:tag/page/:page" => "home#tagged"
 
+  dm_con = { :name => /([^\/]+?)(?=\.json|\.rss|$|\/)/ }
   get "/domain/:name(.:format)" => "home#for_domain", :as => "domain",
-    :constraints => { name: /[^\/]+?/, format: /json|rss/ }
+    :constraints => dm_con
+
   get "/domain/:name/page/:page" => "home#for_domain", :constraints => { name: /[^\/]+/ }
+
+  get "/domains/:name" => "domains#edit", :as => "edit_domain", :constraints => dm_con
+  post "/domains/:name/unban" => "domains#unban", :as => "unban_domain", :constraints => dm_con
+  post "/domains/:name" => "domains#update", :as => "update_domain", :constraints => dm_con
 
   get "/search" => "search#index"
   get "/search/:q" => "search#index"
@@ -177,10 +183,6 @@ Rails.application.routes.draw do
   get "/tags/:tag_name/edit" => "tags#edit", :as => "edit_tag"
   post "/tags" => "tags#create"
   post "/tags/:tag_name" => "tags#update", :as => "update_tag"
-
-  dm_con = { :domain_name => /[-,0-z\.]+/ }
-  get "/domains/:domain_name" => "domains#edit", :as => "edit_domain", :constraints => dm_con
-  post "/domains/:domain_name" => "domains#update", :as => "update_domain", :constraints => dm_con
 
   get "/categories/new" => "categories#new", :as => "new_category"
   get "/categories/:category_name/edit" => "categories#edit", :as => "edit_category"

--- a/db/migrate/20220806200248_set_is_tracker_as_banned_to_domains.rb
+++ b/db/migrate/20220806200248_set_is_tracker_as_banned_to_domains.rb
@@ -1,0 +1,10 @@
+class SetIsTrackerAsBannedToDomains < ActiveRecord::Migration[7.0]
+  def up
+    if ActiveRecord::Base.connection.column_exists?(:domains, :is_tracker)
+      banned_by_user = User.find_by(username: 'pushcx')
+      Domain.where(is_tracker: true).each do |domain|
+        domain.ban_by_user_for_reason!(banned_by_user, 'Used for link shortening and ad tracking')
+      end
+    end
+  end
+end

--- a/db/migrate/20220806200248_set_is_tracker_as_banned_to_domains.rb
+++ b/db/migrate/20220806200248_set_is_tracker_as_banned_to_domains.rb
@@ -1,10 +1,10 @@
 class SetIsTrackerAsBannedToDomains < ActiveRecord::Migration[7.0]
   def up
-    if ActiveRecord::Base.connection.column_exists?(:domains, :is_tracker)
-      banned_by_user = User.find_by(username: 'pushcx')
-      Domain.where(is_tracker: true).each do |domain|
-        domain.ban_by_user_for_reason!(banned_by_user, 'Used for link shortening and ad tracking')
-      end
+    banned_by_user = User.find_by(username: 'pushcx')
+    Domain.where(is_tracker: true).each do |domain|
+      domain.ban_by_user_for_reason!(banned_by_user, 'Used for link shortening and ad tracking')
     end
+
+    remove_column :domains, :is_tracker, :boolean
   end
 end

--- a/db/migrate/20220806202153_remove_is_tracker_from_domains.rb
+++ b/db/migrate/20220806202153_remove_is_tracker_from_domains.rb
@@ -1,7 +1,0 @@
-class RemoveIsTrackerFromDomains < ActiveRecord::Migration[7.0]
-  def change
-    if ActiveRecord::Base.connection.column_exists?(:domains, :is_tracker)
-      remove_column :domains, :is_tracker, :boolean
-    end
-  end
-end

--- a/db/migrate/20220806202153_remove_is_tracker_from_domains.rb
+++ b/db/migrate/20220806202153_remove_is_tracker_from_domains.rb
@@ -1,0 +1,7 @@
+class RemoveIsTrackerFromDomains < ActiveRecord::Migration[7.0]
+  def change
+    if ActiveRecord::Base.connection.column_exists?(:domains, :is_tracker)
+      remove_column :domains, :is_tracker, :boolean
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[6.1].define(version: 2022_03_31_165136) do
-
+ActiveRecord::Schema[7.0].define(version: 2022_08_06_202153) do
   create_table "categories", charset: "utf8mb4", force: :cascade do |t|
     t.string "category"
     t.datetime "created_at", null: false
@@ -49,7 +48,6 @@ ActiveRecord::Schema[6.1].define(version: 2022_03_31_165136) do
 
   create_table "domains", charset: "utf8mb4", force: :cascade do |t|
     t.string "domain"
-    t.boolean "is_tracker", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "banned_at"

--- a/spec/features/submit_story_spec.rb
+++ b/spec/features/submit_story_spec.rb
@@ -133,7 +133,7 @@ RSpec.feature "Submitting Stories", type: :feature do
     expect(page).to have_content "Previous discussions"
   end
 
-  scenario "submitting a tracking link" do
+  scenario "submitting a banned domain" do
     Domain.create!(domain: 'example.com', banned_at: DateTime.now)
 
     expect {

--- a/spec/features/submit_story_spec.rb
+++ b/spec/features/submit_story_spec.rb
@@ -134,7 +134,7 @@ RSpec.feature "Submitting Stories", type: :feature do
   end
 
   scenario "submitting a tracking link" do
-    Domain.create!(domain: 'example.com', is_tracker: true)
+    Domain.create!(domain: 'example.com', banned_at: DateTime.now)
 
     expect {
       visit "/stories/new"
@@ -143,7 +143,7 @@ RSpec.feature "Submitting Stories", type: :feature do
       select :tag1, from: 'Tags'
       click_button "Submit"
 
-      expect(page).to have_content "tracking"
+      expect(page).to have_content "banned"
     }.not_to(change { Story.count })
   end
 end

--- a/spec/models/domain_spec.rb
+++ b/spec/models/domain_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Domain, type: :model do
     }
 
     before do
-      domain.unban_by_user!(user)
+      domain.unban_by_user_for_reason!(user, 'Test reason')
     end
 
     describe 'should be unbanned' do
@@ -90,6 +90,10 @@ RSpec.describe Domain, type: :model do
 
       it 'has correct action' do
         expect(@moderation.action).to eq 'Unbanned'
+      end
+
+      it 'has correct reason' do
+        expect(@moderation.reason).to eq 'Test reason'
       end
     end
   end

--- a/spec/models/domain_spec.rb
+++ b/spec/models/domain_spec.rb
@@ -1,5 +1,96 @@
 require 'rails_helper'
 
 RSpec.describe Domain, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'ban' do
+    let(:user) { create(:user) }
+    let(:domain) { create(:domain) }
+
+    before do
+      domain.ban_by_user_for_reason!(user, 'Test reason')
+    end
+
+    describe 'should be banned' do
+      it 'has correct banned_at' do
+        expect(domain.banned_at).not_to be nil
+      end
+
+      it 'has correct banned_by_user_id' do
+        expect(domain.banned_by_user_id).to eq user.id
+      end
+
+      it 'has correct banned_reason' do
+        expect(domain.banned_reason).to eq 'Test reason'
+      end
+    end
+
+    describe 'should have moderation' do
+      before do
+        @moderation = Moderation.find_by(domain: domain)
+      end
+
+      it 'moderation should be created' do
+        expect(@moderation).not_to be nil
+      end
+
+      it 'has correct moderator_user_id' do
+        expect(@moderation.moderator_user_id).to eq user.id
+      end
+
+      it 'has correct action' do
+        expect(@moderation.action).to eq 'Banned'
+      end
+
+      it 'has correct reason' do
+        expect(@moderation.reason).to eq 'Test reason'
+      end
+    end
+  end
+
+  describe 'unban' do
+    let(:user) { create(:user) }
+    let(:domain) {
+      create(
+        :domain,
+        banned_at: Time.current,
+        banned_by_user_id: user.id,
+        banned_reason: 'test reason'
+      )
+    }
+
+    before do
+      domain.unban_by_user!(user)
+    end
+
+    describe 'should be unbanned' do
+      it 'has empty banned_at' do
+        expect(domain.banned_at).to be nil
+      end
+
+      it 'has empty banned_by_user_id' do
+        expect(domain.banned_by_user_id).to be nil
+      end
+
+      it 'has empty banned_reason' do
+        expect(domain.banned_reason).to be nil
+      end
+    end
+
+    describe 'should have moderation' do
+      before do
+        @moderation = Moderation.find_by(domain: domain)
+      end
+
+      it 'moderation should be created' do
+        expect(@moderation).not_to be nil
+      end
+
+      it 'has correct moderator_user_id' do
+        expect(@moderation.moderator_user_id).to eq user.id
+      end
+
+      it 'has correct action' do
+        expect(@moderation.action).to eq 'Unbanned'
+      end
+    end
+  end
 end

--- a/spec/requests/domains_spec.rb
+++ b/spec/requests/domains_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe "Domains", type: :request do
+  let(:user) { create(:user) }
+
+  before do
+    sign_in user
+    allow_any_instance_of(DomainsController).to receive(:require_logged_in_admin)
+  end
+
+  context 'update' do
+    let(:domain) { create(:domain) }
+
+    it 'updates domain with valid params' do
+      post "/domains/#{domain.domain}", params: { domain: { domain: 'modified_domain.com' } }
+      expect(Domain.find(domain.id).domain).to eq 'modified_domain.com'
+      expect(response).to redirect_to edit_domain_path(domain_name: 'modified_domain.com')
+    end
+
+    it 'does not update domain when the new name is blank' do
+      post "/domains/#{domain.domain}", params: { domain: { domain: '' } }
+      expect(Domain.find(domain.id).domain).not_to be_blank
+      expect(response).to redirect_to edit_domain_path
+    end
+  end
+
+  context 'ban' do
+    let(:domain) { create(:domain) }
+
+    it 'buns domain with valid params' do
+      messg = 'Banned with reason'
+      expect_any_instance_of(Domain).to receive(:ban_by_user_for_reason!).once.with(user, messg)
+
+      post "/domains/ban/#{domain.domain}", params: { domain: { banned_reason: messg } }
+      expect(response).to redirect_to edit_domain_path
+    end
+
+    it 'bans domain when the reason is blank' do
+      expect_any_instance_of(Domain).not_to receive(:ban_by_user_for_reason!)
+      post "/domains/ban/#{domain.domain}", params: { domain: { domain: '' } }
+
+      expect(response).to redirect_to edit_domain_path
+    end
+  end
+end

--- a/spec/requests/domains_spec.rb
+++ b/spec/requests/domains_spec.rb
@@ -11,33 +11,17 @@ RSpec.describe "Domains", type: :request do
   context 'update' do
     let(:domain) { create(:domain) }
 
-    it 'updates domain with valid params' do
-      post "/domains/#{domain.domain}", params: { domain: { domain: 'modified_domain.com' } }
-      expect(Domain.find(domain.id).domain).to eq 'modified_domain.com'
-      expect(response).to redirect_to edit_domain_path(domain_name: 'modified_domain.com')
-    end
-
-    it 'does not update domain when the new name is blank' do
-      post "/domains/#{domain.domain}", params: { domain: { domain: '' } }
-      expect(Domain.find(domain.id).domain).not_to be_blank
-      expect(response).to redirect_to edit_domain_path
-    end
-  end
-
-  context 'ban' do
-    let(:domain) { create(:domain) }
-
     it 'buns domain with valid params' do
       messg = 'Banned with reason'
       expect_any_instance_of(Domain).to receive(:ban_by_user_for_reason!).once.with(user, messg)
 
-      post "/domains/ban/#{domain.domain}", params: { domain: { banned_reason: messg } }
+      post "/domains/#{domain.domain}", params: { domain: { banned_reason: messg } }
       expect(response).to redirect_to edit_domain_path
     end
 
     it 'bans domain when the reason is blank' do
       expect_any_instance_of(Domain).not_to receive(:ban_by_user_for_reason!)
-      post "/domains/ban/#{domain.domain}", params: { domain: { domain: '' } }
+      post "/domains/#{domain.domain}", params: { domain: { domain: '' } }
 
       expect(response).to redirect_to edit_domain_path
     end

--- a/spec/requests/domains_spec.rb
+++ b/spec/requests/domains_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Domains", type: :request do
 
     it 'bans domain when the reason is blank' do
       expect_any_instance_of(Domain).not_to receive(:ban_by_user_for_reason!)
-      post "/domains/#{domain.domain}", params: { domain: { domain: '' } }
+      post "/domains/#{domain.domain}", params: { domain: { banned_reason: '' } }
 
       expect(response).to redirect_to edit_domain_path
     end
@@ -31,9 +31,17 @@ RSpec.describe "Domains", type: :request do
     let(:domain) { create(:domain) }
 
     it 'unbans domain with valid params' do
-      expect_any_instance_of(Domain).to receive(:unban_by_user!).once.with(user)
+      messg = 'Unbanned with reason'
+      expect_any_instance_of(Domain).to receive(:unban_by_user_for_reason!).once.with(user, messg)
 
-      post "/domains/#{domain.domain}/unban"
+      post "/domains/#{domain.domain}/unban", params: { domain: { banned_reason: messg } }
+      expect(response).to redirect_to edit_domain_path
+    end
+
+    it 'unbans domain when the reason is blank' do
+      expect_any_instance_of(Domain).not_to receive(:unban_by_user_for_reason!)
+      post "/domains/#{domain.domain}/unban", params: { domain: { banned_reason: '' } }
+
       expect(response).to redirect_to edit_domain_path
     end
   end

--- a/spec/requests/domains_spec.rb
+++ b/spec/requests/domains_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Domains", type: :request do
   context 'update' do
     let(:domain) { create(:domain) }
 
-    it 'buns domain with valid params' do
+    it 'bans domain with valid params' do
       messg = 'Banned with reason'
       expect_any_instance_of(Domain).to receive(:ban_by_user_for_reason!).once.with(user, messg)
 
@@ -23,6 +23,17 @@ RSpec.describe "Domains", type: :request do
       expect_any_instance_of(Domain).not_to receive(:ban_by_user_for_reason!)
       post "/domains/#{domain.domain}", params: { domain: { domain: '' } }
 
+      expect(response).to redirect_to edit_domain_path
+    end
+  end
+
+  context 'unban' do
+    let(:domain) { create(:domain) }
+
+    it 'unbans domain with valid params' do
+      expect_any_instance_of(Domain).to receive(:unban_by_user!).once.with(user)
+
+      post "/domains/#{domain.domain}/unban"
       expect(response).to redirect_to edit_domain_path
     end
   end


### PR DESCRIPTION
Domains controller with update action and banning logic.
Removed is_tracker field from Domain model.
According this issue:
https://github.com/lobsters/lobsters/issues/1080

