### PR TITLE
Add reveal for TOTP secret for manual entry

### DIFF
--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -101,6 +101,7 @@ class SettingsController < ApplicationController
                        module_size: 5,
                        shape_rendering: "crispEdges")
 
+    @qr_secret = totp.secret
     @qr_svg = "<a href=\"#{totp_url}\">#{qr}</a>"
   end
 

--- a/app/views/settings/twofa_enroll.html.erb
+++ b/app/views/settings/twofa_enroll.html.erb
@@ -10,6 +10,13 @@
   </p>
 
   <%= raw @qr_svg %>
+  <p>
+    Or to add to a device manually enter the secret:
+    <details>
+      <summary>Reveal Secret</summary>
+      <%= raw @qr_secret %>
+    </details>
+  </p>
 
   <p>
   Once you have finished registering with your TOTP application, proceed to


### PR DESCRIPTION
Small change to show TOTP secret (initially hidden and revealed on click). This allows for manual entry, which is particularly useful if your 2FA is a browser extension such as bitwarden.

Preview:
![lobsters_totp](https://user-images.githubusercontent.com/3820235/233753361-78ef722a-dd03-4a86-a275-e29e48ee4086.png)

