### PR TITLE
Accessibility improvements for "unread" feature

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -779,7 +779,8 @@ onPageLoad(() => {
     const foundIndex = Array.from(nodes).findIndex(node => node === event.target)
     const targetIndex = (foundIndex + 1) % nodes.length;
     const targetY = nodes[targetIndex].getBoundingClientRect().top + window.scrollY
-    window.scrollTo({ top: targetY, behavior: 'smooth' })
+    const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    window.scrollTo({ top: targetY, behavior: reducedMotion ? 'instant' : 'smooth' })
   });
 
   // Story view

--- a/app/views/stories/show.html.erb
+++ b/app/views/stories/show.html.erb
@@ -49,7 +49,7 @@
           <% if @ribbon.new_record? %>
             all unread
           <% elsif unread > 0 %>
-            <span class='comment_unread'><%= unread %> unread</span>
+            <span role='link' class='comment_unread'><%= unread %> unread</span>
           <% else %>
             0 unread
           <% end %>


### PR DESCRIPTION
I couldn't activate the "unread" link, that scrolls to the first unread comment, because it lacked a role. Now it has a role.

I also took the opportunity to check the "reduced motion" preference to determine scrolling behavior.