### PR TITLE
fix /stats styles to support dark mode

### DIFF
--- a/app/views/stats/index.html.erb
+++ b/app/views/stats/index.html.erb
@@ -30,12 +30,17 @@ Want more info?
 </p>
 
 <style type="text/css">
-.graphBackground { fill: #ffffff; }
-.axis { stroke: #cccccc; }
+.axis { stroke: var(--color-fg-contrast-4-5); }
+.svgBackground { fill: var(--color-bg); }
+.graphBackground { fill: var(--color-bg); }
+.xAxisLabels { fill: var(--color-fg); }
+.yAxisLabels { fill: var(--color-fg); }
 .key1, .dataPoint1 { fill: #ac130d; }
 circle:last-of-type { fill: #cccccc; }
 .line1 { fill: #ac130d; }
-.guideLines { stroke: #ffffff; stroke-dasharray: none; }
+.guideLines { stroke: var(--color-bg); stroke-dasharray: none; }
+.dataPointPopupMask { fill: var(--color-fg); stroke: var(--color-bg); }
+.dataPointPopup { fill: var(--color-fg); }
 </style>
 
 </div>


### PR DESCRIPTION
fixes #1420 by replacing hardcoded values with `var()` and adding a few more overrides like axis label colours

**Light mode** (no change)
<img width="867" alt="Screenshot 2025-01-09 at 21 06 20" src="https://github.com/user-attachments/assets/34086020-a8fa-4124-becc-b3709766e1f6" />

**Dark mode** (actually dark)
<img width="860" alt="Screenshot 2025-01-09 at 21 06 01" src="https://github.com/user-attachments/assets/c0a69b00-f934-4069-bc66-71d567372e67" />
