### PR TITLE
Update messaging for Pushover settings

### DIFF
--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -97,7 +97,7 @@
         :class => "required" %>
       <%= f.check_box :pushover_replies %>
       <span class="hint indent">
-        Requires Pushover subscription above
+        Requires Pushover subscription below
       </span>
     </div>
 
@@ -115,7 +115,7 @@
         :class => "required" %>
       <%= f.check_box :pushover_mentions %>
       <span class="hint indent">
-        Requires Pushover subscription above
+        Requires Pushover subscription below
       </span>
     </div>
 
@@ -133,7 +133,7 @@
         :class => "required" %>
       <%= f.check_box :pushover_messages %>
       <span class="hint indent">
-        Requires Pushover subscription above
+        Requires Pushover subscription below
       </span>
     </div>
 
@@ -230,7 +230,7 @@
           "Manage Pushover Subscription" : "Subscribe With Pushover"),
           "/settings/pushover_auth", class_name: "pushover_button") %>
         <span class="hint indent">
-          For optional comment and message notifications below
+          For optional comment and message notifications above
         </span>
       </span>
     </div>


### PR DESCRIPTION
Settings that require a Pushover subscription are rendered before the button to setup the Pushover integration, so the labels "above" and "below" should be swapped.