### PR TITLE
Show merged stories on duplicate submission

### DIFF
--- a/app/views/stories/_form_errors.html.erb
+++ b/app/views/stories/_form_errors.html.erb
@@ -2,7 +2,7 @@
   <div class="form_errors_header">
     <% if story.errors.any? %>
       <%= errors_for story %>
-    <% elsif !story.errors.any? && story.public_similar_stories(@user).any? %>
+    <% elsif !story.errors.any? && story.similar_stories.any? %>
       <div class="flash-notice">
         <h2>Note: This story was already submitted <%= time_ago_in_words_label(story.most_recent_similar.created_at) %></h2>
         <p>
@@ -20,7 +20,7 @@
       <% end %>
     <% end %>
 
-    <% if story.public_similar_stories(@user).any? %>
+    <% if story.similar_stories.any? %>
       <p>Previous discussions for this story:</p>
       <%= render partial: "stories/similar", locals: { similar: story.similar_stories } %>
     <% end %>

--- a/app/views/stories/_similar.html.erb
+++ b/app/views/stories/_similar.html.erb
@@ -2,6 +2,9 @@
   <% similar.each do |story| %>
     <li>
       <a href="<%= story.url %>" target="_blank"><%= story.title %></a>
+      <% if story.merged_story_id %>
+        (merged into <a href="<%= story.merged_into_story.url %>" target="_blank"><%= story.merged_into_story.title %></a>)
+      <% end %>
       <%= story.user_is_author? ? "authored by" : "via" %>
       <%= styled_user_link story.user, story %>
       <%= time_ago_in_words_label(story.created_at) %>


### PR DESCRIPTION
Closes #1215.

The approach consists in not filtering out merged stories (avoiding the `unmerged` filter) and showing them in the returned HTML.

Please let me know if should we do it differently.