### PR TITLE
Story: description_or_story_text should return plaintext

### DIFF
--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -491,7 +491,7 @@ class Story < ApplicationRecord
       s = s.to_s[0, chars].gsub(/ [^ ]*\z/, "")
     end
 
-    HtmlEncoder.encode(s.to_s)
+    HtmlEncoder.decode(s.to_s)
   end
 
   def domain_search_url


### PR DESCRIPTION
PR #1320 changed this from HTMLEntities.new.decode to HtmlEncoder.encode which does the opposite of what it used to do.

Should fix #1328

<!--
Issues and PRs are typically reviewed Wednesday and most weekend mornings.
-->
