### PR TITLE
Add relevance weighting to relevance searches #1378

### DIFF
--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -213,7 +213,7 @@ class Search
       # relevance is undefined without search terms so sort by score
       if terms.any?
         terms_sql = <<~SQL.tr("\n", " ")
-        MATCH(comment) AGAINST ('#{terms.map { |s| "+#{s}" }.join(" ")}' IN BOOLEAN MODE) 
+          MATCH(comment) AGAINST ('#{terms.map { |s| "+#{s}" }.join(" ")}' IN BOOLEAN MODE) 
         SQL
         query.order!(Arel.sql(terms_sql + " DESC"))
       else
@@ -325,9 +325,9 @@ class Search
       if terms.any?
         # Assigns different weights: title (10), description (3), body (1) for scoring relevance.
         terms_sql = <<~SQL.tr("\n", " ")
-        MATCH(story_texts.title) AGAINST ('#{terms.map { |s| "+#{s}" }.join(" ")}' IN BOOLEAN MODE) * 10 +
-        MATCH(story_texts.description) AGAINST ('#{terms.map { |s| "+#{s}" }.join(" ")}' IN BOOLEAN MODE) * 3 +
-        MATCH(story_texts.body) AGAINST ('#{terms.map { |s| "+#{s}" }.join(" ")}' IN BOOLEAN MODE) * 1
+          MATCH(story_texts.title) AGAINST ('#{terms.map { |s| "+#{s}" }.join(" ")}' IN BOOLEAN MODE) * 10 +
+          MATCH(story_texts.description) AGAINST ('#{terms.map { |s| "+#{s}" }.join(" ")}' IN BOOLEAN MODE) * 3 +
+          MATCH(story_texts.body) AGAINST ('#{terms.map { |s| "+#{s}" }.join(" ")}' IN BOOLEAN MODE) * 1
         SQL
         query.order!(Arel.sql(terms_sql + " desc"))
       else

--- a/db/migrate/20241129101315_add_fulltext_indexes_to_story_texts.rb
+++ b/db/migrate/20241129101315_add_fulltext_indexes_to_story_texts.rb
@@ -1,0 +1,13 @@
+class AddFulltextIndexesToStoryTexts < ActiveRecord::Migration[8.0]
+  def up
+    execute "ALTER TABLE story_texts ADD FULLTEXT(title)"
+    execute "ALTER TABLE story_texts ADD FULLTEXT(description)"
+    execute "ALTER TABLE story_texts ADD FULLTEXT(body)"
+  end
+
+  def down
+    execute "ALTER TABLE story_texts DROP INDEX title"
+    execute "ALTER TABLE story_texts DROP INDEX description"
+    execute "ALTER TABLE story_texts DROP INDEX body"
+  end
+end


### PR DESCRIPTION
This pull request enhances the relevance-based sorting functionality in the perform_story_search and perform_comment_search methods by leveraging FULLTEXT search capabilities.

Key Changes:
Relevance Sorting for Stories:
Added weighted FULLTEXT search across title, description, and body columns in story_texts.
Assigned weights to prioritize results:
title: weight 10
description: weight 3
body: weight 1

Relevance Sorting for Comments:
Implemented FULLTEXT search on the comment column to rank results based on relevance.

Database Migration:
Added FULLTEXT indexes for columns used in the relevance sorting:
title, description, and body in story_texts

Testing: 
Before
![Capture d'écran 2024-11-29 110817](https://github.com/user-attachments/assets/7bdbec22-df96-4707-8c3e-32436f149dfe)

After
![Capture d'écran 2024-11-29 110916](https://github.com/user-attachments/assets/0c05bbf9-f747-401a-b5d2-eb2ec0057c7d)

