### PR TITLE
Feature: scroll to unread comments

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -736,10 +736,8 @@ onPageLoad(() => {
       }
     })
 
-    var targetIndex = foundIndex + 1
-    if (targetIndex < nodes.length) {
-      var targetY = nodes[targetIndex].getBoundingClientRect().top + window.scrollY
-      window.scrollTo({ top: targetY, behavior: 'smooth' })
-    }
+    var targetIndex = (foundIndex + 1) % nodes.length;
+    var targetY = nodes[targetIndex].getBoundingClientRect().top + window.scrollY
+    window.scrollTo({ top: targetY, behavior: 'smooth' })
   });
 });

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -729,15 +729,10 @@ onPageLoad(() => {
   });
 
   on('click', '.comment_unread', (event) => {
-    var nodes = document.getElementsByClassName('comment_unread')
-    var foundIndex = Array.from(nodes).findIndex(function(n){
-      if (n === event.target) {
-        return true;
-      }
-    })
-
-    var targetIndex = (foundIndex + 1) % nodes.length;
-    var targetY = nodes[targetIndex].getBoundingClientRect().top + window.scrollY
+    const nodes = document.getElementsByClassName('comment_unread')
+    const foundIndex = Array.from(nodes).findIndex(node => node === event.target)
+    const targetIndex = (foundIndex + 1) % nodes.length;
+    const targetY = nodes[targetIndex].getBoundingClientRect().top + window.scrollY
     window.scrollTo({ top: targetY, behavior: 'smooth' })
   });
 });

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -731,7 +731,7 @@ onPageLoad(() => {
   on('click', '.comment_unread', (event) => {
     var nodes = document.getElementsByClassName('comment_unread')
     var foundIndex = Array.from(nodes).findIndex(function(n){
-      if (n.id == event.target.id) {
+      if (n === event.target) {
         return true;
       }
     })

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -727,4 +727,24 @@ onPageLoad(() => {
         response.text().then(text => replace(comment, text));
       });
   });
+
+  on('click', '.comment_unread', (event) => {
+    var nodes = document.getElementsByClassName('comment_unread')
+    var foundIndex = Array.from(nodes).findIndex(function(n){
+      if (n.id == event.target.id) {
+        return true;
+      }
+    })
+
+    var targetIndex = foundIndex + 1
+    if (targetIndex < nodes.length) {
+      // Option 1: "scroll" using html anchor
+      // var targetHash = "#" + nodes[targetIndex].id
+      // window.location.hash = targetHash
+
+      // Option 2: scroll w/javascript
+      var targetY = nodes[targetIndex].getBoundingClientRect().top + window.scrollY
+      window.scrollTo({ top: targetY, behavior: 'smooth' })
+    }
+  });
 });

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -738,11 +738,6 @@ onPageLoad(() => {
 
     var targetIndex = foundIndex + 1
     if (targetIndex < nodes.length) {
-      // Option 1: "scroll" using html anchor
-      // var targetHash = "#" + nodes[targetIndex].id
-      // window.location.hash = targetHash
-
-      // Option 2: scroll w/javascript
       var targetY = nodes[targetIndex].getBoundingClientRect().top + window.scrollY
       window.scrollTo({ top: targetY, behavior: 'smooth' })
     }

--- a/app/assets/stylesheets/application.css.erb
+++ b/app/assets/stylesheets/application.css.erb
@@ -1176,6 +1176,7 @@ div.comment_form_container textarea {
 span.comment_unread {
 	color: var(--color-fg-accent);
 	font-weight: 600;
+	cursor: pointer;
 }
 
 /* trees */

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -73,7 +73,7 @@ class="comment <%= comment.current_vote ? (comment.current_vote[:vote] == 1 ?
         <% end %>
         <% is_unread ||= false %>
         <%= time_ago_in_words_label(comment.has_been_edited? ? comment.updated_at : comment.created_at) %>
-        <%= raw "<span class='comment_unread'>(unread)</span>" if is_unread %>
+        <%= raw "<span id='unread-comment-#{comment.id}' class='comment_unread'>(unread)</span>" if is_unread %>
       <% end %>
 
       <% if !comment.previewing %>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -73,7 +73,7 @@ class="comment <%= comment.current_vote ? (comment.current_vote[:vote] == 1 ?
         <% end %>
         <% is_unread ||= false %>
         <%= time_ago_in_words_label(comment.has_been_edited? ? comment.updated_at : comment.created_at) %>
-        <%= raw "<span class='comment_unread'>(unread)</span>" %>
+        <%= raw "<span class='comment_unread'>(unread)</span>" if is_unread %>
       <% end %>
 
       <% if !comment.previewing %>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -73,7 +73,7 @@ class="comment <%= comment.current_vote ? (comment.current_vote[:vote] == 1 ?
         <% end %>
         <% is_unread ||= false %>
         <%= time_ago_in_words_label(comment.has_been_edited? ? comment.updated_at : comment.created_at) %>
-        <%= raw "<span id='unread-comment-#{comment.id}' class='comment_unread'>(unread)</span>" if is_unread %>
+        <%= raw "<span class='comment_unread'>(unread)</span>" %>
       <% end %>
 
       <% if !comment.previewing %>


### PR DESCRIPTION
The is a new feature from request #919

When viewing comments you can now click on the "(unread)" label to scroll to the next unread label.

This was done by adding a unique id and a bit of JS to find the next label then scroll.