### PR TITLE
search: Use the page in pagination links

### DIFF
--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -130,7 +130,7 @@
 
       <% page_numbers_for_pagination(@search.page_count, @search.page).each do |p| %>
         <% if p.is_a?(Integer) %>
-          <%= link_to p, search_path(@search.to_param), class: (@search.page == p ? 'cur' : '') %>
+          <%= link_to p, search_path(@search.to_param.merge({ page: p })), class: (@search.page == p ? 'cur' : '') %>
         <% else %>
           <span>...</span>
         <% end %>


### PR DESCRIPTION
Without this, all of the pagination buttons link to the current page.

Before:

![pagination points to current page](https://github.com/lobsters/lobsters/assets/77421532/6a3ecc46-e6d8-4743-9a59-1647911b2f6f)

After:

![correct pagination link](https://github.com/lobsters/lobsters/assets/77421532/99089be9-e13f-4f4a-bebd-81adc4712393)
