### PR TITLE
Fix archive button has no hand cursor on hover

### DIFF
--- a/app/assets/stylesheets/application.css.erb
+++ b/app/assets/stylesheets/application.css.erb
@@ -1068,22 +1068,9 @@ div.comment_text code {
 .archive_button:not(:checked) ~ .archive-dropdown {
 	display: none;
 }
-.archive_button:checked ~ .archive_dismiss {
-	display: block;
+.archive_button ~ label{
+	cursor: pointer;
 }
-.archive_dismiss {
-	display: none;
-	position: fixed;
-	width: 100%;
-	height: 100%;
-	left: 0;
-	top: 0;
-	bottom: 0;
-	right: 0;
-	z-index: 14;
-}
-
-
 
 .markdown_help {
 	background-color: var(--color-box-bg-shaded);

--- a/app/views/stories/_listdetail.html.erb
+++ b/app/views/stories/_listdetail.html.erb
@@ -158,9 +158,8 @@ class="story <%= story.vote && story.vote[:vote] == 1 ? "upvoted" : "" %>
         <% if story.url.present? %>
           |
           <span class="dropdown_parent">
-            <input id="archive_<%= story.short_id %>"  class="archive_button" type="checkbox">
+            <input id="archive_<%= story.short_id %>" class="archive_button" type="checkbox">
             <label for="archive_<%= story.short_id %>">archive</label>
-            <label for="archive_<%= story.short_id %>" class="archive_dismiss"></label>
             <div class="archive-dropdown">
               <a href="<%= story.archiveorg_url %>">Archive.org</a>
               <a href="<%= story.archivetoday_url %>">Archive.today</a>


### PR DESCRIPTION
<!--
Issues and PRs are typically reviewed Wednesday and most weekend mornings.
-->
In #1121 I fixed the issue that the dropdown for the archive button had a wrong position. I still spot a minor issue the archive button has no hand cursor on hover.

This PR is a quick fix to this issue.

This PR also removes the `archive_dismiss` `<label>` and associated styles since it's not needed anymore.