### PR TITLE
Change "archive" link to "caches"

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -181,7 +181,7 @@ class="story <%= story.current_upvoted? ? "upvoted" : "" %>
           <span> | </span>
           <span class="dropdown_parent">
             <input id="archive_<%= story.short_id %>" class="archive_button" type="checkbox">
-            <label for="archive_<%= story.short_id %>">archive</label>
+            <label for="archive_<%= story.short_id %>">caches</label>
             <div class="archive-dropdown">
               <a href="<%= story.archiveorg_url %>">Archive.org</a>
               <a href="<%= story.archivetoday_url %>">Archive.today</a>


### PR DESCRIPTION
This might be more clear.
There's a [discussion thread](https://lobste.rs/s/nsdzkf/suggestion_change_archive_link_text)

Perhaps "mirrors" or "archives" would be better, but I figured the "obvious improvement" comment was a sign to go ahead rather than do some bikeshedding.
