### PR TITLE
correct dark mode tags

### DIFF
--- a/app/assets/stylesheets/application.css.erb
+++ b/app/assets/stylesheets/application.css.erb
@@ -59,6 +59,7 @@ light = <<-LIGHT
 	--color-tag-bg: #fffcd7;
 	--color-tag-border: #d5d458;
 	--color-tag-media-bg: #ddebf9;
+	--color-tag-bg-img: -webkit-linear-gradient(top, #f4f4f4 20%, #f0f0f0 50%, #e8e8e8 52%, #eeeeee 100%);
 	--color-tag-media-border: #b2ccf0;
 	--color-tag-meta-bg: #e0e0e0;
 	--color-tag-meta-border: #c8c8c8;
@@ -135,6 +136,7 @@ dark = <<-DARK
 	--color-table-row-border: #262626;
 
 	--color-tag-bg: #3b320d;
+	--color-tag-bg-img: none;
 	--color-tag-border: #665501;
 	--color-tag-media-bg: #15293d;
 	--color-tag-media-border: #214669;
@@ -1482,11 +1484,11 @@ div.flash-success h2 {
 }
 
 #story_holder .ts-control .data-ts-item { /* item already selected by user*/
-	background-color: #e4e4e4;
-	background-image: -webkit-linear-gradient(top, #f4f4f4 20%, #f0f0f0 50%, #e8e8e8 52%, #eeeeee 100%);
-	border: 1px solid #aaaaaa;
+	background-color: var(--color-tag-bg);
+	background-image: var(--color-tag-bg-img);
+	border: 1px solid var(--color-tagborder);
 	border-radius: 3px;
-	color: #333;
+	color: var(--color-fgcontrast-10);
 	line-height: 13px;
 	margin: 3px 5px 3px 0;
 	padding: 3px 0.5rem 3px 1rem !important;

--- a/app/views/stories/edit.html.erb
+++ b/app/views/stories/edit.html.erb
@@ -1,64 +1,66 @@
 <div class="box" id="story_box">
-  <%= form_with model: @story, id: 'edit_story' do |f| %>
-    <%= render :partial => "stories/form", :locals => { :story => @story,
-      :f => f } %>
+	<div id="story_holder">
+    <%= form_with model: @story, id: 'edit_story' do |f| %>
+      <%= render :partial => "stories/form", :locals => { :story => @story,
+        :f => f } %>
 
-    <% if @user.is_moderator? %>
-      <br />
-      <div class="box">
-        <div class="boxline">
-          <%= f.label :merge_story_short_id, "Merge Into:",
-            :class => "required" %>
-          <%= f.text_field :merge_story_short_id, :autocomplete => "off",
-            :placeholder => "Short id of story into which this story " <<
-            "be merged" %>
-        </div>
-        <div class="boxline">
-          <%= f.label :unavailable_at, "Unavailable:",
-            :class => "required" %>
-          <%= f.check_box :is_unavailable %>
-          <%= f.label :unavailable_at, "Source URL is unavailable, " <<
-            "enable display of cached text", :class => "normal" %>
-        </div>
-        <% if @story.user_id != @user.id %>
+      <% if @user.is_moderator? %>
+        <br />
+        <div class="box">
           <div class="boxline">
-            <%= f.label :moderation_reason, "Mod Reason:", :class => "required" %>
-            <%= f.text_field :moderation_reason %>
+            <%= f.label :merge_story_short_id, "Merge Into:",
+              :class => "required" %>
+            <%= f.text_field :merge_story_short_id, :autocomplete => "off",
+              :placeholder => "Short id of story into which this story " <<
+              "be merged" %>
           </div>
-        <% end %>
+          <div class="boxline">
+            <%= f.label :unavailable_at, "Unavailable:",
+              :class => "required" %>
+            <%= f.check_box :is_unavailable %>
+            <%= f.label :unavailable_at, "Source URL is unavailable, " <<
+              "enable display of cached text", :class => "normal" %>
+          </div>
+          <% if @story.user_id != @user.id %>
+            <div class="boxline">
+              <%= f.label :moderation_reason, "Mod Reason:", :class => "required" %>
+              <%= f.text_field :moderation_reason %>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
+
+      <p></p>
+
+      <div class="box">
+        <div class="boxline actions markdown_help_toggler">
+          <div class="markdown_help_label">
+            Markdown formatting available
+          </div>
+
+          <%= f.submit "Save" %>
+
+          <% if @story.is_gone? && @story.is_undeletable_by_user?(@user) %>
+            &nbsp; | &nbsp;
+            <%= f.submit "Undelete", formaction: story_undelete_path(@story.short_id),
+              :data => { :confirm => "Undelete this story?" } %>
+          <% elsif !@story.is_gone? %>
+            &nbsp; | &nbsp;
+            <% if @story.user_id != @user.id && @user.is_moderator? %>
+              <%= f.submit "Delete", formaction: story_destroy_path(@story.short_id),
+                :class => "deletion", :data => { :confirm => "Delete this story?" }  %>
+            <% else %>
+              <%= f.submit "Delete", formaction: story_destroy_path(@story.short_id),
+                :class => "deletion", :data => { :confirm => "Delete this story?" } %>
+            <% end %>
+          <% end %>
+
+          <div style="clear: both;"></div>
+
+          <%= render :partial => "global/markdownhelp",
+            :locals => { allow_images: @story.can_have_images? } %>
+        </div>
       </div>
     <% end %>
-
-    <p></p>
-
-    <div class="box">
-      <div class="boxline actions markdown_help_toggler">
-        <div class="markdown_help_label">
-          Markdown formatting available
-        </div>
-
-        <%= f.submit "Save" %>
-
-        <% if @story.is_gone? && @story.is_undeletable_by_user?(@user) %>
-          &nbsp; | &nbsp;
-          <%= f.submit "Undelete", formaction: story_undelete_path(@story.short_id),
-            :data => { :confirm => "Undelete this story?" } %>
-        <% elsif !@story.is_gone? %>
-          &nbsp; | &nbsp;
-          <% if @story.user_id != @user.id && @user.is_moderator? %>
-            <%= f.submit "Delete", formaction: story_destroy_path(@story.short_id),
-              :class => "deletion", :data => { :confirm => "Delete this story?" }  %>
-          <% else %>
-            <%= f.submit "Delete", formaction: story_destroy_path(@story.short_id),
-              :class => "deletion", :data => { :confirm => "Delete this story?" } %>
-          <% end %>
-        <% end %>
-
-        <div style="clear: both;"></div>
-
-        <%= render :partial => "global/markdownhelp",
-          :locals => { allow_images: @story.can_have_images? } %>
-      </div>
-    </div>
-  <% end %>
+	</div>
 </div>


### PR DESCRIPTION
Issue #1157 
- Created css variables to the TomSelect tags in forms.
- Eliminated the background-image on TomSelect tags in dark mode.
- Added the story_holder div to the suggest form as it got forgotten with the original shift to TomSelect. This should stop the Tags entry from being white in dark mode.