### PR TITLE
Add instrumentation of the GVL

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ gem "memory_profiler"
 gem "rack-mini-profiler"
 gem "stackprof"
 gem "prosopite"
+gem "gvl_timing"
 
 gem "builder" # for rss
 gem "oauth" # for linking accounts

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,6 +141,7 @@ GEM
     flamegraph (0.9.5)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    gvl_timing (0.2.0)
     hashdiff (1.1.2)
     hashery (2.1.2)
     hashie (5.0.0)
@@ -429,6 +430,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   flamegraph
+  gvl_timing
   htmlentities
   json
   letter_opener

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -102,6 +102,9 @@ Rails.application.configure do
   # why help timing attacks?
   config.middleware.delete(Rack::Runtime)
 
+  require File.expand_path("../../extras/gvl_instrumentation", __FILE__)
+  config.middleware.insert 0, GvlInstrumentation, File.open(Rails.root.join("/srv/lobste.rs/log/production-gvl.log"), "a+")
+
   # Enable DNS rebinding protection and other `Host` header attacks.
   # config.hosts = [
   #   "example.com",     # Allow requests from example.com

--- a/extras/gvl_instrumentation.rb
+++ b/extras/gvl_instrumentation.rb
@@ -1,0 +1,37 @@
+require "gvl_timing"
+
+class GvlInstrumentation
+  def initialize(app, log_file)
+    @app = app
+    @log_file = log_file
+    @log_file.sync = true
+  end
+
+  def call(env)
+    response = nil
+
+    before_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    before_gc_time = GC.total_time
+    timer = GVLTiming.measure do
+      response = @app.call(env)
+    end
+    total_time = Process.clock_gettime(Process::CLOCK_MONOTONIC) - before_time
+    gc_time = GC.total_time - before_gc_time
+
+    data = {
+      gc_ms: (gc_time / 1_000_000.0).round(2),
+      run_ms: (timer.cpu_duration * 1_000.0).round(2),
+      idle_ms: (timer.idle_duration * 1_000.0).round(2),
+      stall_ms: (timer.stalled_duration * 1_000.0).round(2),
+      io_percent: (timer.idle_duration / total_time * 100.0).round(1),
+      method: env["REQUEST_METHOD"]
+    }
+    if (controller = env["action_controller.instance"])
+      data[:action] = "#{controller.controller_path}##{controller.action_name}"
+    end
+
+    @log_file.puts(JSON.generate(data))
+
+    response
+  end
+end


### PR DESCRIPTION
In response to https://byroot.github.io/ruby/performance/2025/01/23/the-mythical-io-bound-rails-app.html @pushcx kindly offered to instrument the actual IO ration on lobster production environment.

This PR does exactly that using the `gvl_timing` gem, inside a custom middleware mounted about as high as possible in the stack.

On my local environment it produces the following logs:

```
[GVL] io_percent=9.1, run_ms=30.57, idle_ms=2.95, stall_ms=0.03, gc_ms=0.0, path=/active
```

Perhaps you'd prefer if these were integrated in the main logs? I'm not familiar with your current log infra, but if you point me to it, I can probably hook them off.
