### PR TITLE
Fix mismatched tags on search page

### DIFF
--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -376,7 +376,7 @@ class="story <%= story.current_upvoted? ? "upvoted" : "" %>
       <li>Search titles with <span class="searchq">title:kernel</span> or <span class="searchq">title:"linux kernel"</span></li>
       <li>Search by domain with <span class="searchq">domain:example.com</span></li>
       <li>Search by story submitter with <span class="searchq">submitter:alice</span></li>
-      <li>Search by <%= link_to 'tag', tags_path %> with <code>tag:meta</span></li>
+      <li>Search by <%= link_to 'tag', tags_path %> with <span class="searchq">tag:meta</span></li>
     </ul>
   </div>
 <% end %>


### PR DESCRIPTION
`tag:meta` in the search page is inconsistent:
![image](https://github.com/lobsters/lobsters/assets/48535279/3fb5e6e3-a83b-4375-9382-c253776420a6)


Replaced a mismatched `<code>` tag to fix the inconsistency.