### PR TITLE
Add domain to RSS author

### DIFF
--- a/app/views/home/rss.erb
+++ b/app/views/home/rss.erb
@@ -13,7 +13,7 @@
         <title><%= raw coder.encode(story.title, :decimal) %></title>
         <link><%= story.url_or_comments_url %></link>
         <guid isPermaLink="false"><%= story.short_id_url %></guid>
-        <author><%= story.user.username %>@users.<%= Rails.application.domain %> (<%= story.user.username %>)</author>
+        <author><%= story.domain.domain %> via <%= story.user.username %></author>
         <pubDate><%= story.created_at.rfc2822 %></pubDate>
         <comments><%= story.comments_url %></comments>
         <description>


### PR DESCRIPTION
When I'm browsing lobste.rs it's helpful to see the domain without hovering over the link. This adds that ability to the RSS field. It saves space by removing the email-address-like part of the username.

<!--
Issues and PRs are typically reviewed Wednesday and most weekend mornings.
-->
