### PR TITLE
Add profile toggle value to optionally show your e-mail address to authenticated users

### DIFF
--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -271,7 +271,7 @@ class SettingsController < ApplicationController
       :username, :email, :password, :password_confirmation, :homepage, :about,
       :email_replies, :email_messages, :email_mentions,
       :pushover_replies, :pushover_messages, :pushover_mentions,
-      :mailing_list_mode, :show_avatars, :show_story_previews,
+      :mailing_list_mode, :show_email, :show_avatars, :show_story_previews,
       :show_submitted_story_threads, :prefers_color_scheme
     )
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -68,6 +68,7 @@ class User < ApplicationRecord
     s.boolean :pushover_messages, default: false
     s.boolean :email_mentions, default: false
     s.boolean :show_avatars, default: true
+    s.boolean :show_email, default: false
     s.boolean :show_story_previews, default: false
     s.boolean :show_submitted_story_threads, default: false
     s.string :totp_secret

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -182,6 +182,12 @@
     <h2>Miscellaneous Settings</h2>
 
     <div class="boxline">
+      <%= f.label :show_email, "Show Email Address:",
+        :class => "required" %>
+      <%= f.check_box :show_email %>
+    </div>
+
+    <div class="boxline">
       <%= f.label :show_story_previews, "Show Story Previews:",
         :class => "required" %>
       <%= f.check_box :show_story_previews %>

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -185,6 +185,9 @@
       <%= f.label :show_email, "Show Email Address:",
         :class => "required" %>
       <%= f.check_box :show_email %>
+      <span class="hint indent">
+        Only shown to logged-in users
+      </span>
     </div>
 
     <div class="boxline">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -100,6 +100,14 @@
     <div style="clear: both;"></div>
   <% end %>
 
+  <% if @user.is_admin? && @user.show_email? %>
+    <label class="required">E-Mail:</label>
+    <span class="d">
+      <%= @showing_user.email %>
+    </span>
+    <br>
+  <% end %>
+
   <% if @showing_user.homepage.present? %>
     <label class="required">Homepage:</label>
 
@@ -202,12 +210,6 @@
 
     <% if @user.is_admin? %>
       <h3>Admin Information</h3>
-
-      <label class="required">E-Mail:</label>
-      <span class="d">
-        <%= @showing_user.email %>
-      </span>
-      <br>
 
       <label class="required">Recent Votes:</label>
       <table class="data zebra clear tall">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -100,7 +100,7 @@
     <div style="clear: both;"></div>
   <% end %>
 
-  <% if @user.is_admin? && @user.show_email? %>
+  <% if @user&.is_admin? || @user&.show_email? %>
     <label class="required">E-Mail:</label>
     <span class="d">
       <%= @showing_user.email %>

--- a/db/migrate/20231023155620_add_user_setting_show_email.rb
+++ b/db/migrate/20231023155620_add_user_setting_show_email.rb
@@ -1,0 +1,5 @@
+class AddUserSettingShowEmail < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :show_email, :boolean, default: false, null: false
+  end
+end


### PR DESCRIPTION

# Notable Changes

* This PR aims to add the show_email boolean attribute to user settings for users to toggle if they want to publicise their email addresses to other authenticated users.

## Screenshots (Optional)

<img width="965" alt="profile-with-email Screenshot " src="https://github.com/lobsters/lobsters/assets/25585114/cb5115e2-259a-40ee-99db-c19e6cfad82e">

<img width="706" alt="show-email-setting Screenshot" src="https://github.com/lobsters/lobsters/assets/25585114/33530f72-0229-4197-9c62-5e5e8ee059cd">


## Todo

* N/A


<!--
Issues and PRs are typically reviewed Wednesday and most weekend mornings.
-->
