### PR TITLE
Remove redundant limit from #pick call

### DIFF
--- a/app/models/keystore.rb
+++ b/app/models/keystore.rb
@@ -12,7 +12,7 @@ class Keystore < ApplicationRecord
   end
 
   def self.value_for(key)
-    where(key: key).limit(1).pick(:value)
+    where(key: key).pick(:value)
   end
 
   def self.put(key, value)


### PR DESCRIPTION
<!--
Issues and PRs are typically reviewed Wednesday and most weekend mornings.
-->

`#pick` is a short-hand for `relation.limit(1).pluck(*column_names).first`, hence the `limit` clause is redundant here.