### PR TITLE
moves "with recursive CTE" to activerecord

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -28,6 +28,8 @@ class CommentsController < ApplicationController
       # includes parent story_id to ensure this comment's story_id matches
       comment.parent_comment =
         Comment.find_by(story_id: story.id, short_id: params[:parent_comment_short_id])
+      comment.depth = comment.parent_comment.depth + 1
+
       if !comment.parent_comment
         return render json: {error: "invalid parent comment", status: 400}
       end
@@ -50,6 +52,11 @@ class CommentsController < ApplicationController
     if comment.valid? && params[:preview].blank? && comment.save
       comment.current_vote = {vote: 1}
       render_created_comment(comment)
+
+      if comment.parent_comment
+        old_reply_count = comment.parent_comment.reply_count
+        comment.parent_comment.update_column(reply_count: old_reply_count + 1)
+      end
     else
       comment.score = 1
       comment.current_vote = {vote: 1}

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -52,11 +52,6 @@ class CommentsController < ApplicationController
     if comment.valid? && params[:preview].blank? && comment.save
       comment.current_vote = {vote: 1}
       render_created_comment(comment)
-
-      if comment.parent_comment
-        old_reply_count = comment.parent_comment.reply_count
-        comment.parent_comment.update_column(reply_count: old_reply_count + 1)
-      end
     else
       comment.score = 1
       comment.current_vote = {vote: 1}

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -131,7 +131,7 @@ class CommentsController < ApplicationController
     if request.xhr?
       render partial: "commentbox", locals: {comment: comment, story: story}
     else
-      parents = comment.parents.with_thread_attributes.for_presentation
+      parents = comment.parents.for_presentation
 
       parent_ids = parents.map(&:id)
       @votes = Vote.comment_votes_by_user_for_comment_ids_hash(@user&.id, parent_ids)

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -10,6 +10,7 @@ class Comment < ApplicationRecord
   belongs_to :parent_comment,
     class_name: "Comment",
     inverse_of: false,
+    counter_cache: :reply_count,
     optional: true
   has_one :moderation,
     class_name: "Moderation",

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -61,10 +61,6 @@ class Comment < ApplicationRecord
       .by(user).arel.exists
     ) : where("true")
   }
-  # workaround: if this select is in #parents, calling .count produces invalid SQL
-  scope :with_thread_attributes, -> {
-    select("comments.*, comments_recursive.depth as depth, comments_recursive.reply_count")
-  }
 
   FLAGGABLE_DAYS = 7
   DELETEABLE_DAYS = FLAGGABLE_DAYS * 2

--- a/db/migrate/20250123073107_add_reply_count_and_depth_to_comments.rb
+++ b/db/migrate/20250123073107_add_reply_count_and_depth_to_comments.rb
@@ -1,0 +1,11 @@
+class AddReplyCountAndDepthToComments < ActiveRecord::Migration[8.0]
+  def change
+    add_column :comments, :reply_count, :integer, default: 0
+    add_column :comments, :depth, :integer, default: 0
+  end
+
+  def down
+    remove_column :comments, :depth
+    remove_column :comments, :reply_count
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_11_06_160424) do
+ActiveRecord::Schema[8.0].define(version: 2025_01_24_063340) do
   create_table "action_mailbox_inbound_emails", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "status", default: 0, null: false
     t.string "message_id", null: false
@@ -79,6 +79,8 @@ ActiveRecord::Schema[8.0].define(version: 2024_11_06_160424) do
     t.boolean "is_moderated", default: false, null: false
     t.boolean "is_from_email", default: false, null: false
     t.bigint "hat_id", unsigned: true
+    t.integer "reply_count", default: 0
+    t.integer "depth", default: 0
     t.index ["comment"], name: "index_comments_on_comment", type: :fulltext
     t.index ["confidence"], name: "confidence_idx"
     t.index ["hat_id"], name: "comments_hat_id_fk"


### PR DESCRIPTION
## Overview 
As we prepare to [migrate to postgresql](https://github.com/lobsters/lobsters/issues/539), we will be moving raw sql to active record queries slowly and carefully. This PR moves recursive CTEs to newly introduced `with_recursive` function. 
- [X] Get the right syntax for recursive query
- [X] pushes the `reply_count` and `depth` [into the database](https://github.com/lobsters/lobsters/issues/1438) 
- [ ] Get feature/column parity for recursive CTEs


## Testing 
TBD