### PR TITLE
Fix long lines in moderation action description

### DIFF
--- a/app/assets/stylesheets/application.css.erb
+++ b/app/assets/stylesheets/application.css.erb
@@ -1304,6 +1304,9 @@ table.data tr.nobottom td {
 	border-bottom: 0px;
 	padding-bottom: 0px;
 }
+table.data tr.nobottom td.wrap {
+	overflow-wrap: anywhere;
+}
 table.data.tall td {
 	vertical-align: top;
 }

--- a/app/views/moderations/_table.html.erb
+++ b/app/views/moderations/_table.html.erb
@@ -39,7 +39,7 @@
   </tr>
   <tr class="<%= mod.reason.present?? "nobottom" : "" %>">
     <td colspan=2></td>
-    <td>Action: <em><%= mod.action %></em></td>
+    <td class="wrap">Action: <em><%= mod.action %></em></td>
   </tr>
   <% if mod.reason.present? %>
     <tr>


### PR DESCRIPTION
Closes #1231.

Lines containing a long URL, for instance, would cause the text to overflow its content box.

In the original issue [it was suggested][1] to use `word-break: break-word;` but [this property value is considered to be deprecated][2].

The fix was specifically applied to the `Action` column in order to not break the username in the `Moderator` column. 

# Preview

![image](https://github.com/lobsters/lobsters/assets/459906/be465464-6240-4843-bfb3-7f455780a9f1)

P.s.: I'm not a Frontend Developer, so please let me know if this has to be done in a completely different way.

[1]: https://github.com/lobsters/lobsters/issues/1231#issuecomment-1858890718
[2]: https://developer.mozilla.org/en-US/docs/Web/CSS/word-break