### PR TITLE
Update check.yml to use actions/checkout@v4

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -22,7 +22,7 @@ jobs:
       RAILS_ENV: test
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true


### PR DESCRIPTION
actions/checkout@v3 uses Node 16 which is no longer used in GH actions. This updates it to the latest version.