### PR TITLE
Fix #1333 Some but not all text changes size when rotating Mobile Safari to landscape

### DIFF
--- a/app/assets/stylesheets/application.css.erb
+++ b/app/assets/stylesheets/application.css.erb
@@ -223,9 +223,14 @@ html {
 
 /* generics */
 
-/* force a vertical scrollbar to avoid page-shifting */
 html {
+	/* force a vertical scrollbar to avoid page-shifting */
 	overflow-y: scroll;
+
+	/* avoid automatic resizing of some text elements on phones in landscape */
+	-moz-text-size-adjust: none;
+	-webkit-text-size-adjust: none;
+	text-size-adjust: none;
 }
 
 body, textarea, input, button {


### PR DESCRIPTION
Fixes #1333.

Tested with the home list page and a story page:

## Landscape

Before: Landscape exhibits the bug, in which some fonts are the same as portrait and some are enlarged.

![list, landscape, before](https://github.com/user-attachments/assets/102f4092-f1d6-4878-ad60-61fbdd774a7b)
![story, landscape, before](https://github.com/user-attachments/assets/5f1f6498-ffa1-4b48-8c89-4f97af2a165c)

After: Landscape keeps the same font sizes as portrait.

![list, landscape, after](https://github.com/user-attachments/assets/9248edeb-aab3-436d-9b08-bf7aafebf6f9)
![story, landscape, after](https://github.com/user-attachments/assets/aca8d2fb-b2e6-4331-abc0-3c2969a09f67)

## Portrait

Portrait font sizes were unaffected by the change.

Before:

![list, portrait, before](https://github.com/user-attachments/assets/10b8da61-e678-4c46-a389-ab95ded4dc36)
![story, portrait, before](https://github.com/user-attachments/assets/15766661-cc04-43f5-adad-635846c28dba)

After:

![list, portrait, after](https://github.com/user-attachments/assets/132f30a3-6df0-4d70-919a-46dedc973500)
![story, portrait, after](https://github.com/user-attachments/assets/2d1be66b-5579-41d9-90c7-5dbc326fd78d)

Curiously, I didn't reproduce today the enlarged tags on the story page that I saw when I wrote up the issue.