### PR TITLE
Issue #1338 Partial view disappears on click

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -415,6 +415,7 @@ class StoriesController < ApplicationController
     @story = Story.new(user: @user)
     @story.attributes = story_params
     @story.already_posted_recently?
+    @story.valid?
 
     respond_to do |format|
       linking_comments = Link.recently_linked_from_comments(@story.url)


### PR DESCRIPTION
<!--
Issues and PRs are typically reviewed Wednesday and most weekend mornings.
-->
Fix #1338 

Stories form is validating URL duplicity in advance of form submit and due the event used results in an view override when the form have other errors.


**Current behavior:**
onfocusout event is called for URL input, this result in a request (`/stories/check_url_dupe`) that overrides the current form errors, if any.
[Exhibit A](https://www.loom.com/share/c7b54a3cb59f4d0caeecb547bcec39c2?sid=0e1b918d-3e5c-48ad-adac-9d3cf85c82f1)

New behavior:
complement `url_dupe` request with `.valid?` method to avoid loss previous error messages if any
[Exhibit B](https://www.loom.com/share/3bd0562ae78b4c95995c6561e8665feb?sid=c87e7d5f-9a63-446c-9285-1e1665694601)