### PR TITLE
Issue #1331 Implement story disowning

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -635,6 +635,16 @@ onPageLoad(() => {
     }
   });
 
+  on('click', 'a.story-disowner', (event) => {
+    if (confirm("Are you sure you want to disown this story?")) {
+      let li = parentSelector(event.target, '.story');
+      fetchWithCSRF('/stories/' + li.getAttribute('data-shortid') + '/disown', { method: 'post' })
+        .then(response => {
+          response.text().then(text => replace(li, text));
+        });
+    }
+  });
+
   on("click", "a.comment_replier", (event) => {
     event.preventDefault();
     if (!Lobster.curUser) return Lobster.bounceToLogin();

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -434,7 +434,7 @@ class StoriesController < ApplicationController
   end
 
   def disown
-    if !((story = find_story) && story.is_disownable_by_user?(@user))
+    if !((story = find_story) && story.disownable_by_user?(@user))
       return render plain: "can't find story", status: 400
     end
 
@@ -444,8 +444,9 @@ class StoriesController < ApplicationController
 
     load_user_votes
 
-    render partial: "listdetail",  layout: false, content_type: "text/html", locals: {story: @story, :single_story => true}
+    render partial: "listdetail", layout: false, content_type: "text/html", locals: {story: @story, single_story: true}
   end
+
   private
 
   def story_params

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -433,6 +433,19 @@ class StoriesController < ApplicationController
     end
   end
 
+  def disown
+    if !((story = find_story) && story.is_disownable_by_user?(@user))
+      return render plain: "can't find story", status: 400
+    end
+
+    InactiveUser.disown! story
+    @story = find_story
+    @comments = Comment.story_threads(@story).for_presentation
+
+    load_user_votes
+
+    render partial: "listdetail",  layout: false, content_type: "text/html", locals: {story: @story, :single_story => true}
+  end
   private
 
   def story_params

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -198,6 +198,10 @@ class Story < ApplicationRecord
     check_tags
   end
 
+  def is_disownable_by_user?(user)
+    user && user.id == user_id
+  end
+
   def accepting_comments?
     !is_gone? &&
       !previewing &&

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -136,6 +136,7 @@ class Story < ApplicationRecord
 
   COMMENTABLE_DAYS = 90
   FLAGGABLE_DAYS = 14
+  DELETEABLE_DAYS = FLAGGABLE_DAYS * 2
 
   # the lowest a score can go
   FLAGGABLE_MIN_SCORE = -5
@@ -196,10 +197,6 @@ class Story < ApplicationRecord
     end
 
     check_tags
-  end
-
-  def is_disownable_by_user?(user)
-    user && user.id == user_id
   end
 
   def accepting_comments?
@@ -575,6 +572,10 @@ class Story < ApplicationRecord
 
   def hider_count
     @hider_count ||= HiddenStory.where(story_id: id).count
+  end
+
+  def disownable_by_user?(user)
+    user && user.id == user_id && created_at < DELETEABLE_DAYS.days.ago
   end
 
   def is_flaggable?

--- a/app/views/stories/_listdetail.html.erb
+++ b/app/views/stories/_listdetail.html.erb
@@ -153,6 +153,10 @@ class="story <%= story.current_upvoted? ? "upvoted" : "" %>
             <span> | </span><%= link_to "hide", story_hide_path(story.short_id),
               :class => "hider" %>
           <% end %>
+          <% if story.is_disownable_by_user?(@user) %>
+          |
+          <a tabindex="0" class="story-disowner" href="#">disown</a>
+          <% end %>
           <% if single_story && story.hider_count > 0 %>
             (hidden by <%= pluralize(story.hider_count, "user") %>)
           <% end %>

--- a/app/views/stories/_listdetail.html.erb
+++ b/app/views/stories/_listdetail.html.erb
@@ -153,9 +153,9 @@ class="story <%= story.current_upvoted? ? "upvoted" : "" %>
             <span> | </span><%= link_to "hide", story_hide_path(story.short_id),
               :class => "hider" %>
           <% end %>
-          <% if story.is_disownable_by_user?(@user) %>
+          <% if single_story && story.disownable_by_user?(@user) %>
           |
-          <a tabindex="0" class="story-disowner" href="#">disown</a>
+          <a class="story-disowner" href="#">disown</a>
           <% end %>
           <% if single_story && story.hider_count > 0 %>
             (hidden by <%= pluralize(story.hider_count, "user") %>)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -113,6 +113,7 @@ Rails.application.routes.draw do
     post "unsave"
     get "suggest"
     post "suggest", action: "submit_suggestions"
+    post "disown"
   end
   post "/stories/fetch_url_attributes", format: "json"
   post "/stories/preview" => "stories#preview"

--- a/spec/features/story_spec.rb
+++ b/spec/features/story_spec.rb
@@ -1,0 +1,46 @@
+# typed: false
+
+require "rails_helper"
+
+# uses page.driver.post because we're not running a full js engine,
+# so the call can't just be click_on('delete'), etc.
+
+RSpec.feature "Stories" do
+  let(:user) { create(:user) }
+  let(:story) { create(:story, user: user) }
+  let!(:inactive_user) { create(:user, :inactive) }
+  let!(:story_without_user) { create(:story) }
+
+  before(:each) { stub_login_as user }
+
+  feature "disowning stories" do
+    scenario "disowning a story" do
+      page.driver.post "/stories/#{story.short_id}/disown"
+      story.reload
+      expect(story.user).to eq(inactive_user)
+
+      visit "/s/#{story.short_id}"
+      expect(page).to have_content("inactive-user")
+    end
+
+    scenario "shows disown in story page" do
+      visit "/s/#{story.short_id}"
+      expect(page).to have_link("disown")
+    end
+
+    scenario "does not show disown in active stories page" do
+      visit "/active"
+      expect(page).not_to have_link("disown")
+      expect(page).to have_content(user.username)
+    end
+
+    scenario "trying to disown not owned stories" do
+      visit "/s/#{story_without_user.short_id}"
+      expect(page).not_to have_link("disown")
+
+      page.driver.post "/stories/#{story_without_user.short_id}/disown"
+      story.reload
+      expect(story.user).to eq(user)
+    end
+  end
+end

--- a/spec/requests/stories_spec.rb
+++ b/spec/requests/stories_spec.rb
@@ -299,6 +299,8 @@ describe "stories", type: :request do
     before { sign_in user }
 
     it "disown story" do
+      story.update!(created_at: (Story::DELETEABLE_DAYS + 1).days.ago)
+
       expect {
         post "/stories/#{story.short_id}/disown"
         expect(response.status).to eq(200)

--- a/spec/requests/stories_spec.rb
+++ b/spec/requests/stories_spec.rb
@@ -293,6 +293,18 @@ describe "stories", type: :request do
     end
   end
 
+  describe "disowning" do
+    let(:inactive_user) { create(:user, :inactive) }
+
+    before { sign_in user }
+
+    it "disown story" do
+      expect {
+        post "/stories/#{story.short_id}/disown"
+        expect(response.status).to eq(200)
+      }.to change { story.reload.user }.from(story.user).to(inactive_user)
+    end
+  end
   describe "adding suggestions to a story"
 
   describe "user editing an editable story"


### PR DESCRIPTION
<!--
Issues and PRs are typically reviewed Wednesday and most weekend mornings.
-->
Fix #1331 

Allow stories to be disowned individually

![Screenshot 2024-10-13 at 11 53 44 p m](https://github.com/user-attachments/assets/037bad12-48db-4619-9ea0-6b568f8b48bf)

![Screenshot 2024-10-13 at 11 54 06 p m](https://github.com/user-attachments/assets/bcd89b9f-2481-4d9d-a290-0b5676c7b373)


Validate:

- [x] add disown route
- [x] add disown button only in story page
- [x] add specs