### PR TITLE
Avoid continiously instantiating HTMLEntities

### DIFF
--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -484,7 +484,7 @@ class Story < ApplicationRecord
       s = s.to_s[0, chars].gsub(/ [^ ]*\z/, "")
     end
 
-    HTMLEntities.new.decode(s.to_s)
+    HtmlEncoder.encode(s.to_s)
   end
 
   def domain_search_url

--- a/app/views/comments/index.rss.erb
+++ b/app/views/comments/index.rss.erb
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<% coder = HTMLEntities.new %>
 <rss version="2.0">
   <channel>
     <title><%= Rails.application.name %><%= @title.present? ?
@@ -9,14 +8,13 @@
 
     <% @comments.each do |comment| %>
       <item>
-        <title>on <%= raw coder.encode(comment.story.title, :decimal) %></title>
+        <title>on <%= raw HtmlEncoder.encode(comment.story.title) %></title>
         <link><%= comment.url %></link>
         <guid><%= comment.short_id_url %></guid>
         <author><%= comment.user.username %>@users.<%= Rails.application.domain %> (<%= comment.user.username %>)</author>
         <pubDate><%= comment.created_at.rfc2822 %></pubDate>
         <comments><%= comment.url %></comments>
-        <description><%= raw coder.encode(comment.markeddown_comment,
-          :decimal) %></description>
+        <description><%= raw HtmlEncoder.encode(comment.markeddown_comment) %></description>
       </item>
     <% end %>
   </channel>

--- a/app/views/home/rss.erb
+++ b/app/views/home/rss.erb
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<% coder = HTMLEntities.new %>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title><%= Rails.application.name %><%= @title.present? ?
@@ -10,17 +9,17 @@
 
     <% @stories.each do |story| %>
       <item>
-        <title><%= raw coder.encode(story.title, :decimal) %></title>
+        <title><%= raw HtmlEncoder.encode(story.title) %></title>
         <link><%= story.url_or_comments_url %></link>
         <guid isPermaLink="false"><%= story.short_id_url %></guid>
         <author><%= story.domain&.domain %> <%= story.user_is_author? ? "by" : "via" %> <%= story.user.username %></author>
         <pubDate><%= story.created_at.rfc2822 %></pubDate>
         <comments><%= story.comments_url %></comments>
         <description>
-          <%= raw coder.encode(story.markeddown_description, :decimal) %>
+          <%= raw HtmlEncoder.encode(story.markeddown_description) %>
           <% if story.url.present? %>
-            <%= raw coder.encode("<p>" +
-              link_to("Comments", story.comments_url) + "</p>", :decimal) %>
+            <%= raw HtmlEncoder.encode("<p>" +
+              link_to("Comments", story.comments_url) + "</p>") %>
           <% end %>
         </description>
         <% story.taggings.each do |tagging| %>

--- a/extras/html_encoder.rb
+++ b/extras/html_encoder.rb
@@ -1,0 +1,17 @@
+# typed: false
+
+require "cgi"
+
+module HtmlEncoder
+  HTML_ENTITIES = HTMLEntities.new
+
+  class << self
+    def encode(string, type = :decimal)
+      HTML_ENTITIES.encode(string, type)
+    end
+
+    def decode(encoded_string)
+      CGI.unescape_html(encoded_string)
+    end
+  end
+end

--- a/spec/extras/html_encoder_spec.rb
+++ b/spec/extras/html_encoder_spec.rb
@@ -1,0 +1,13 @@
+# typed: false
+
+require "rails_helper"
+
+describe HtmlEncoder do
+  it "encode all non-ascii characters" do
+    expect(subject.encode("<Héllø>")).to eq "&#60;H&#233;ll&#248;&#62;"
+  end
+
+  it "decode all entities" do
+    expect(subject.decode("&#60;H&#233;ll&#248;&#62;")).to eq "<Héllø>"
+  end
+end


### PR DESCRIPTION
While profiling the lobsters benchmark in the yjit-bench suite I noticed a weird 0.8% of time spent in `instance_eval`.

Tracking it down, it's coming from the htmlentities gem, when calling `HTMLEntities.new` it generates code on the fly based on the options.

~~As such you aren't meant to instantiate a new one every time, but have a single global object somewhere.~~ Actually seems like you are, that gems just bad.

Otherwise this constant code generation is wasting performance for now reason, and potentially use YJIT executable memory if called enough.
