### PR TITLE
fix unintentional scrolling when flagging a comment

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -637,6 +637,7 @@ onPageLoad(() => {
   });
 
   on('click', '.comment #flag_dropdown a', (event) => {
+    event.preventDefault();
     if (event.target.getAttribute('data') != '') {
       Lobster.voteComment(parentSelector(event.target, '.comment'), -1,  event.target.getAttribute('data'));
     }


### PR DESCRIPTION
This fixes #1134 

Flagging a comment is a two-step process.

1. Click the "flag" link. This opens a list of reasons for the flag.
2. Click the reason

Step 2 was missing `event.preventDefault()` in the click handler.