### PR TITLE
Fix git clone URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ There's an external project [docker-lobsters](https://github.com/utensils/docker
 
 * Checkout the lobsters git tree from Github
     ```sh
-    $ git clone git://github.com/lobsters/lobsters.git
+    $ git clone git@github.com:lobsters/lobsters.git
     $ cd lobsters
     lobsters$
     ```


### PR DESCRIPTION
Update git clone url to the preferred github, git user style.

<!--
Issues and PRs are typically reviewed Wednesday and most weekend mornings.
-->
