### PR TITLE
Issue #1353 Fix unread counts for message destroy

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,7 +87,7 @@ GEM
     bcrypt (3.1.20)
     benchmark-perf (0.6.0)
     bigdecimal (3.1.8)
-    brakeman (6.2.1)
+    brakeman (6.2.2)
       racc
     builder (3.3.0)
     byebug (11.1.3)

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -43,6 +43,7 @@ class Message < ApplicationRecord
 
   before_validation :assign_short_id, on: :create
   after_create :deliver_email_notifications
+  after_destroy :update_unread_counts
   after_save :update_unread_counts
   after_save :check_for_both_deleted
 

--- a/spec/factories/message.rb
+++ b/spec/factories/message.rb
@@ -6,5 +6,7 @@ FactoryBot.define do
     association(:author, factory: :user)
     sequence(:subject) { |n| "message subject #{n}" }
     sequence(:body) { |n| "message body #{n}" }
+
+    has_been_read { false }
   end
 end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -29,4 +29,17 @@ describe Message do
       expect(message.errors[:hat]).to be_empty
     end
   end
+
+  describe "update_unread_counts" do
+    let(:user) { create(:user) }
+    let(:message) { create(:message, recipient: user) }
+
+    it "updates the unread message count" do
+      message.update_unread_counts
+      expect(user.reload.unread_message_count).to eq(1)
+
+      message.destroy
+      expect(user.reload.unread_message_count).to eq(0)
+    end
+  end
 end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -38,7 +38,7 @@ describe Message do
       message.update_unread_counts
       expect(user.reload.unread_message_count).to eq(1)
 
-      message.destroy
+      message.destroy!
       expect(user.reload.unread_message_count).to eq(0)
     end
   end


### PR DESCRIPTION
<!--
Issues and PRs are typically reviewed Wednesday and most weekend mornings.
-->
Fix #1353 

I was able to reproduce the issue but just for `messages` and the only way i was able to reproduce it was deleting the record through the console/database.

My hunch is there was a directly delete of the record for some reason, or for another strange reason the `after_save :update_unread_counts` hook was not triggered.

- added `before_destroy` to make sure recipient gets `unread_messages_count` updated

![Screenshot 2024-10-17 at 11 08 27 p m](https://github.com/user-attachments/assets/84257ea9-40b3-49e4-908a-c8b4c653ea1d)
![Screenshot 2024-10-17 at 11 08 39 p m](https://github.com/user-attachments/assets/7f53e8dc-fe2f-4d8a-a26e-d978620275cd)
