### PR TITLE
#fix issue 1298 : hiding merged stories removes the "on + link to story" in the comment title.

### DIFF
--- a/app/views/comments/_threads.html.erb
+++ b/app/views/comments/_threads.html.erb
@@ -25,7 +25,7 @@
       force_open = true
       show_tree_lines = true
       # show "on: <title>" for comments from merged stories + on non-story pages
-      show_story ||= story.try(:id) != comment.story_id
+      show_story ||= (story.try(:id) != comment.story_id) && !story.is_hidden_by_user?(@user)
       # show merge icon only on story page when merged
       was_merged = story && (story.id != comment.story_id)
       is_unread = ribbon&.is_unread?(comment)


### PR DESCRIPTION
Im not sure of my understanding of this issue, yet i tried something. So what it does is that when merged stories are hidden, there are no more comments with the "on + link to story" in the title. However, it doesnt apply immediately after hitting hide, you have to refresh the page manually after that so im not sure its the fix you are looking for.