### PR TITLE
typo fix for undeleting a comment alert

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -704,7 +704,7 @@ onPageLoad(() => {
 
   on('click', 'a.comment_undeletor', (event) => {
     event.preventDefault();
-    if (confirm("Are uou sure you want to undelete this comment?")) {
+    if (confirm("Are you sure you want to undelete this comment?")) {
       const comment = parentSelector(event.target, '.comment');
       const commentId = comment.getAttribute('data-shortid');
       fetchWithCSRF('/comments/' + commentId + '/undelete', {method: 'post'})


### PR DESCRIPTION
<!--
Issues and PRs are typically reviewed Wednesday and most weekend mornings.
-->

Minor typo I came across when I accidentally deleted my comment.

Previously: `Are uou sure you want to undelete this comment?`

Now: `Are you sure you want to undelete this comment?`