### PR TITLE
fix: filter hidden stories in active tab

### DIFF
--- a/app/models/story_repository.rb
+++ b/app/models/story_repository.rb
@@ -26,6 +26,7 @@ class StoryRepository
 
   def active
     Story.base(@user)
+      .where.not(id: Story.hidden_by(@user).pluck(:id))
       .filter_tags(@params[:exclude_tags] || [])
       .select('stories.*, (
         select max(comments.id)

--- a/spec/models/story_repository_spec.rb
+++ b/spec/models/story_repository_spec.rb
@@ -13,6 +13,19 @@ describe StoryRepository do
 
       expect(repo.active).to eq([newer_comment.story, older_comment.story])
     end
+
+    it "does not show hidden stories" do
+      hidden_story = create(:story)
+      normal_story = create(:story)
+      create(:comment, story: hidden_story)
+      normal_comment = create(:comment, story: normal_story)
+
+      HiddenStory.hide_story_for_user(hidden_story.id, hidden_story.user_id)
+      hidden_story_user = User.find_by(:id => hidden_story.user_id)
+
+      repo = StoryRepository.new(hidden_story_user)
+      expect(repo.active).to eq([normal_comment.story])
+    end
   end
 
   describe ".newest_by_user" do

--- a/spec/models/story_repository_spec.rb
+++ b/spec/models/story_repository_spec.rb
@@ -23,8 +23,8 @@ describe StoryRepository do
       HiddenStory.hide_story_for_user(hidden_story.id, hidden_story.user_id)
       hidden_story_user = User.find_by(:id => hidden_story.user_id)
 
-      repo = StoryRepository.new(hidden_story_user)
-      expect(repo.active).to eq([normal_comment.story])
+      hidden_story_user_repo = StoryRepository.new(hidden_story_user)
+      expect(hidden_story_user_repo.active).to eq([normal_comment.story])
     end
   end
 


### PR DESCRIPTION
When a story is hidden gets filtered out when loading the Active tab

Fixes [Issue#1113](https://github.com/lobsters/lobsters/issues/1133)

What was done?
- A `where.not` clause is addded to exclude the user's hidden stories
<!--
Issues and PRs are typically reviewed Wednesday and most weekend mornings.
-->
