### PR TITLE
Issue #1339 Utils.normalize(url) mishandles www10.org 

### DIFF
--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -930,7 +930,7 @@ class Story < ApplicationRecord
   end
 
   def set_domain_and_origin(domain_name)
-    domain_name&.sub!(/^www\d*\./, "")
+    domain_name&.sub!(/\Awww\d*\.(.+?\..+)/, '\1') # remove www\d* from domain if the url is not like www10.org
     if domain_name.present?
       self.domain = Domain.where(domain: domain_name).first_or_initialize
       self.origin = domain&.origin(url)

--- a/extras/utils.rb
+++ b/extras/utils.rb
@@ -19,7 +19,7 @@ class Utils
     url.slice! %r{/Default\.aspx$}
 
     url.slice! %r{https?://} # consider http and https the same
-    url.slice! %r{^(www\d*\.)} # remove www\d* from domain
+    url.sub!(/\Awww\d*\.(.+?\..+)/, '\1') # remove www\d* from domain if the url is not like www10.org
 
     url, *args = url.split(/[&\?]/) # trivia: ?a=1?c=2 is a valid uri
     url ||= "" # if original url was just '#', ''.split made url nil

--- a/spec/extras/normalize_url_spec.rb
+++ b/spec/extras/normalize_url_spec.rb
@@ -21,6 +21,8 @@ describe "normalizing urls" do
     "https://e.com?b=2&a=1" => "e.com?a=1&b=2", # sort query args
     "https://e.com?a=1?b=2" => "e.com?a=1&b=2", # normalize ? to &
     "https://e.com?c=3&a=1?b=2&" => "e.com?a=1&b=2&c=3", # combined; trailing &
+    "https://www10.org" => "www10.org", # keep www10. since org alone doesn't fully describe the domain
+    "https://www10.example.org" => "example.org", # remove www10.
 
     "https://www.arxiv.org" => "arxiv.org",
     "https://arxiv.org/abs/1234.12345" => "arxiv.org/abs/1234.12345",

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -97,7 +97,9 @@ describe Story do
       "http://example.com:8000" => "example.com",
       "http://example.com:8000/" => "example.com",
       "http://www3.example.com/goose" => "example.com",
-      "http://flub.example.com" => "flub.example.com"
+      "http://flub.example.com" => "flub.example.com",
+      "http://www10.org" => "www10.org",
+      "http://www10.example.org" => "example.org"
     }.each_pair do |url, domain|
       story.url = url
       expect(story.domain.domain).to eq(domain)


### PR DESCRIPTION
Fix #1339 

The url normalizing methods ( Utils.Normalize and Story.set_domain_and_origin ) have been updated in order to be more flexible with domains names as www10.org .

Current behavior : 
www10.org is displayed as org in a story

New behavior :
www10.org is displayed and classic urls are still displayed correctly for instance www.google.com is displayed google.com