### PR TITLE
Issue #1334 Fix validation for resubmitted story form

### DIFF
--- a/app/views/stories/_form.html.erb
+++ b/app/views/stories/_form.html.erb
@@ -1,5 +1,5 @@
 <%# locals: (story:, f:, suggesting: false) -%>
-<%= render :partial => "stories/form_errors", :locals => { :f => f, :story => f.object } %>
+<%= render :partial => "stories/form_errors", :locals => { :f => f, :story => f.object, suggesting: suggesting } %>
 
 <div class="box">
   <% unless suggesting %>

--- a/app/views/stories/_form_errors.html.erb
+++ b/app/views/stories/_form_errors.html.erb
@@ -1,10 +1,10 @@
-<%# locals: (story:, f: nil, linking_comments: []) -%>
+<%# locals: (story:, f: nil, linking_comments: [], suggesting: false) -%>
 <div>
   <div class="form_errors_header">
     <% if story.errors.any? %>
       <%= errors_for story %>
     <% end %>
-    <% if story.is_resubmit? %>
+    <% if story.is_resubmit? && !suggesting %>
       <div class="flash-notice">
         <p>
           This story has been submitted before. You can resubmit it with a comment to start a fresh discussion.
@@ -24,7 +24,7 @@
         <%= text_area_tag "comment", @comment&.comment, :rows => 5 %>
         <br><br>
       </div>
-    <% elsif story.similar_stories.any? %>
+    <% elsif story.similar_stories.any? && !suggesting %>
       <p>Previous discussions for this story:</p>
       <%= render partial: "stories/similar", locals: { similar: story.similar_stories } %>
     <% elsif linking_comments.any? %>


### PR DESCRIPTION
<!--
Issues and PRs are typically reviewed Wednesday and most weekend mornings.
-->
Fix #1334 

Currently for an already submitted story when a different user tries to do a suggestion (click on `suggest` link) it show the `is_resubmit?` form as well as the `similar_stories.any?` form, this forms are intended when a user is submitting a story.

Current behavior:
- test user with original story:
![Screenshot 2024-10-15 at 7 17 48 p m](https://github.com/user-attachments/assets/73563f72-d247-4b70-95ae-54f8e200f0a7)
- renna_collins with a resubmitted story 
![Screenshot 2024-10-15 at 7 19 21 p m](https://github.com/user-attachments/assets/0e362f92-4588-4b5a-bce2-ade6428e87b3)
![Screenshot 2024-10-15 at 7 20 38 p m](https://github.com/user-attachments/assets/8bde0a68-81a3-4f5e-bcb6-9402feaafc2b)
- will_shannon clicking "suggest" (different user)
![Screenshot 2024-10-15 at 7 22 00 p m](https://github.com/user-attachments/assets/cc03943e-2121-48f5-b084-57d4e6b9d2fa)
![Screenshot 2024-10-15 at 7 22 16 p m](https://github.com/user-attachments/assets/0deea0c1-2c2c-456e-b6d0-6da6055d97df)

New behavior:
- will_shannon clicking "suggest" (different user)
![Screenshot 2024-10-15 at 7 30 52 p m](https://github.com/user-attachments/assets/49656be2-6a51-4b55-840b-5ed13a818c60)
![Screenshot 2024-10-15 at 7 24 36 p m](https://github.com/user-attachments/assets/98145a29-2f61-4bfb-b4f7-40b5f6a658b7)
- long_armstrong clicking "suggest" (different user)
 ![Screenshot 2024-10-15 at 7 30 05 p m](https://github.com/user-attachments/assets/3c2e7d78-c21b-4d69-87b5-b045f2f4d9e1)
![Screenshot 2024-10-15 at 7 26 40 p m](https://github.com/user-attachments/assets/4ae15801-077e-4ce1-ac60-f6a123474260)



