### PR TITLE
Fix 500 status in /recent.json by adding respond_to (#1114)

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -130,7 +130,13 @@ class HomeController < ApplicationController
     # our list is unstable because upvoted stories get removed, so point at /newest.rss
     @rss_link = { :title => "RSS 2.0 - Newest Items", :href => user_token_link("/newest.rss") }
 
-    render :action => "index"
+    respond_to do |format|
+      format.html { render :action => "index" }
+      format.rss {
+        render :action => "rss", :layout => false
+      }
+      format.json { render :json => @stories }
+    end
   end
 
   def saved


### PR DESCRIPTION
Fixes #1114 

/recent.json is returning a 500 error because the template is not found.
We fix this by adding multiple response types, just like in other methods is
already done.

<!--
Issues and PRs are typically reviewed Wednesday and most weekend mornings.
-->
