### PR TITLE
Remember tags when previewing a story

### DIFF
--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -727,13 +727,13 @@ class Story < ApplicationRecord
   end
 
   def tags_a
-    @_tags_a ||= taggings
-      .includes(:tag)
-      .reject(&:marked_for_destruction?)
-      .map { |t| t.tag.tag }
+    @_tags_a ||= Tag
+      .where(id: taggings.reject(&:marked_for_destruction?).map { |t| t.tag_id })
+      .pluck(:tag)
   end
 
   def tags_a=(new_tag_names_a)
+    @_tags_a = nil
     taggings.each do |tagging|
       if !new_tag_names_a.include?(tagging.tag.tag)
         tagging.mark_for_destruction

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -749,6 +749,10 @@ class Story < ApplicationRecord
     end
   end
 
+  def preview_tags
+    Tag.where(id: taggings.map { |t| t.tag_id })
+  end
+
   def save_suggested_tags_a_for_user!(new_tag_names_a, user)
     suggested_taggings.where(user_id: user.id).destroy_all
 

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -62,7 +62,7 @@ class="story <%= story.current_upvoted? ? "upvoted" : "" %>
     <% end %>
     <% if story.can_be_seen_by_user?(@user) %>
       <span class="tags">
-        <% story.tags.each do |tag| %>
+        <% (story.previewing ? story.preview_tags : story.tags).each do |tag| %>
           <%= tag_link(tag) %>
         <% end %>
       </span>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -184,7 +184,7 @@ class="story <%= story.current_upvoted? ? "upvoted" : "" %>
     <% end %>
     <% if story.can_be_seen_by_user?(@user) %>
       <span class="tags">
-        <% story.tags.each do |tag| %>
+        <% (story.previewing ? story.preview_tags : story.tags).each do |tag| %>
           <%= tag_link(tag) %>
         <% end %>
       </span>

--- a/app/views/stories/_listdetail.html.erb
+++ b/app/views/stories/_listdetail.html.erb
@@ -48,7 +48,7 @@ class="story <%= story.current_upvoted? ? "upvoted" : "" %>
     <% end %>
     <% if story.can_be_seen_by_user?(@user) %>
       <span class="tags">
-        <% story.tags.each do |tag| %>
+        <% (story.previewing ? story.preview_tags : story.tags).each do |tag| %>
           <%= tag_link(tag) %>
         <% end %>
       </span>

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -519,4 +519,13 @@ describe Story do
 
     it { is_expected.to eq(150) }
   end
+
+  describe "#preview_tags" do
+    it "allows accessing tags set by tags_a on unsaved stories" do
+      tag = Tag.find_by(tag: "tag1")
+      s = build(:story, tags_a: ["tag1"])
+      expect(s.preview_tags).to eq([tag])
+      expect(s.tags).to eq([])
+    end
+  end
 end

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -231,6 +231,13 @@ describe Story do
     expect(s.url).to eq("https://factorable.net/")
   end
 
+  it "sets tags_a properly on an unsaved story" do
+    s = build(:story, tags_a: [])
+    expect(s.tags_a).to eq([])
+    s.tags_a = ["tag1", "tag2"]
+    expect(s.tags_a).to eq(["tag1", "tag2"])
+  end
+
   it "calculates tag changes properly" do
     s = create(:story, title: "blah", tags_a: ["tag1", "tag2"])
 


### PR DESCRIPTION
This is a late PR after the issue submitted on #1321.

The changes are described on the commit messages. Basically:

* The first commit makes the story preview action not forget the story tags by making `Story#tags_a` work on preview stories (i.e. unsaved). It fixes #1264.
* The second commit makes the story preview show the submitted tags.

I'm not too keen on the approach taken on the 2nd commit. I wish `Story#tags` would Just Work™ on unsaved stories, but alas, it doesn't. Suggestions are welcomed!

The two commits are independent from each other. I left them this way if you prefer to apply the first one without the questionable approach of the second one :)