### PR TITLE
Fix 500 in moderations pagination

### DIFF
--- a/app/controllers/moderations_controller.rb
+++ b/app/controllers/moderations_controller.rb
@@ -9,15 +9,15 @@ class ModerationsController < ApplicationController
     @title = "Moderation Log"
     @moderators = ["(All)", "(Users)"] + User.moderators.map(&:username)
 
-    @moderator = params.fetch("moderator", "(All)")
+    @moderator = moderation_params.fetch("moderator", "(All)")
     @what = {
-      stories: params.dig(:what, :stories),
-      comments: params.dig(:what, :comments),
-      tags: params.dig(:what, :tags),
-      users: params.dig(:what, :users),
-      domains: params.dig(:what, :domains),
-      origins: params.dig(:what, :origins),
-      categories: params.dig(:what, :categories)
+      stories: moderation_params.dig(:what, :stories),
+      comments: moderation_params.dig(:what, :comments),
+      tags: moderation_params.dig(:what, :tags),
+      users: moderation_params.dig(:what, :users),
+      domains: moderation_params.dig(:what, :domains),
+      origins: moderation_params.dig(:what, :origins),
+      categories: moderation_params.dig(:what, :categories)
     }
     @what.transform_values! { true } if @what.values.none?
 
@@ -48,7 +48,7 @@ class ModerationsController < ApplicationController
 
     # paginate
     @pages = (@moderations.count / ENTRIES_PER_PAGE).ceil
-    @page = params[:page].to_i
+    @page = moderation_params[:page].to_i
     if @page == 0
       @page = 1
     elsif @page < 0 || @page > (2**32) || @page > @pages
@@ -59,5 +59,12 @@ class ModerationsController < ApplicationController
       .offset((@page - 1) * ENTRIES_PER_PAGE)
       .order("moderations.created_at desc")
       .limit(ENTRIES_PER_PAGE)
+  end
+
+  private
+
+  def moderation_params
+    @moderation_params ||= params.permit(:moderator, :page,
+      what: %i[stories comments tags users domains origins categories])
   end
 end

--- a/app/controllers/moderations_controller.rb
+++ b/app/controllers/moderations_controller.rb
@@ -43,7 +43,7 @@ class ModerationsController < ApplicationController
     # filter based on type of thing moderated
     @what.each do |type, checked|
       next if checked
-      @moderations = @moderations.where("`moderations`.`#{type.to_s.singularize}_id` is null")
+      @moderations = @moderations.where("#{type.to_s.singularize}_id": nil)
     end
 
     # paginate

--- a/app/views/moderations/index.html.erb
+++ b/app/views/moderations/index.html.erb
@@ -15,12 +15,12 @@
 
 <div class="morelink">
   <% if @page > 1 %>
-    <%= link_to "<< Page #{@page - 1}", request.query_parameters.merge({:page => @page - 1}) %>
+    <%= link_to "<< Page #{@page - 1}", @moderation_params.merge({:page => @page - 1}) %>
   <% end %>
   <% if @pages > 1 && @page < @pages %>
     <% if @page > 1 %>
       |
     <% end %>
-    <%= link_to "Page #{@page + 1} >>", request.query_parameters.merge({:page => @page + 1}) %>
+    <%= link_to "Page #{@page + 1} >>", @moderation_params.merge({:page => @page + 1}) %>
   <% end %>
 </div>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -603,29 +603,6 @@
         89
       ],
       "note": "IntervalHelper#time_interval is a security control"
-    },
-    {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
-      "fingerprint": "fdd54f924c48f192955bf4ed6deea77708243f3e2dab34af1f2f245b96033b72",
-      "check_name": "SQL",
-      "message": "Possible SQL injection",
-      "file": "app/controllers/moderations_controller.rb",
-      "line": 46,
-      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "((Moderation.all.eager_load(:moderator, :story, { :comment => ([:story, :user]) }, :tag, :user, :domain, :origin, :category) or Moderation.all.eager_load(:moderator, :story, { :comment => ([:story, :user]) }, :tag, :user, :domain, :origin, :category).where(\"is_from_suggestions = true\")) or Moderation.all.eager_load(:moderator, :story, { :comment => ([:story, :user]) }, :tag, :user, :domain, :origin, :category).joins(:moderator).where(:users => ({ :username => params.fetch(\"moderator\", \"(All)\") }))).where(\"`moderations`.`#{type.to_s.singularize}_id` is null\")",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "ModerationsController",
-        "method": "index"
-      },
-      "user_input": "type.to_s.singularize",
-      "confidence": "Weak",
-      "cwe_id": [
-        89
-      ],
-      "note": "type comes from @what.keys, which are symbols for table names"
     }
   ],
   "updated": "2024-12-03 17:25:37 -0600",

--- a/spec/requests/moderations_spec.rb
+++ b/spec/requests/moderations_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+RSpec.describe "moderations", type: :request do
+  describe "#index" do
+    let(:domain) { create :domain }
+
+    context "with fewer entries than two pages" do
+      it "shows the first page", :aggregate_failures do
+        Moderation.create!(domain: domain)
+        get "/moderations"
+
+        expect(response).to be_successful
+        expect(response.body).to include("Moderation Log")
+        expect(response.body).to include(domain.domain)
+        expect(response.body).not_to include("Page 2")
+      end
+    end
+
+    context "with more entries" do
+      it "shows the page ignoring extra params", :aggregate_failures do
+        # Ensure we end up with two pages of results
+        (ModerationsController::ENTRIES_PER_PAGE * 2).times do
+          Moderation.create!(domain: domain)
+        end
+
+        get "/moderations"
+
+        expect(response).to be_successful
+        expect(response.body).to include("Moderation Log")
+        expect(response.body).to include(domain.domain)
+        expect(response.body).to include("Page 2")
+      end
+    end
+
+    # https://github.com/lobsters/lobsters/issues/1425 - vulnerability scanner
+    context "with extra params specified" do
+      it "shows the page ignoring extra params", :aggregate_failures do
+        # Ensure we end up with two pages of results
+        (ModerationsController::ENTRIES_PER_PAGE * 2).times do
+          Moderation.create!(domain: domain)
+        end
+
+        get "/moderations", params: {action: "u99p5"}
+
+        expect(response).to be_successful
+        expect(response.body).to include("Moderation Log")
+        expect(response.body).to include(domain.domain)
+        expect(response.body).to include("Page 2")
+      end
+    end
+  end
+end

--- a/spec/requests/moderations_spec.rb
+++ b/spec/requests/moderations_spec.rb
@@ -32,6 +32,22 @@ RSpec.describe "moderations", type: :request do
       end
     end
 
+    context "when filtering entries by type" do
+      let(:story) { create :story, title: "How to 10x your pipeline with this one weird trick" }
+
+      it "shows entries matching the filters" do
+        Moderation.create!(domain: domain)
+        Moderation.create!(story: story)
+
+        get "/moderations", params: {what: {domains: "1"}}
+
+        expect(response).to be_successful
+        expect(response.body).to include("Moderation Log")
+        expect(response.body).to include(domain.domain)
+        expect(response.body).not_to include(story.title)
+      end
+    end
+
     # https://github.com/lobsters/lobsters/issues/1425 - vulnerability scanner
     context "with extra params specified" do
       it "shows the page ignoring extra params", :aggregate_failures do


### PR DESCRIPTION
## What?

- [x] Add spec to reproduce (`params[:action]` being passed in)
- [x] Lean on `ActionController::Parameters` in the controller to whitelist what we accept/forward in links
- [x] Rewrite a `where()` to stop Brakeman whinging about it

## Why?

Fixes #1425 

The params in the moderations index are used to generate the pagination links so we keep the same filters on the next/previous page. Currently on master we're forwarding *all* `params` whether they're used by the page or not. This breaks if `:action` (or `:controller`) are injected as parameters, due to Rails internals. As a rule of thumb we shouldn't be generating links containing injected content from users/previous URLs, but generating a link only with the whitelisted params we expect to be in the URL.

Brakeman was upset with our construction of SQL conditional from a string, even though we controlled the input from hash keys. Rewrite it slightly to generate the same SQL (minus some superfluous brackets) but using the power of the DSL to escape anything untoward if it somehow made it in there. Removes a brakeman ignore.

(This doesn't currently appear to be a security issue, but it would've been a useful place for injecting things into links on the page if required to pair with another attack later.)