### PR TITLE
Improve setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,17 +31,14 @@ There's an external project [docker-lobsters](https://github.com/utensils/docker
   On MacOS you can [install with brew](https://mariadb.com/kb/en/installing-mariadb-on-macos-using-homebrew/).
   On Windows there's an [installer](https://mariadb.org/download/?t=mariadb&p=mariadb&r=11.5.2&os=Linux&cpu=x86_64&pkg=tar_gz&i=systemd&mirror=starburst_stlouis).
 
-* Start mysql and set the `root` user password
+* Start the mariadb server, open the console, and set the `root` user password (type `ctrl-d` to exit afterwards)
 
 ```sh
-# Start the server
 mysql.server start
-# open a mysql console
-mysql
+mariadb
 ```
 
 ```sql
-FLUSH PRIVILEGES;
 ALTER USER 'root'@'localhost' IDENTIFIED BY 'localdev';
 ```
 

--- a/README.md
+++ b/README.md
@@ -31,12 +31,9 @@ There's an external project [docker-lobsters](https://github.com/utensils/docker
   On MacOS you can [install with brew](https://mariadb.com/kb/en/installing-mariadb-on-macos-using-homebrew/).
   On Windows there's an [installer](https://mariadb.org/download/?t=mariadb&p=mariadb&r=11.5.2&os=Linux&cpu=x86_64&pkg=tar_gz&i=systemd&mirror=starburst_stlouis).
 
-* Start the mariadb server, open the console, and set the `root` user password (type `ctrl-d` to exit afterwards)
+* Start the mariadb server using one of the [methods mentioned in the mariadb knowledge base](https://mariadb.com/kb/en/starting-and-stopping-mariadb-automatically/).
 
-```sh
-mysql.server start
-mariadb
-```
+* Open the console using `mariadb`, and set the `root` user password (type `ctrl-d` to exit afterwards)
 
 ```sql
 ALTER USER 'root'@'localhost' IDENTIFIED BY 'localdev';

--- a/README.md
+++ b/README.md
@@ -31,6 +31,20 @@ There's an external project [docker-lobsters](https://github.com/utensils/docker
   On MacOS you can [install with brew](https://mariadb.com/kb/en/installing-mariadb-on-macos-using-homebrew/).
   On Windows there's an [installer](https://mariadb.org/download/?t=mariadb&p=mariadb&r=11.5.2&os=Linux&cpu=x86_64&pkg=tar_gz&i=systemd&mirror=starburst_stlouis).
 
+* Start mysql and set the `root` user password
+
+```sh
+# Start the server
+mysql.server start
+# open a mysql console
+mysql
+```
+
+```sql
+FLUSH PRIVILEGES;
+ALTER USER 'root'@'localhost' IDENTIFIED BY 'localdev';
+```
+
 * Install the Ruby version specified in [.ruby-version](https://github.com/lobsters/lobsters/blob/master/.ruby-version)
 
 * Checkout the lobsters git tree from Github

--- a/bin/setup
+++ b/bin/setup
@@ -29,9 +29,7 @@ FileUtils.chdir APP_ROOT do
   system! "bin/rails log:clear tmp:clear"
 
   puts "\n== Preparing database =="
-  system! "bin/rails db:schema:load"
-  system! "bin/rails db:migrate"
-  system! "bin/rails db:seed"
+  system! "bin/rails db:setup"
 
   puts "\n== Restarting application server if running =="
   system! "bin/rails restart"


### PR DESCRIPTION
Hi. I was setting up the codebase this morning and struggled a bit as I don't have a lot of mysql experience. I took some steps to get it working, and then updated some README/code:

* Add instructions to start the `mysql` server
* Add instructions to set the root password to match `database.yml.sample`
* Use the `db:setup` command in `bin/setup`. It does the same thing and will be a little faster since it doesn't have to load the rails app for three commands.

Totally open to feedback if there's a more idiomatic way to set up local mariadb.