### PR TITLE
Color schemes with increased contrast

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -20,9 +20,9 @@
 
 	--base-shadow: 0 0 0;
 	--color-shadow: rgb(var(--base-shadow));
-	--color-shadow-80: rgb(var(--base-shadow) / 80%);
-	--color-shadow-25: rgb(var(--base-shadow) / 25%);
-	--color-shadow-10: rgb(var(--base-shadow) / 10%);
+	--color-shadow-80: rgb(var(--base-shadow) / var(--opacity-shadow-80));
+	--color-shadow-25: rgb(var(--base-shadow) / var(--opacity-shadow-25));
+	--color-shadow-10: rgb(var(--base-shadow) / var(--opacity-shadow-10));
 }
 
 /* generics */
@@ -769,7 +769,7 @@ li.story.saved a.saver {
 }
 
 li.story.deleted {
-	opacity: 0.6;
+	opacity: var(--opacity-deleted);
 }
 li.story.deleted a {
 	color: var(--color-fg-contrast-5) !important;

--- a/app/assets/stylesheets/dark-contrast.css
+++ b/app/assets/stylesheets/dark-contrast.css
@@ -1,0 +1,79 @@
+/* dark color scheme (contrast) */
+
+:root {
+	/* monochrome */
+	--base-bg: 0 0 0;
+	--base-fg: 255 255 255;
+
+	--opacity-fg: 100%; /* primary text */
+	--opacity-fg-contrast-13: 100%;
+	--opacity-fg-contrast-10: 99%;
+	--opacity-fg-contrast-7-5: 98%;
+	--opacity-fg-contrast-6: 97%;
+	--opacity-fg-contrast-5: 96%;
+	--opacity-fg-contrast-4-5: 95%;
+
+	--opacity-gradient-lit: 20%;
+	--opacity-gradient-shadowed: 5%;
+
+	--opacity-shadow-80: 80%;
+	--opacity-shadow-25: 70%;
+	--opacity-shadow-10: 60%;
+
+	--opacity-deleted: 0.7;
+
+	/* backgrounds and foregrounds */
+	--color-bg-accent: rgb(255 50 50);
+	--color-bg-target: rgb(80 70 20);
+
+	--color-fg-link: rgb(150 190 255);
+	--color-fg-link-visited: rgb(130 160 255);
+	--color-fg-accent: rgb(255 70 70); /* red as in lobste.rs */
+	--color-fg-negative: rgb(255 60 60); /* red as in warning */
+	--color-fg-affirmative: rgb(60 200 60);
+	--color-fg-author: rgb(100 140 220);
+	--color-fg-shape: rgb(120 120 120);
+
+	/* elements */
+	--color-box-bg: #111;
+	--color-box-bg-shaded: #222;
+	--color-box-border: #444;
+	--color-box-border-focus: #999;
+
+	--color-button-bg: #222;
+	--color-button-bg-shaded: #333;
+
+	--color-table-header-bg: #333;
+	--color-table-header-border: #555;
+	--color-table-row-bg-even: #111;
+	--color-table-row-bg-odd: #222;
+	--color-table-row-border: #333;
+
+	--color-tag-bg: #4d4000;
+	--color-tag-border: #806600;
+	--color-tag-media-bg: #1a3d66;
+	--color-tag-media-border: #264d80;
+	--color-tag-meta-bg: #333;
+	--color-tag-meta-border: #555;
+
+	--color-hat-crown-fill: #595959;
+	--color-hat-crown-stroke: #333;
+	--color-hat-brim-stroke: #444;
+
+	--color-flash-bg-error: #660000;
+	--color-flash-bg-success: #006600;
+	--color-flash-bg-notice: #003366;
+
+	--color-lobsters-fg-has-suggestions: #ff8080;
+
+	--color-lobsters-tag-special-bg: #4d0000;
+	--color-lobsters-tag-special-border: #800000;
+
+	--color-lobsters-hat-sysop-crown-fill: #8a5252;
+	--color-lobsters-hat-sysop-brim-stroke: #6f4444;
+
+	/* mobile */
+	--color-mobile-story-liner-bg: #000;
+	--color-mobile-story-comments-bubble-fill: #333;
+	--color-mobile-story-comments-bubble-fill-zero: #222;
+}

--- a/app/assets/stylesheets/dark.css
+++ b/app/assets/stylesheets/dark.css
@@ -16,6 +16,12 @@
 	--opacity-gradient-lit: 13%;
 	--opacity-gradient-shadowed: 3%;
 
+	--opacity-shadow-80: 80%;
+	--opacity-shadow-25: 25%;
+	--opacity-shadow-10: 10%;
+
+	--opacity-deleted: 0.6;
+
 	/* backgrounds and foregrounds */
 	--color-bg-accent: rgb(253 78 72);
 	--color-bg-target: rgb(61 53 11);
@@ -24,7 +30,7 @@
 	--color-fg-link-visited: rgb(79 138 255);
 	--color-fg-accent: rgb(207 54 49); /* red as in lobste.rs */
 	--color-fg-negative: rgb(190 45 45); /* red as in warning */
-	--color-fg-affirmative: rgb(42 180 42) ;
+	--color-fg-affirmative: rgb(42 180 42);
 	--color-fg-author: rgb(80 112 177);
 	--color-fg-shape: rgb(80 80 80);
 

--- a/app/assets/stylesheets/light-contrast.css
+++ b/app/assets/stylesheets/light-contrast.css
@@ -1,0 +1,79 @@
+/* light color scheme (contrast) */
+
+:root {
+	/* monochrome */
+	--base-bg: 255 255 255;
+	--base-fg: 0 0 0;
+
+	--opacity-fg: 100%; /* primary text */
+	--opacity-fg-contrast-13: 100%;
+	--opacity-fg-contrast-10: 99%;
+	--opacity-fg-contrast-7-5: 98%;
+	--opacity-fg-contrast-6: 97%;
+	--opacity-fg-contrast-5: 96%;
+	--opacity-fg-contrast-4-5: 95%;
+
+	--opacity-gradient-lit: 0%;
+	--opacity-gradient-shadowed: 20%;
+
+	--opacity-shadow-80: 80%;
+	--opacity-shadow-25: 70%;
+	--opacity-shadow-10: 60%;
+
+	--opacity-deleted: 0.7;
+
+	/* backgrounds and foregrounds */
+	--color-bg-accent: rgb(190 0 0);
+	--color-bg-target: rgb(255 255 200);
+
+	--color-fg-link: rgb(0 0 238);
+	--color-fg-link-visited: rgb(85 26 139);
+	--color-fg-accent: rgb(190 0 0); /* red as in lobste.rs */
+	--color-fg-negative: rgb(170 0 0); /* red as in warning */
+	--color-fg-affirmative: rgb(0 100 0);
+	--color-fg-author: rgb(47 84 150);
+	--color-fg-shape: rgb(128 128 128);
+
+	/* elements */
+	--color-box-bg: #fff;
+	--color-box-bg-shaded: #ddd;
+	--color-box-border: #666;
+	--color-box-border-focus: #000;
+
+	--color-button-bg: #fff;
+	--color-button-bg-shaded: #ddd;
+
+	--color-table-header-bg: #d0d0d0;
+	--color-table-header-border: #999;
+	--color-table-row-bg-even: #fff;
+	--color-table-row-bg-odd: #f0f0f0;
+	--color-table-row-border: #999;
+
+	--color-tag-bg: #fff7b3;
+	--color-tag-border: #b3a000;
+	--color-tag-media-bg: #cbe5ff;
+	--color-tag-media-border: #0066cc;
+	--color-tag-meta-bg: #e0e0e0;
+	--color-tag-meta-border: #666;
+
+	--color-hat-crown-fill: #dadada;
+	--color-hat-crown-stroke: #999;
+	--color-hat-brim-stroke: #bbb;
+
+	--color-flash-bg-error: #ffb8b8;
+	--color-flash-bg-success: #b5eab5;
+	--color-flash-bg-notice: #cbe5ff;
+
+	--color-lobsters-fg-has-suggestions: #990000;
+
+	--color-lobsters-tag-special-bg: #ffcccc;
+	--color-lobsters-tag-special-border: #cc0000;
+
+	--color-lobsters-hat-sysop-crown-fill: #eea7a7;
+	--color-lobsters-hat-sysop-brim-stroke: #cc8080;
+
+	/* mobile */
+	--color-mobile-story-liner-bg: #fff;
+	--color-mobile-story-comments-bubble-fill: #999;
+	--color-mobile-story-comments-bubble-fill-zero: #666;
+}

--- a/app/assets/stylesheets/light.css
+++ b/app/assets/stylesheets/light.css
@@ -16,6 +16,12 @@
 	--opacity-gradient-lit: 0%;
 	--opacity-gradient-shadowed: 13%;
 
+	--opacity-shadow-80: 80%;
+	--opacity-shadow-25: 25%;
+	--opacity-shadow-10: 10%;
+
+	--opacity-deleted: 0.6;
+
 	/* backgrounds and foregrounds */
 	--color-bg-accent: rgb(172 19 13);
 	--color-bg-target: rgb(255 252 215);

--- a/app/assets/stylesheets/system-contrast.css
+++ b/app/assets/stylesheets/system-contrast.css
@@ -1,0 +1,4 @@
+/* system color scheme (contrast) */
+
+@import url("light-contrast.css"); /* default */
+@import url("dark-contrast.css") (prefers-color-scheme: dark);

--- a/app/assets/stylesheets/system.css
+++ b/app/assets/stylesheets/system.css
@@ -1,2 +1,4 @@
+/* system color scheme */
+
 @import url("light.css"); /* light is default */
 @import url("dark.css") (prefers-color-scheme: dark);

--- a/app/assets/stylesheets/system.css
+++ b/app/assets/stylesheets/system.css
@@ -1,4 +1,6 @@
 /* system color scheme */
 
-@import url("light.css"); /* light is default */
-@import url("dark.css") (prefers-color-scheme: dark);
+@import url("light.css"); /* default */
+@import url("light-contrast.css") (not (prefers-color-scheme: dark)) and (prefers-contrast: more);
+@import url("dark.css") (prefers-color-scheme: dark) and (not (prefers-contrast: more));
+@import url("dark-contrast.css") (prefers-color-scheme: dark) and (prefers-contrast: more);

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -278,7 +278,7 @@ class SettingsController < ApplicationController
       :email_replies, :email_messages, :email_mentions,
       :pushover_replies, :pushover_messages, :pushover_mentions,
       :mailing_list_mode, :show_email, :show_avatars, :show_story_previews,
-      :show_submitted_story_threads, :prefers_color_scheme
+      :show_submitted_story_threads, :prefers_color_scheme, :prefers_contrast
     )
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -63,6 +63,7 @@ class User < ApplicationRecord
 
   typed_store :settings do |s|
     s.string :prefers_color_scheme, default: "system"
+    s.boolean :prefers_contrast, default: false
     s.boolean :email_notifications, default: false
     s.boolean :email_replies, default: false
     s.boolean :pushover_replies, default: false

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,7 +29,7 @@
     Rails.application.name %></title>
 
   <%= stylesheet_link_tag "application" %>
-  <%= stylesheet_link_tag @user&.prefers_color_scheme || "system" %>
+  <%= stylesheet_link_tag (@user&.prefers_color_scheme || "system") + (@user&.prefers_contrast ? "-contrast" : "") %>
   
   <%= stylesheet_link_tag "tom-select", "data-turbo-track": "reload" %>
   <%= stylesheet_link_tag "TomSelect_remove_button", "data-turbo-track": "reload" %>

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -209,6 +209,11 @@
       <label><%= f.radio_button :prefers_color_scheme, :dark %> Dark</label>
     </div>
 
+    <div class="boxline">
+      <%= f.label :prefers_contrast, "Increase Contrast:", :class => "required" %>
+      <%= f.check_box :prefers_contrast %>
+    </div>
+
     <br>
     <br>
 

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -180,6 +180,24 @@
 
     <br>
 
+    <h2>Color Settings</h2>
+
+    <div class="boxline">
+      <%= f.label :prefers_color_scheme, "Color Scheme:", :class => "required" %>
+      <label><%= f.radio_button :prefers_color_scheme, :system %> System (<a href="https://lobste.rs/s/eg1n75/dark_mode">details</a>)</label>
+      <label><%= f.radio_button :prefers_color_scheme, :light %> Light</label>
+      <label><%= f.radio_button :prefers_color_scheme, :dark %> Dark</label>
+    </div>
+
+    <div class="boxline">
+      <%= f.label :prefers_contrast, "Contrast:", :class => "required" %>
+      <label><%= f.radio_button :prefers_contrast, :false %> System</label>
+      <label><%= f.radio_button :prefers_contrast, :true %> High</label>
+    </div>
+
+    <br>
+    <br>
+
     <h2>Miscellaneous Settings</h2>
 
     <div class="boxline">
@@ -200,18 +218,6 @@
     <div class="boxline">
       <%= f.label :show_avatars, "Show User Avatars:", :class => "required" %>
       <%= f.check_box :show_avatars %>
-    </div>
-
-    <div class="boxline">
-      <%= f.label :prefers_color_scheme, "Color Scheme:", :class => "required" %>
-      <label><%= f.radio_button :prefers_color_scheme, :system %> System (<a href="https://lobste.rs/s/eg1n75/dark_mode">details</a>)</label>
-      <label><%= f.radio_button :prefers_color_scheme, :light %> Light</label>
-      <label><%= f.radio_button :prefers_color_scheme, :dark %> Dark</label>
-    </div>
-
-    <div class="boxline">
-      <%= f.label :prefers_contrast, "Increase Contrast:", :class => "required" %>
-      <%= f.check_box :prefers_contrast %>
     </div>
 
     <br>


### PR DESCRIPTION
This PR builds on #1453 and adds a user setting that enables increased contrast in the current color scheme.

This functionality was recently brought up after a bug (#1445) turned the text black on white (and vice versa in dark mode), and multiple users in [the thread about it](https://lobste.rs/s/o2hhjc/what_happened_text_colour) expressed support for the inadvertent change.

Feedback on the suggested colors and nuances is more than welcome.