### PR TITLE
Prevent a css error at various zoom levels.

### DIFF
--- a/app/views/stories/_form.html.erb
+++ b/app/views/stories/_form.html.erb
@@ -6,7 +6,7 @@
     <% if f.object.url_is_editable_by_user?(@user) %>
       <%= f.label :url, "URL:", :class => "required" %>
       <%= f.text_field :url, :autocomplete => "off" %>
-      <%= button_tag "Fetch Title", :id => "story_fetch_title",
+      <%= button_tag "Fetch&nbsp;Title", :id => "story_fetch_title",
         :type => "button" %>
     <% elsif !f.object.new_record? && !f.object.url.blank? %>
       <%= f.label :url, "URL:", :class => "required" %>


### PR DESCRIPTION
Fixed #1161 with a simple "\&nbsp;" in the Fetch Title.

After that I could not replicate the bug at any zoom level.
