### PR TITLE
fix count of pages in ModerationsController #1433

### DIFF
--- a/app/controllers/moderations_controller.rb
+++ b/app/controllers/moderations_controller.rb
@@ -47,11 +47,10 @@ class ModerationsController < ApplicationController
     end
 
     # paginate
-    @pages = (@moderations.count / ENTRIES_PER_PAGE).ceil
-    @page = moderation_params[:page].to_i
-    if @page == 0
-      @page = 1
-    elsif @page < 0 || @page > (2**32) || @page > @pages
+    @pages = helpers.page_count(@moderations.count, ENTRIES_PER_PAGE)
+    @page = moderation_params.fetch(:page) { 1 }.to_i
+
+    if @page <= 0 || @page > (2**32) || @page > @pages
       raise ActionController::RoutingError.new("page out of bounds")
     end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -97,6 +97,10 @@ module ApplicationHelper
     }
   end
 
+  def page_count(record_count, entries_per_page)
+    (record_count + entries_per_page - 1) / entries_per_page
+  end
+
   def page_numbers_for_pagination(max, cur)
     if max <= MAX_PAGES
       return (1..max).to_a

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -71,4 +71,14 @@ describe ApplicationHelper do
         .to eq([1, "...", 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25])
     end
   end
+
+  describe "#page_count" do
+    it "returns the right number of pages" do
+      expect(page_count(49, 50)).to eq(1)
+      expect(page_count(50, 50)).to eq(1)
+      expect(page_count(51, 50)).to eq(2)
+      expect(page_count(99, 50)).to eq(2)
+      expect(page_count(100, 50)).to eq(2)
+    end
+  end
 end


### PR DESCRIPTION
this should fix #1433 
I put the calculation in a helper, just so I could write an easy test for it.
There are several other controllers that use pagination (any that define a `*_PER_PAGE` constant) but none count the total number of pages, so don't seem to be affected by this bug.