### PR TITLE
Fix search failing test

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -27,7 +27,7 @@ class SearchController < ApplicationController
   # If you are maintaining a searx fork, please don't 'fix' your targeting of this site.
   def ignore_searx
     return unless params[:utf8] == "✓"
-    @search = Search.new({}, nil)
+    @search = Search.new({results_count: 0}, nil)
     render :index
   end
 

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -39,7 +39,7 @@ class Search
     @searcher = user
 
     @results = nil
-    @results_count = -1
+    @results_count = params[:results_count] || -1
     @invalid_because = nil
   end
 


### PR DESCRIPTION
This PR is just for fixing the latest merge that introduces a failing
test.

When initializing a new Search model it has some default values,
especially the `results_count` one.
https://github.com/JuanVqz/lobsters/blob/5338e5a4b335b94337636a59b7bbc83529dfce81/app/models/search.rb#L42

When doing Search.new({}, nil) in the `ignore_searx` method
https://github.com/JuanVqz/lobsters/blob/5338e5a4b335b94337636a59b7bbc83529dfce81/app/controllers/search_controller.rb#L30

It takes the` -1` value by default which in this if/else statement

https://github.com/JuanVqz/lobsters/blob/5338e5a4b335b94337636a59b7bbc83529dfce81/app/views/search/index.html.erb#L40

is rendering this else block

https://github.com/JuanVqz/lobsters/blob/5338e5a4b335b94337636a59b7bbc83529dfce81/app/views/search/index.html.erb#L157-L167

and that doesn't render the` 0 results` but it renders the `Search hints:`

if that is the required behaviour then this PR is solving it.
otherwise, let me know and I'll arrange it as desired.

<!--
Issues and PRs are typically reviewed on Wednesday and most weekend mornings.
-->
