### PR TITLE
Fixed text highlight color

### DIFF
--- a/app/assets/stylesheets/application.css.erb
+++ b/app/assets/stylesheets/application.css.erb
@@ -181,10 +181,6 @@ html.color-scheme-dark {
 /* overall page */
 
 html {
-	/* environment colors */
-	--color-selection-fg: HighlightText;
-	--color-selection-bg: Highlight;
-
 	/* derived colors */
 
 	/* These colors are derived from the light or dark palette. This
@@ -480,12 +476,6 @@ input.deletion {
 	-webkit-appearance: none;
 	margin: 0;
 }
-
-::selection {
-	color: var(--color-selection-fg);
-	background-color: var(--color-selection-bg);
-}
-
 
 
 /* header */


### PR DESCRIPTION
System colors are deprecated in CSS3, and as such the Highlight and HighlightText keywords don't function properly on Chrome. 

https://www.w3.org/TR/CSS2/ui.html#system-colors

Removing these lines makes browsers just use the defaults, which looks more similar (albeit not the same) across the board. Don't know if you want to hard code in a selection color value, some users might want to define their own. 