### PR TITLE
Fix spec of bg in mobile comments speech bubble

### DIFF
--- a/app/assets/stylesheets/application.css.erb
+++ b/app/assets/stylesheets/application.css.erb
@@ -1808,7 +1808,7 @@ input[type="submit"].link_post.pushover_button {
 		height: 7px;
 		left: 4px;
 		position: absolute;
-		width: 5px;
+		width: 5.4px;
 		z-index: 10;
 	}
 	ol.stories.list li.story .mobile_comments span:after {


### PR DESCRIPTION
There's a slight spec of the background color / lack of fill in the mobile comments speech bubble when you have the page at a higher zoom level. The issue is more visible on Firefox but also happens on Chrome. 

before: 
![image](https://user-images.githubusercontent.com/206854/229906496-af867cae-2304-4f06-8fb5-8bf0e961dfa3.png)

after:

![image](https://user-images.githubusercontent.com/206854/229906645-90cd26d5-0a75-4efa-a7a3-15ea7d17aa38.png)

