### PR TITLE
Fix unnecessary tag wrapping in Firefox.

### DIFF
--- a/app/assets/stylesheets/application.css.erb
+++ b/app/assets/stylesheets/application.css.erb
@@ -277,6 +277,7 @@ a.tag {
 	margin-left: 0.25em;
 	padding: 0px 0.4em 1px 0.4em;
 	text-decoration: none;
+	white-space: nowrap;
 }
 a.tag_is_media {
 	background-color: var(--color-tag-media-bg);


### PR DESCRIPTION
Noticed this small thing while browsing lobste.rs on Firefox on my phone today.

![thats-a-wrap](https://github.com/lobsters/lobsters/assets/16073340/2ad33e53-6cc7-435f-ba0b-15c899a6dbfa)
