### PR TITLE
Add cop to standardrb to enforce Mod::ModeratorController #1393

### DIFF
--- a/.custom_cops.yml
+++ b/.custom_cops.yml
@@ -1,0 +1,11 @@
+require:
+  - ./lib/custom_cops/inherits_moderator_controller.rb
+  # to use additional cops, list individual ruby files here
+  #   (listing directories or glob patterns doesn't seem to work)
+  # ex:
+  # - ./lib/custom_cops/<cop-filename>.rb
+
+CustomCops/InheritsModeratorController:
+  Enabled: true
+  Include:
+    - "app/controllers/mod/**/*.rb"

--- a/.standard.yml
+++ b/.standard.yml
@@ -20,3 +20,6 @@ plugins:
 #  - use_form_with:
 #      require_path: extras/prohibit_form_for_and_form_tag
 #      plugin_class_name: RuboCop::Cop::Style::DisallowFormForandFormTag
+
+extend_config:
+  - .custom_cops.yml

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,7 +28,7 @@ module Lobsters
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.
-    config.autoload_lib(ignore: %w[assets tasks])
+    config.autoload_lib(ignore: %w[assets custom_cops tasks])
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/lib/custom_cops/inherits_moderator_controller.rb
+++ b/lib/custom_cops/inherits_moderator_controller.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "active_support/core_ext/string" # String.underscore
+
+module CustomCops
+  class InheritsModeratorController < RuboCop::Cop::Base
+    MOD_DIRECTORY = "app/controllers/mod/"
+    MOD_CONTROLLER = "Mod::ModeratorController"
+    MSG = "All controllers in the Mod namespace should inherit from #{MOD_CONTROLLER}"
+
+    def on_class(node)
+      rel_path = RuboCop::PathUtil.relative_path(filename(node))
+
+      # make sure we're in the right subdirectory
+      return unless rel_path.start_with?(MOD_DIRECTORY)
+
+      class_name = node.identifier.const_name
+      # We only care about the class if it matches the expected name for the current filename.
+      # If the class name and filepath don't match, Zeitwerk should complain.
+      return unless rel_path.end_with?(class_name.underscore + ".rb")
+
+      parent_module_name = node.parent_module_name
+
+      full_class_name = case parent_module_name
+      when "Object", ""
+        class_name
+      else
+        "#{parent_module_name}::#{class_name}"
+      end
+
+      return if full_class_name == MOD_CONTROLLER
+
+      parent_class = node.parent_class&.const_name || ""
+
+      if parent_class == MOD_CONTROLLER ||
+          (parent_module_name.split("::").include?("Mod") && "Mod::#{parent_class}" == MOD_CONTROLLER)
+        return
+      end
+
+      add_offense(node)
+    end
+
+    def filename(node)
+      node.location.expression.source_buffer.name
+    end
+  end
+end


### PR DESCRIPTION
All controllers in the `app/controllers/mod/` directory should inherit from `Mod::ModeratorController`
resolves #1393

Note:
The cops are located in the `.lib/custom_cops/` directory, which I've added to the ignore list of `config.autolod_libs`. If my understanding of [config.autoload_libs(ignore:)](https://guides.rubyonrails.org/autoloading_and_reloading_constants.html#config-autoload-lib-ignore) is correct, this should prevent this directory from being loaded when the application runs (in any environment).

If your editor is configured with standardrb integration, the code in `.lib/custom_cops/` will load and will run for ruby files in the `app/controllers/mod/` directory.