### PR TITLE
Fix reloading for extras folder

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -42,7 +42,6 @@ module Lobsters
     config.eager_load_namespaces << I18n
 
     config.autoload_paths.push(
-      "#{root}/app/types",
       "#{root}/extras",
       "#{root}/lib"
     )

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,7 +43,8 @@ module Lobsters
 
     config.autoload_paths.push(
       "#{root}/app/types",
-      "#{root}/extras"
+      "#{root}/extras",
+      "#{root}/lib"
     )
 
     # Raise an exception when using mass assignment with unpermitted attributes

--- a/config/initializers/00_zeitwerk.rb
+++ b/config/initializers/00_zeitwerk.rb
@@ -9,7 +9,7 @@ Rails.autoloaders.main.ignore(Rails.root.join("extras/prohibit*rb"))
 Rails.autoloaders.main.ignore(Rails.root.join("lib/monkey.rb"))
 require Rails.root.join("lib/monkey.rb").to_s
 
-%w[extras lib].each do |dir|
+%w[lib].each do |dir|
   Rails.autoloaders.main.push_dir(Rails.root.join(dir))
   Dir[Rails.root.join(dir, "*.rb").to_s].sort.each { |l| require l }
 end

--- a/config/initializers/00_zeitwerk.rb
+++ b/config/initializers/00_zeitwerk.rb
@@ -8,8 +8,3 @@
 Rails.autoloaders.main.ignore(Rails.root.join("extras/prohibit*rb"))
 Rails.autoloaders.main.ignore(Rails.root.join("lib/monkey.rb"))
 require Rails.root.join("lib/monkey.rb").to_s
-
-%w[lib].each do |dir|
-  Rails.autoloaders.main.push_dir(Rails.root.join(dir))
-  Dir[Rails.root.join(dir, "*.rb").to_s].sort.each { |l| require l }
-end


### PR DESCRIPTION
Hi :) 
Fixes https://github.com/lobsters/lobsters/issues/1246

According to documentation, adding `extras` folder to `autoload_path` [here](https://github.com/lobsters/lobsters/issues/1246) is the right way to make every file in it autoloaded.
However it looks like we also manually `require` all files in this folder [here](https://github.com/lobsters/lobsters/blob/master/config/initializers/00_zeitwerk.rb#L14) which probably (I don't actually know) messes up with RoR reload mechanisms. 

Hope this small fix can make hacking on lobsters a more pleasurable experience. 

Let me know what do you think. 

P.S.
Should we add that `lib` folder to `autoload_path` in the `config/application.rb` similarly to how `extras` folder is added? I guess the whole `each` block can be removed then. Apparently there is/was(?) something wrong with how files are autoloaded on prod based on [this](https://github.com/lobsters/lobsters/blob/master/config/initializers/00_zeitwerk.rb#L6-L7) comment. Do you remember any details on it by any chance?

<!--
Issues and PRs are typically reviewed Wednesday and most weekend mornings.
-->
