### PR TITLE
Replace `.execute` with `.select_all`

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -18,7 +18,7 @@ class StatsController < ApplicationController
       graph_title: "Active users by month",
       scale_y_divisions: 500
     }) {
-      User.connection.execute <<~SQL
+      User.connection.select_all <<~SQL
         SELECT ym, count(distinct user_id)
         FROM (
           SELECT date_format(created_at, '%Y-%m') as ym, user_id FROM stories

--- a/app/helpers/traffic_helper.rb
+++ b/app/helpers/traffic_helper.rb
@@ -11,7 +11,7 @@ module TrafficHelper
   def self.traffic_range
     div = PERIOD_LENGTH * 60
     start_at = 90.days.ago
-    result = ActiveRecord::Base.connection.execute <<-SQL
+    result = ActiveRecord::Base.connection.select_all <<-SQL
       select
         min(activity) as low,
         max(activity) as high
@@ -40,7 +40,7 @@ module TrafficHelper
 
   def self.current_activity
     start_at = PERIOD_LENGTH.minutes.ago.utc
-    result = ActiveRecord::Base.connection.execute <<-SQL
+    result = ActiveRecord::Base.connection.select_all <<-SQL
       select
         (SELECT count(1) AS n_votes   FROM votes    WHERE updated_at >= '#{start_at}') +
         (SELECT count(1) AS n_comment FROM comments WHERE created_at >= '#{start_at}') * 10 +


### PR DESCRIPTION
<!--
Issues and PRs are typically reviewed Wednesday and most weekend mornings.
-->
Fixes #1367 

Refactored instances of `.execute` in read-only queries to use `.select_all` instead. There are two more instances of `.exeucte` that are used for UPDATE queries in `app/models/comment.rb` and `app/models/story.rb`, but these were not refactored because `.select_all` is meant only for read-only queries.
