### PR TITLE
Remove blank href from comment disown flow

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -594,12 +594,17 @@ onPageLoad(() => {
     }
   });
 
-  on('submit', 'form.story-disowner-form', (event) => {
+  // Disown
+
+  on('submit', 'form.disowner-form', (event) => {
     event.preventDefault();
 
-    if (confirm("Are you sure you want to disown this story?")) {
-      let li = parentSelector(event.target, '.story');
-      fetchWithCSRF(event.target.action, { method: 'post' })
+    let type = event.target.elements['type'].value;
+
+    if (confirm(`Are you sure you want to disown this ${type}?`)) {
+      let li = parentSelector(event.target, `.${type}`);
+
+      fetchWithCSRF(event.target.action, { method: 'post', body: new FormData(event.target) })
         .then(response => {
           response.text().then(text => replace(li, text));
         });
@@ -636,16 +641,6 @@ onPageLoad(() => {
         folder.checked = true;
     }
   })();
-
-  on('click', 'a.comment-disowner', (event) => {
-    if (confirm("Are you sure you want to disown this comment?")) {
-      let li = parentSelector(event.target, '.comment');
-      fetchWithCSRF('/comments/' + li.getAttribute('data-shortid') + '/disown', { method: 'post' })
-        .then(response => {
-          response.text().then(text => replace(li, text));
-        });
-    }
-  });
 
   on("click", "a.comment_replier", (event) => {
     event.preventDefault();

--- a/app/assets/stylesheets/application.css.erb
+++ b/app/assets/stylesheets/application.css.erb
@@ -411,7 +411,7 @@ button:focus {
 	font-style: italic;
 }
 
-form.story-disowner-form {
+form.disowner-form {
 	display: inline;
 	button {
 		background: none;
@@ -426,7 +426,6 @@ form.story-disowner-form {
 		}
 	}
 }
-
 
 button,
 input[type="button"],

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -169,10 +169,16 @@ class CommentsController < ApplicationController
     end
 
     InactiveUser.disown! comment
-    comment = find_comment
 
-    render partial: "comment", layout: false,
-      content_type: "text/html", locals: {comment: comment}
+    if request.xhr?
+      comment = find_comment
+      show_story = ActiveModel::Type::Boolean.new.cast(params[:show_story])
+      show_tree_lines = ActiveModel::Type::Boolean.new.cast(params[:show_tree_lines])
+
+      render partial: "comment", locals: {comment: comment, show_story: show_story, show_tree_lines: show_tree_lines}
+    else
+      redirect_back fallback_location: root_path
+    end
   end
 
   def update

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -105,7 +105,10 @@
           <% end %>
         <% elsif !comment.is_gone? && comment.is_disownable_by_user?(@user) %>
           |
-          <a class="comment-disowner" href="#">disown</a>
+          <%= button_to("disown", disown_comment_path(comment.short_id),
+          form_class: "disowner-form",
+          params: { type: 'comment', show_story: show_story, show_tree_lines: show_tree_lines })
+          %>
         <% end %>
 
         <% if can_flag && !comment.current_flagged? %>

--- a/app/views/comments/_threads.html.erb
+++ b/app/views/comments/_threads.html.erb
@@ -140,7 +140,10 @@
           <% end %>
         <% elsif !comment.is_gone? && comment.is_disownable_by_user?(@user) %>
           |
-          <a class="comment-disowner" href="#">disown</a>
+          <%= button_to("disown", disown_comment_path(comment.short_id),
+          form_class: "disowner-form",
+          params: { type: 'comment', show_story: show_story, show_tree_lines: show_tree_lines })
+          %>
         <% end %>
 
         <% if can_flag && !comment.current_flagged? %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -169,7 +169,7 @@ class="story <%= story.current_upvoted? ? "upvoted" : "" %>
           <% end %>
           <% if single_story && story.disownable_by_user?(@user) %>
           |
-          <%= button_to("disown", story_disown_path(story.short_id), form_class: "story-disowner-form") %>
+          <%= button_to("disown", story_disown_path(story.short_id), form_class: "disowner-form", params: { type: 'story' }) %>
           <% end %>
           <% if single_story && story.hider_count > 0 %>
             (hidden by <%= pluralize(story.hider_count, "user") %>)

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -291,7 +291,7 @@ class="story <%= story.current_upvoted? ? "upvoted" : "" %>
           <% end %>
           <% if single_story && story.disownable_by_user?(@user) %>
           |
-          <%= button_to("disown", story_disown_path(story.short_id), form_class: "story-disowner-form") %>
+          <%= button_to("disown", story_disown_path(story.short_id), form_class: "disowner-form", params: { type: 'story' }) %>
           <% end %>
           <% if single_story && story.hider_count > 0 %>
             (hidden by <%= pluralize(story.hider_count, "user") %>)

--- a/app/views/stories/_listdetail.html.erb
+++ b/app/views/stories/_listdetail.html.erb
@@ -155,7 +155,7 @@ class="story <%= story.current_upvoted? ? "upvoted" : "" %>
           <% end %>
           <% if single_story && story.disownable_by_user?(@user) %>
           |
-          <%= button_to("disown", story_disown_path(story.short_id), form_class: "story-disowner-form") %>
+          <%= button_to("disown", story_disown_path(story.short_id), form_class: "disowner-form", params: { type: 'story' }) %>
           <% end %>
           <% if single_story && story.hider_count > 0 %>
             (hidden by <%= pluralize(story.hider_count, "user") %>)

--- a/spec/features/comment_spec.rb
+++ b/spec/features/comment_spec.rb
@@ -80,7 +80,7 @@ RSpec.feature "Commenting" do
 
       comment = create(:comment, user_id: user.id, story_id: story.id, created_at: 90.days.ago)
       visit "/s/#{story.short_id}"
-      expect(page).to have_link("disown")
+      expect(page).to have_button("disown")
 
       page.driver.post "/comments/#{comment.short_id}/disown"
       comment.reload

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -62,4 +62,27 @@ describe "comments", type: :request do
       expect(response.body).to include(comment.user.username)
     end
   end
+
+  describe "disowning" do
+    let(:inactive_user) { create(:user, :inactive) }
+
+    before do
+      sign_in author
+      comment.update!(created_at: (Comment::DELETEABLE_DAYS + 1).days.ago)
+    end
+
+    it "returns 302 for non-xhr request" do
+      expect {
+        post "/comments/#{comment.short_id}/disown"
+        expect(response.status).to eq(302)
+      }.to change { comment.reload.user }.from(comment.user).to(inactive_user)
+    end
+
+    it "returns 200 for xhr request" do
+      expect {
+        post "/comments/#{comment.short_id}/disown", xhr: true
+        expect(response.status).to eq(200)
+      }.to change { comment.reload.user }.from(comment.user).to(inactive_user)
+    end
+  end
 end


### PR DESCRIPTION
<!--
Issues and PRs are typically reviewed Wednesday and most weekend mornings.
-->

As part of issue 

- refactor js to be reusable by `comment` or `story` disown
- added no js functionality for `comment` disown
- fixed missing `show_story` boolean when render partial after xhr disown in `search` view
- fixed missing `show_tree_lines` boolean when render partial after xhr disown in `threads` view

### Visual bug for disown comment in different views
#### search
`on: story` label disappear after disown
![Screenshot 2024-11-13 at 5 40 17 p m](https://github.com/user-attachments/assets/86b505e0-a108-4044-9ae1-499f9a429e23)
![Screenshot 2024-11-13 at 5 40 33 p m](https://github.com/user-attachments/assets/a88842fe-7ee0-4223-b001-a3d680f9878f)

#### threads
`upvote` & `comment_folder` order change after disown
![Screenshot 2024-11-13 at 5 38 25 p m](https://github.com/user-attachments/assets/dbae5c0f-02c6-4604-9267-44f07178ebbf)
![Screenshot 2024-11-13 at 5 39 39 p m](https://github.com/user-attachments/assets/46dc327f-1c2a-46ed-b213-3f745ff2cdb2)

### After
search view
![Screenshot 2024-11-13 at 5 45 14 p m](https://github.com/user-attachments/assets/c6af2973-5bc6-4b6e-9126-1085d445b23f)
thread view
![Screenshot 2024-11-13 at 5 44 49 p m](https://github.com/user-attachments/assets/84b855ef-060e-4126-b0f0-3eb2669363ff)

