### PR TITLE
Update URL when fetching title

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -185,7 +185,8 @@ class _LobstersFunction {
   }
 
   fetchURLTitle(button) {
-    const targetUrl = qS('#story_url').value;
+    const url_field = qS('#story_url');
+    const targetUrl = url_field.value;
     const title_field = qS('#story_title');
     const formData = new FormData();
     const old_text = button.textContent;
@@ -204,6 +205,7 @@ class _LobstersFunction {
       .then (response => response.json())
       .then (data => {
         title_field.value = data.title
+        url_field.value = data.url
         button.textContent = old_text
       });
     button.removeAttribute("disabled");


### PR DESCRIPTION
When the user clicks 'Fetch Title', in addition to filling in the title field, also automatically set the value of the URL field. This is primarily because servers often redirect to a canonicalized or secure (HTTPS) version of a URL if someone requests an alternate or insecure (HTTP) version.

With this change, we use the URL that the server prefers for the document.

<!--
Issues and PRs are typically reviewed Wednesday and most weekend mornings.
-->
