### PR TITLE
Fix incorrect dropdown menu location for the archive button

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -155,13 +155,7 @@ class _LobstersFunction {
 
     const flaggingDropDown = document.createElement('div');
     flaggingDropDown.setAttribute('id', 'flag_dropdown');
-    const flagWrapper = document.createElement('span');
-    flagWrapper.setAttribute('id', 'flag_wrapper')
-    flagWrapper.style.position = 'relative';
-    flagWrapper.style.maxWidth = '1 px';
-    flagWrapper.style.maxHeight = '1 px';
-    flagWrapper.appendChild(flaggingDropDown);
-    voterEl.after(flagWrapper);
+    voterEl.after(flaggingDropDown);
 
     Object.keys(reasons).map(function(k, v) {
       let a = document.createElement('a')
@@ -258,7 +252,6 @@ class _LobstersFunction {
   removeFlagModal() {
     document.getElementById("flag_dropdown").remove();
     document.getElementById("modal_backdrop").remove();
-    document.querySelector('#flag_wrapper').remove();
   }
 
   postComment(form) {

--- a/app/assets/stylesheets/application.css.erb
+++ b/app/assets/stylesheets/application.css.erb
@@ -1016,10 +1016,13 @@ div.comment_text code {
 	line-height: 1.2em;
 }
 
+.dropdown_parent {
+	position: relative;
+}
 
 #flag_dropdown, .archive-dropdown {
 	position: absolute;
-  left: -1.5rem;
+	left: -0.125rem;
 	width: 100px;
 	border: 1px solid var(--color-box-border);
 	border-bottom: 0;

--- a/app/views/stories/_listdetail.html.erb
+++ b/app/views/stories/_listdetail.html.erb
@@ -132,7 +132,10 @@ class="story <%= story.vote && story.vote[:vote] == 1 ? "upvoted" : "" %>
             | <a class="flagger">unflag (<%=
               Vote::STORY_REASONS[story.vote[:reason]].to_s.downcase %>)</a>
           <% elsif @user && @user.can_flag?(story) %>
-            | <a class="flagger">flag</a>
+            | 
+            <span class="dropdown_parent">
+              <a class="flagger">flag</a>
+            </span>
           <% end %>
           <% if story.is_hidden_by_cur_user %>
             | <%= link_to "unhide", story_unhide_path(story.short_id),
@@ -154,7 +157,7 @@ class="story <%= story.vote && story.vote[:vote] == 1 ? "upvoted" : "" %>
         <% end %>
         <% if story.url.present? %>
           |
-          <span>
+          <span class="dropdown_parent">
             <input id="archive_<%= story.short_id %>"  class="archive_button" type="checkbox">
             <label for="archive_<%= story.short_id %>">archive</label>
             <label for="archive_<%= story.short_id %>" class="archive_dismiss"></label>


### PR DESCRIPTION
<!--
Issues and PRs are typically reviewed Wednesday and most weekend mornings.
-->

This PR fixes the incorrect dropdown menu location for the archive button.
<img width="1213" alt="Screenshot 2022-08-12 23 51 03" src="https://user-images.githubusercontent.com/8158163/184394178-3020574b-7c3a-47aa-8c84-a7c3608540b5.png">

Both dropdown menus for the flag and dropdown buttons should work well after this fix:
<img width="922" alt="Screenshot 2022-08-12 23 52 37" src="https://user-images.githubusercontent.com/8158163/184394608-abc72b57-fc8f-4a88-a087-6cafc6d2d156.png">

<img width="922" alt="Screenshot 2022-08-12 23 52 34" src="https://user-images.githubusercontent.com/8158163/184394618-873070a5-2d55-48a0-a60b-39af9f632010.png">

