### PR TITLE
Make the application compatible with `--enable-frozen-string-literal`

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -34,6 +34,10 @@ jobs:
         run: |
           bundle exec rspec
           bundle exec rspec spec/slow/*_spec.rb
+        env:
+          # Enabling frozen string literals in rspec only because brakeman
+          # isn't compatible yet: https://github.com/presidentbeef/brakeman/pull/1855
+          RUBYOPT: "--enable-frozen-string-literal --debug-frozen-string-literal"
       - name: Run linters
         run: |
           bundle exec standardrb

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,7 +18,7 @@ module ApplicationHelper
   end
 
   def errors_for(object)
-    html = ""
+    html = +""
     unless object.errors.blank?
       html << "<div class=\"flash-error\">"
       html << "<h2>#{pluralize(object.errors.count, "error")} prohibited this \

--- a/app/models/moderation.rb
+++ b/app/models/moderation.rb
@@ -42,7 +42,7 @@ class Moderation < ApplicationRecord
 
     if story
       m.recipient_user_id = story.user_id
-      m.subject = "Your story has been edited by " <<
+      m.subject = "Your story has been edited by " +
         (is_from_suggestions? ? "user suggestions" : "a moderator")
       m.body = "Your story [#{story.title}](" \
         "#{story.comments_url}) has been edited with the following " \
@@ -65,7 +65,7 @@ class Moderation < ApplicationRecord
       m.body = "Your comment on [#{comment.story.title}](" \
         "#{comment.story.comments_url}) has been moderated:\n" \
         "\n" <<
-        comment.comment.split("\n").map { |l| "> " << l }.join("\n")
+        comment.comment.split("\n").map { |l| "> #{l}" }.join("\n")
 
       if reason.present?
         m.body << "\n" \

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -855,7 +855,7 @@ class Story < ApplicationRecord
       params.reject! { |p|
         p.match(/^utm_(source|medium|campaign|term|content|referrer)=|^sk=|^gclid=|^fbclid=|^si=/x)
       }
-      u = match[1] << (params.any? ? "?" << params.join("&") : "")
+      u = match[1] << (params.any? ? "?#{params.join("&")}" : "")
     end
 
     self.normalized_url = Utils.normalize_url(u)

--- a/spec/extras/bitpacking_spec.rb
+++ b/spec/extras/bitpacking_spec.rb
@@ -12,7 +12,7 @@ end
 
 RSpec::Matchers.define :be_bytes do |bytes|
   match do |str|
-    str.eql?(bytes.force_encoding("binary"))
+    str.eql?(bytes.b)
   end
 end
 

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -213,8 +213,8 @@ describe Story do
 
     context "with unicode" do
       it "can fetch unicode titles properly" do
-        content = "<!DOCTYPE html><html><title>你好世界！ Here’s a fancy apostrophe</title></html>"
-          .force_encoding("ASCII-8BIT") # This is the encoding returned by Sponge#fetch
+        # Sponge#fetch returns a binary string
+        content = "<!DOCTYPE html><html><title>你好世界！ Here’s a fancy apostrophe</title></html>".b
         res = fake_response(content, "text/html")
         s = build(:story)
         s.fetched_response = res


### PR DESCRIPTION
As you may know, Ruby 4 is likely to make frozen string literals the default, in that context I wanted to see how much work would be needed for a relatively classic app.

Turns out it wasn't much work for lobsters.

I'm not particularly asking for this to be merged, just submitting it in case you'd want this change. It would allow you to run ruby with `--enable-frozen-string-literal` in production, which should reduce the GC pressure a bit (but don't expect crazy numbers).