### PR TITLE
Database consistency fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,4 +63,6 @@ group :test, :development do
   gem "vcr"
   gem "webmock" # used to support vcr
   gem "simplecov", require: false
+  gem "active_record_doctor"
+  gem "database_consistency"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,6 +53,8 @@ GEM
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
+    active_record_doctor (1.14.0)
+      activerecord (>= 4.2.0)
     activejob (7.1.3.2)
       activesupport (= 7.1.3.2)
       globalid (>= 0.3.6)
@@ -115,6 +117,8 @@ GEM
       activerecord (>= 5.a)
       database_cleaner-core (~> 2.0.0)
     database_cleaner-core (2.0.1)
+    database_consistency (1.7.23)
+      activerecord (>= 3.2)
     date (3.3.4)
     diff-lcs (1.5.0)
     docile (1.4.0)
@@ -390,6 +394,7 @@ PLATFORMS
 
 DEPENDENCIES
   actionpack-page_caching
+  active_record_doctor
   activerecord-typedstore
   bcrypt
   benchmark-perf
@@ -398,6 +403,7 @@ DEPENDENCIES
   capybara
   commonmarker (< 1)
   database_cleaner
+  database_consistency
   exception_notification
   factory_bot_rails
   faker

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -74,7 +74,9 @@ class Comment < ApplicationRecord
 
   validates :short_id, length: {maximum: 10}, presence: true
   validates :markeddown_comment, length: {maximum: 16_777_215}
-  validates :comment, presence: {with: true, message: "cannot be empty."}
+  validates :comment,
+    presence: {with: true, message: "cannot be empty."},
+    length: {maximum: 16_777_215}
   validates :confidence, :confidence_order, :flags, :score, presence: true
   validates :is_deleted, :is_moderated, :is_from_email, inclusion: {in: [true, false]}
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -72,9 +72,11 @@ class Comment < ApplicationRecord
 
   SCORE_RANGE_TO_HIDE = (-2..4)
 
-  validates :short_id, length: {maximum: 10}
+  validates :short_id, length: {maximum: 10}, presence: true
   validates :markeddown_comment, length: {maximum: 16_777_215}
   validates :comment, presence: {with: true, message: "cannot be empty."}
+  validates :confidence, :confidence_order, :flags, :score, presence: true
+  validates :is_deleted, :is_moderated, :is_from_email, inclusion: {in: [true, false]}
 
   validate do
     parent_comment&.is_gone? &&

--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -8,7 +8,7 @@ class Domain < ApplicationRecord
     optional: true
   validates :banned_reason, length: {maximum: 200}
 
-  validates :domain, presence: true
+  validates :domain, presence: true, length: {maximum: 255}
 
   def ban_by_user_for_reason!(banner, reason)
     self.banned_at = Time.current

--- a/app/models/hat.rb
+++ b/app/models/hat.rb
@@ -8,6 +8,7 @@ class Hat < ApplicationRecord
 
   validates :hat, presence: true
   validates :hat, :link, length: {maximum: 255}
+  validates :modlog_use, inclusion: {in: [true, false]}
 
   scope :active, -> { joins(:user).where(doffed_at: nil).merge(User.active) }
 

--- a/app/models/invitation_request.rb
+++ b/app/models/invitation_request.rb
@@ -12,6 +12,7 @@ class InvitationRequest < ApplicationRecord
     format: {with: Story::URL_RE},
     length: {maximum: 255}
   validates :code, :ip_address, length: {maximum: 255}
+  validates :is_verified, inclusion: {in: [true, false]}
 
   before_validation :create_code
   after_create :send_email

--- a/app/models/mastodon_app.rb
+++ b/app/models/mastodon_app.rb
@@ -2,7 +2,9 @@
 
 # https://docs.joinmastodon.org/methods/apps/
 class MastodonApp < ApplicationRecord
-  validates :name, :client_id, :client_secret, presence: true
+  validates :name, :client_id, :client_secret,
+    presence: true,
+    length: {maximum: 255}
 
   # https://docs.joinmastodon.org/methods/oauth/
   def oauth_auth_url

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -19,6 +19,7 @@ class Message < ApplicationRecord
   validates :subject, length: {in: 1..100}
   validates :body, length: {maximum: (64 * 1024)}
   validates :short_id, length: {maximum: 30}
+  validates :has_been_read, :deleted_by_author, :deleted_by_recipient, inclusion: {in: [true, false]}
   validate :hat do
     next if hat.blank?
     if author.blank? || author.wearable_hats.exclude?(hat)

--- a/app/models/moderation.rb
+++ b/app/models/moderation.rb
@@ -29,6 +29,7 @@ class Moderation < ApplicationRecord
   }
 
   validates :action, :reason, length: {maximum: 16_777_215}
+  validates :is_from_suggestions, inclusion: {in: [true, false]}
   validate :one_foreign_key_present
 
   after_create :send_message_to_moderated

--- a/app/models/read_ribbon.rb
+++ b/app/models/read_ribbon.rb
@@ -4,6 +4,8 @@ class ReadRibbon < ApplicationRecord
   belongs_to :user
   belongs_to :story
 
+  validates :is_following, inclusion: { in: [true, false] }
+
   def is_unread? comment
     return false if !user
 

--- a/app/models/read_ribbon.rb
+++ b/app/models/read_ribbon.rb
@@ -4,7 +4,7 @@ class ReadRibbon < ApplicationRecord
   belongs_to :user
   belongs_to :story
 
-  validates :is_following, inclusion: { in: [true, false] }
+  validates :is_following, inclusion: {in: [true, false]}
 
   def is_unread? comment
     return false if !user

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -107,13 +107,15 @@ class Story < ApplicationRecord
       .limit(10)
   }
 
-  validates :title, length: {in: 3..150}
+  validates :title, length: {in: 3..150}, presence: true
   validates :description, length: {maximum: (64 * 1024)}
   validates :url, length: {maximum: 250, allow_nil: true}
   validates :short_id, presence: true, length: {maximum: 6}
   validates :markeddown_description, length: {maximum: 16_777_215, allow_nil: true}
   validates :mastodon_id, length: {maximum: 25, allow_nil: true}
   validates :twitter_id, length: {maximum: 20, allow_nil: true}
+  validates :is_deleted, :is_moderated, :user_is_author, :user_is_following, inclusion: {in: [true, false]}
+  validates :score, :flags, :hotness, :comments_count, presence: true
 
   validates_each :merged_story_id do |record, _attr, value|
     if value.to_i == record.id
@@ -1020,7 +1022,7 @@ class Story < ApplicationRecord
 
   def self.title_maximum_length
     validators_on(:title)
-      .sole { |v| v.is_a? ActiveRecord::Validations::LengthValidator }
+      .find { |v| v.is_a? ActiveRecord::Validations::LengthValidator }
       .options[:maximum]
   end
 

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -116,6 +116,7 @@ class Story < ApplicationRecord
   validates :twitter_id, length: {maximum: 20, allow_nil: true}
   validates :is_deleted, :is_moderated, :user_is_author, :user_is_following, inclusion: {in: [true, false]}
   validates :score, :flags, :hotness, :comments_count, presence: true
+  validates :normalized_url, length: {maximum: 255, allow_nil: true}
 
   validates_each :merged_story_id do |record, _attr, value|
     if value.to_i == record.id

--- a/app/models/story_text.rb
+++ b/app/models/story_text.rb
@@ -5,7 +5,8 @@ class StoryText < ApplicationRecord
 
   belongs_to :story, foreign_key: :id, inverse_of: :story_text
 
-  validates :title, presence: true
+  validates :title, presence: true, length: { maximum: 150 }
+  validates :description, :body, length: { maximum: 16_777_215 }
 
   def body=(s)
     # pass nil, truncate to column limit https://mariadb.com/kb/en/mediumtext/

--- a/app/models/story_text.rb
+++ b/app/models/story_text.rb
@@ -5,8 +5,8 @@ class StoryText < ApplicationRecord
 
   belongs_to :story, foreign_key: :id, inverse_of: :story_text
 
-  validates :title, presence: true, length: { maximum: 150 }
-  validates :description, :body, length: { maximum: 16_777_215 }
+  validates :title, presence: true, length: {maximum: 150}
+  validates :description, :body, length: {maximum: 16_777_215}
 
   def body=(s)
     # pass nil, truncate to column limit https://mariadb.com/kb/en/mediumtext/

--- a/app/models/suggested_title.rb
+++ b/app/models/suggested_title.rb
@@ -3,4 +3,6 @@
 class SuggestedTitle < ApplicationRecord
   belongs_to :story
   belongs_to :user
+
+  validates :title, length: {maximum: 150}, presence: true
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -21,7 +21,8 @@ class Tag < ApplicationRecord
     format: {with: /\A[A-Za-z0-9_\-\+]+\z/}
   validates :description, length: {maximum: 100}
   validates :hotness_mod, inclusion: {in: -10..10}
-  validates :permit_by_new_users, :privileged, inclusion: {in: [true, false]}
+  validates :permit_by_new_users, :privileged, :active, :is_media,
+    inclusion: {in: [true, false]}
 
   scope :active, -> { where(active: true) }
   scope :not_permitted_for_new_users, -> { where(permit_by_new_users: false) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -117,6 +117,16 @@ class User < ApplicationRecord
   validates :disabled_invite_reason,
     length: {maximum: 200}
 
+  validates :show_email, :is_admin, :is_moderator, :pushover_mentions,
+    inclusion: {in: [true, false]}
+
+  validates :session_token,
+    allow_blank: true,
+    presence: true
+
+  validates :karma,
+    presence: true
+
   validates_each :username do |record, attr, value|
     if BANNED_USERNAMES.include?(value.to_s.downcase) || value.starts_with?("tag-")
       record.errors.add(attr, "is not permitted")

--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -14,7 +14,8 @@ class Vote < ApplicationRecord
   validates :vote, presence: true
   validates :reason,
     length: {is: 1},
-    allow_blank: true
+    allow_blank: true,
+    presence: true
 
   scope :comments_flags, ->(comments, user = nil) {
     q = where(comment: comments, vote: -1)

--- a/db/migrate/20240606084311_add_missing_null_checks.rb
+++ b/db/migrate/20240606084311_add_missing_null_checks.rb
@@ -1,0 +1,23 @@
+class AddMissingNullChecks < ActiveRecord::Migration[7.1]
+  def change
+    # NULL string columns
+    change_column_null :domains, :domain, false
+    change_column_null :categories, :category, false
+
+    # Booleans
+    change_column_null :users, :is_admin, false
+    change_column_null :users, :is_moderator, false
+    change_column_null :users, :pushover_mentions, false
+    change_column_null :read_ribbons, :is_following, false
+    change_column_null :comments, :is_deleted, false
+    change_column_null :comments, :is_moderated, false
+    change_column_null :comments, :is_from_email, false
+    change_column_null :moderations, :is_from_suggestions, false
+    change_column_null :messages, :has_been_read, false
+    change_column_null :messages, :deleted_by_author, false
+    change_column_null :messages, :deleted_by_recipient, false
+    change_column_null :stories, :user_is_author, false
+    change_column_null :invitation_requests, :is_verified, false
+    change_column_null :hats, :modlog_use, false
+  end
+end

--- a/db/migrate/20240608224626_add_indexes_on_foreign_keys.rb
+++ b/db/migrate/20240608224626_add_indexes_on_foreign_keys.rb
@@ -1,0 +1,7 @@
+class AddIndexesOnForeignKeys < ActiveRecord::Migration[7.1]
+  def change
+    add_index :moderations, :category_id
+    add_index :messages, :author_user_id
+    add_index :domains, :banned_by_user_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_15_143804) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_06_084311) do
   create_table "categories", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
-    t.string "category"
+    t.string "category", null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.index ["category"], name: "index_categories_on_category", unique: true
@@ -32,9 +32,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_15_143804) do
     t.integer "flags", default: 0, null: false, unsigned: true
     t.decimal "confidence", precision: 20, scale: 19, default: "0.0", null: false
     t.text "markeddown_comment", size: :medium
-    t.boolean "is_deleted", default: false
-    t.boolean "is_moderated", default: false
-    t.boolean "is_from_email", default: false
+    t.boolean "is_deleted", default: false, null: false
+    t.boolean "is_moderated", default: false, null: false
+    t.boolean "is_from_email", default: false, null: false
     t.bigint "hat_id", unsigned: true
     t.index ["comment"], name: "index_comments_on_comment", type: :fulltext
     t.index ["confidence"], name: "confidence_idx"
@@ -48,7 +48,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_15_143804) do
   end
 
   create_table "domains", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
-    t.string "domain"
+    t.string "domain", null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.datetime "banned_at", precision: nil
@@ -73,7 +73,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_15_143804) do
     t.bigint "granted_by_user_id", null: false, unsigned: true
     t.string "hat", null: false
     t.string "link"
-    t.boolean "modlog_use", default: false
+    t.boolean "modlog_use", default: false, null: false
     t.datetime "doffed_at", precision: nil
     t.index ["granted_by_user_id"], name: "hats_granted_by_user_id_fk"
     t.index ["user_id"], name: "hats_user_id_fk"
@@ -88,7 +88,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_15_143804) do
 
   create_table "invitation_requests", id: { type: :bigint, unsigned: true }, charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.string "code"
-    t.boolean "is_verified", default: false
+    t.boolean "is_verified", default: false, null: false
     t.string "email", null: false
     t.string "name", null: false
     t.text "memo"
@@ -129,12 +129,12 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_15_143804) do
     t.datetime "created_at", precision: nil
     t.bigint "author_user_id", unsigned: true
     t.bigint "recipient_user_id", null: false, unsigned: true
-    t.boolean "has_been_read", default: false
+    t.boolean "has_been_read", default: false, null: false
     t.string "subject", limit: 100
     t.text "body", size: :medium
     t.string "short_id", limit: 30
-    t.boolean "deleted_by_author", default: false
-    t.boolean "deleted_by_recipient", default: false
+    t.boolean "deleted_by_author", default: false, null: false
+    t.boolean "deleted_by_recipient", default: false, null: false
     t.bigint "hat_id", unsigned: true
     t.index ["hat_id"], name: "index_messages_on_hat_id"
     t.index ["recipient_user_id"], name: "messages_recipient_user_id_fk"
@@ -161,7 +161,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_15_143804) do
     t.bigint "user_id", unsigned: true
     t.text "action", size: :medium
     t.text "reason", size: :medium
-    t.boolean "is_from_suggestions", default: false
+    t.boolean "is_from_suggestions", default: false, null: false
     t.bigint "tag_id", unsigned: true
     t.integer "domain_id"
     t.bigint "category_id"
@@ -175,7 +175,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_15_143804) do
   end
 
   create_table "read_ribbons", id: { type: :bigint, unsigned: true }, charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
-    t.boolean "is_following", default: true
+    t.boolean "is_following", default: true, null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.bigint "user_id", null: false, unsigned: true
@@ -211,7 +211,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_15_143804) do
     t.bigint "merged_story_id", unsigned: true
     t.datetime "unavailable_at", precision: nil
     t.string "twitter_id", limit: 20
-    t.boolean "user_is_author", default: false
+    t.boolean "user_is_author", default: false, null: false
     t.boolean "user_is_following", default: false, null: false
     t.bigint "domain_id"
     t.string "mastodon_id", limit: 25
@@ -288,13 +288,13 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_15_143804) do
     t.string "email", limit: 100
     t.string "password_digest", limit: 75
     t.datetime "created_at", precision: nil
-    t.boolean "is_admin", default: false
+    t.boolean "is_admin", default: false, null: false
     t.string "password_reset_token", limit: 75
     t.string "session_token", limit: 75, default: "", null: false
     t.text "about", size: :medium
     t.bigint "invited_by_user_id", unsigned: true
-    t.boolean "is_moderator", default: false
-    t.boolean "pushover_mentions", default: false
+    t.boolean "is_moderator", default: false, null: false
+    t.boolean "pushover_mentions", default: false, null: false
     t.string "rss_token", limit: 75
     t.string "mailing_list_token", limit: 75
     t.integer "mailing_list_mode", default: 0

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_06_084311) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_08_224626) do
   create_table "categories", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.string "category", null: false
     t.datetime "created_at", precision: nil, null: false
@@ -54,6 +54,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_06_084311) do
     t.datetime "banned_at", precision: nil
     t.integer "banned_by_user_id"
     t.string "banned_reason", limit: 200
+    t.index ["banned_by_user_id"], name: "index_domains_on_banned_by_user_id"
   end
 
   create_table "hat_requests", id: { type: :bigint, unsigned: true }, charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
@@ -136,6 +137,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_06_084311) do
     t.boolean "deleted_by_author", default: false, null: false
     t.boolean "deleted_by_recipient", default: false, null: false
     t.bigint "hat_id", unsigned: true
+    t.index ["author_user_id"], name: "index_messages_on_author_user_id"
     t.index ["hat_id"], name: "index_messages_on_hat_id"
     t.index ["recipient_user_id"], name: "messages_recipient_user_id_fk"
     t.index ["short_id"], name: "random_hash", unique: true
@@ -165,6 +167,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_06_084311) do
     t.bigint "tag_id", unsigned: true
     t.integer "domain_id"
     t.bigint "category_id"
+    t.index ["category_id"], name: "index_moderations_on_category_id"
     t.index ["comment_id"], name: "moderations_comment_id_fk"
     t.index ["created_at"], name: "index_moderations_on_created_at"
     t.index ["domain_id"], name: "index_moderations_on_domain_id"

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -478,4 +478,10 @@ describe Story do
       expect(creator.reload.received_messages.length).to eq(1)
     end
   end
+
+  describe ".title_maximum_length" do
+    subject { Story.title_maximum_length }
+
+    it { is_expected.to eq(150) }
+  end
 end


### PR DESCRIPTION
First pass at making updates recommended by `database_consistency` and `active_record_doctor` as per issue #1281 
These are the straight forward updates. There's some "non-standard" stuff in the schema that's resulting tricky fixes and  false positives. I think this PR is boarding on too big so I'll tackle the rest in another PR.

Note: There is a possibility that the migration that adds NOT NULL constraints might fail if those columns have NULL in them.
