### PR TITLE
Fix bug where the comment flag dropdown is out of position.

### DIFF
--- a/app/assets/stylesheets/application.css.erb
+++ b/app/assets/stylesheets/application.css.erb
@@ -1020,6 +1020,11 @@ div.comment_text code {
 	position: relative;
 }
 
+.comments_subtree .dropdown_parent > #flag_dropdown {
+  position: absolute;
+  left: 0.25rem;
+}
+
 #flag_dropdown, .archive-dropdown {
 	position: absolute;
 	left: -0.125rem;

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -101,7 +101,9 @@ class="comment <%= comment.current_vote ? (comment.current_vote[:vote] == 1 ?
         <% end %>
 
         <% if can_flag && !flagged %>
-          | <a class="flagger">flag</a>
+          <span class="dropdown_parent">
+            | <a class="flagger">flag</a>
+          </span>
         <% elsif flagged %>
           | <a class="flagger">unflag</a>
         <% else %>

--- a/app/views/stories/_listdetail.html.erb
+++ b/app/views/stories/_listdetail.html.erb
@@ -132,7 +132,7 @@ class="story <%= story.vote && story.vote[:vote] == 1 ? "upvoted" : "" %>
             | <a class="flagger">unflag (<%=
               Vote::STORY_REASONS[story.vote[:reason]].to_s.downcase %>)</a>
           <% elsif @user && @user.can_flag?(story) %>
-            | 
+            |
             <span class="dropdown_parent">
               <a class="flagger">flag</a>
             </span>


### PR DESCRIPTION
When the last fix for the archive/flag drop downs went through it only fixed the story related drop downs. This patch with make those same changes to the flag drop down in the comments section.
