### PR TITLE
Issue #1282 - Updating application.css.erb rule to hide folders

### DIFF
--- a/app/assets/stylesheets/application.css.erb
+++ b/app/assets/stylesheets/application.css.erb
@@ -1962,3 +1962,9 @@ input[type="submit"].link_post.pushover_button {
 		float: none;
 	}
 }
+@media print {
+	.comment_folder,
+	.comment_form {
+	    display: none;
+	}
+  }

--- a/app/assets/stylesheets/application.css.erb
+++ b/app/assets/stylesheets/application.css.erb
@@ -1965,6 +1965,6 @@ input[type="submit"].link_post.pushover_button {
 @media print {
 	.comment_folder,
 	.comment_form {
-	    display: none;
+		display: none;
 	}
-  }
+}


### PR DESCRIPTION
Issue #1282

Checked the issue & came to following conclusion
Updated the current print-specific CSS
Defined rules to hide the comment_folder and comment forms when a user prints a page.

Looks fine to me for now will update if more fixes are needed

