### PR TITLE
Enable YJIT in the test suite

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -23,6 +23,7 @@ jobs:
     env:
       DATABASE_URL: trilogy://root:root@127.0.0.1/lobsters_dev
       RAILS_ENV: test
+      RUBY_YJIT_ENABLE: "1"
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## What?

- [x] Enable YJIT in the test suite via Envariable

## Why?

We might see a speedup in tests if hot code is JIT'd. Costs us very little to figure that out by opening a PR and letting the specs run.