### PR TITLE
Dump heap after boot and after bloat

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -37,15 +37,40 @@ workers ENV.fetch("PUMA_WORKERS") { 3 }
 worker_boot_timeout 180
 
 # https://github.com/Shopify/ruby/issues/556
+on_first_worker = false
 on_worker_boot do |worker_index|
-  if defined?(RubyVM::YJIT) && worker_index == 0
-    Thread.new do
-      loop do
-        # rubocop doesn't know activesupport isn't available here
-        # rubocop:disable Rails/TimeZone
-        File.write("/tmp/yjit-stats.txt", [Time.now.strftime("%Y-%m-%dT%H:%M:%S.%L%z"), " ", RubyVM::YJIT.runtime_stats, " ", GC.stat, "\n"].join, mode: "a+")
-        # rubocop:enable Rails/TimeZone
-        sleep 300
+  on_first_worker = worker_index == 0
+
+  if on_first_worker
+    require "objspace"
+    GC.start
+    File.open("/tmp/heap-boot.json", "w+") do |f|
+      ObjectSpace.dump_all(output: f)
+    end
+    if defined?(RubyVM::YJIT)
+      Thread.new do
+        loop do
+          # rubocop doesn't know activesupport isn't available here
+          # rubocop:disable Rails/TimeZone
+          File.write("/tmp/yjit-stats.txt", [Time.now.strftime("%Y-%m-%dT%H:%M:%S.%L%z"), " ", RubyVM::YJIT.runtime_stats, " ", GC.stat, "\n"].join, mode: "a+")
+          # rubocop:enable Rails/TimeZone
+          sleep 300
+        end
+      end
+    end
+  end
+end
+
+heap_dumped = false
+out_of_band do
+  if on_first_worker && !heap_dumped
+    if GC.stat(:heap_live_slots) > 750_000
+      GC.start
+      if GC.stat(:heap_live_slots) > 750_000
+        heap_dumped = true
+        File.open("/tmp/heap-bloated.json", "w+") do |f|
+          ObjectSpace.dump_all(output: f)
+        end
       end
     end
   end


### PR DESCRIPTION
Ref: https://github.com/Shopify/ruby/issues/556#issuecomment-2211754838

Note: This is totally untested

`out_of_band` is invoke when a request finishes and no other thread is busy. So theorically it may never be invoked if the worker is under constant load, but I'm hoping it will eventually.

The idea here is to wait for the number of live object to go over some threshold we found in the GC stqats we dumped previously, and when it's reached we dump the heap a second time.

By comparing it with the heap that was dumped after boot, we should be able to figure out what extra objects are being retained after the worker ages.

<!--
Issues and PRs are typically reviewed Wednesday and most weekend mornings.
-->
