### PR TITLE
Added aria role and levels for stories and comments

### DIFF
--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -134,7 +134,7 @@ class="comment <%= comment.current_vote ? (comment.current_vote[:vote] == 1 ?
         </span>
       <% end %>
     </div>
-    <div class="comment_text">
+    <div role="heading" aria-level="3" class="comment_text">
       <% if comment.is_gone? %>
         <p>
         <span class="na">

--- a/app/views/stories/_listdetail.html.erb
+++ b/app/views/stories/_listdetail.html.erb
@@ -24,7 +24,7 @@ class="story <%= story.vote && story.vote[:vote] == 1 ? "upvoted" : "" %>
     <div class="score"><%= story.show_score_to_user?(@user) ? story.score : '~' %></div>
   </div>
   <div class="details">
-    <span class="link h-cite u-repost-of">
+    <span role="heading" aria-level="1" class="link h-cite u-repost-of">
       <% if story.can_be_seen_by_user?(@user) %>
         <a class="u-url" href="<%= story.url_or_comments_path %>" rel="ugc <%= story.send_referrer? ? '' : 'noreferrer' %>"><%= story.title %></a>
       <% end %>
@@ -173,7 +173,7 @@ class="story <%= story.vote && story.vote[:vote] == 1 ? "upvoted" : "" %>
         <% if !story.is_gone? || @user.try(:is_moderator?) %>
           <span class="comments_label">
             <span> | </span>
-            <a href="<%= story.comments_path %>">
+            <a role="heading" aria-level="2" href="<%= story.comments_path %>">
             <% if story.comments_count == 0 %>
               no comments</a>
             <% else %>


### PR DESCRIPTION
These changes have zero impact on sighted users,
but give screen reader users some core elements
to key off of for navigation, level 1 headings
for stories, level 2 for comment links and level
3 for comments themselves.

The reason the comment role was not used is that
it is not yet supported by most screen readers,
but I plan to add that in another forthcoming
PR.

closes: #1123 

<!--
Issues and PRs are typically reviewed Wednesday and most weekend mornings.
-->
