### PR TITLE
Fix duplicate url check bug, for both less & greater than 30 days

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -178,8 +178,9 @@ class _LobstersFunction {
   checkStoryDuplicate(form) {
     const formData = new FormData(form);
     const action = '/stories/check_url_dupe';
-    fetch(action, {
-      method: 'POST',
+    fetchWithCSRF(action, {
+      method: 'post',
+      headers: new Headers({'X-Requested-With': 'XMLHttpRequest'}),
       body: formData,
     }).then (response => {
       response.text().then(text => {
@@ -266,7 +267,7 @@ class _LobstersFunction {
     const action = form.getAttribute('action');
     formData.append('show_tree_lines', true);
     fetchWithCSRF (action, {
-      method: 'POST',
+      method: 'post',
       headers: new Headers({'X-Requested-With': 'XMLHttpRequest'}),
       body: formData
     })
@@ -281,7 +282,7 @@ class _LobstersFunction {
     formData.append('preview', 'true');
     formData.append('show_tree_lines', 'true');
     fetchWithCSRF(action, {
-      method: 'POST',
+      method: 'post',
       headers: new Headers({'X-Requested-With': 'XMLHttpRequest'}),
       body: formData
     })
@@ -294,12 +295,16 @@ class _LobstersFunction {
   }
 
   previewStory(formElement) {
+    if(!Lobster.curUser)
+      return Lobster.bounceToLogin();
+
     const formData = new FormData(formElement);
     const previewElement = document.getElementById('inside');
     fetchWithCSRF('/stories/preview', {
       method: 'post',
+      headers: new Headers({'X-Requested-With': 'XMLHttpRequest'}),
       body: formData
-    }).then (response => {
+    }).then(response => {
       response.text().then(text => {
         previewElement.innerHTML = text;
         Lobsters.runSelect2();
@@ -577,7 +582,7 @@ onPageLoad(() => {
     }
 
     // check for dupe if there's a URL, but not when editing existing
-    if (document.getElementById('story_url').getAttribute('value') !== "" &&
+    if (document.getElementById('story_url').value !== "" &&
       (!document.querySelector('input[name="_method"]') ||
       document.querySelector('input[name="_method"]').getAttribute('value') === 'put')) {
         Lobster.checkStoryDuplicate(parentSelector(document.getElementById('story_url'), 'form'));

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -527,10 +527,11 @@ onPageLoad(() => {
   on('change', '#story_title', Lobster.checkStoryTitle);
 
   on('click', '.story #flag_dropdown a', (event) => {
+    event.preventDefault();
     if (event.target.getAttribute('data') != '') {
       Lobster.voteStory(parentSelector(event.target, '.story'), -1,  event.target.getAttribute('data'));
     }
-    Lobster.removeFlagModal()
+    Lobster.removeFlagModal();
   });
 
   on('click', '#story_fetch_title', (event) => {


### PR DESCRIPTION
This is an easy fix just changing a "getAttribute" to a .value as the former only looks at the state in which it was created, not the current state.

I'm sorry that the bug crept back into the code.

I also took the opportunity to clean up some other inconsistencies. 
- When you flag a story it no longer jumps to the top of the page.