### PR TITLE
Proxy Scenic to correct adapter with multiple databases

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem "mission_control-jobs"
 # rails
 gem "scenic"
 gem "scenic-mysql_adapter"
+gem "scenic_sqlite_adapter"
 gem "activerecord-typedstore"
 gem "propshaft"
 gem "importmap-rails", "~> 2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -355,6 +355,8 @@ GEM
       railties (>= 4.0.0)
     scenic-mysql_adapter (1.1.0)
       scenic (>= 1.4.0)
+    scenic_sqlite_adapter (0.1.0)
+      activerecord (>= 4.0.0)
     securerandom (0.4.1)
     silencer (2.0.0)
     simplecov (0.22.0)
@@ -484,6 +486,7 @@ DEPENDENCIES
   rspec-rails
   scenic
   scenic-mysql_adapter
+  scenic_sqlite_adapter
   silencer
   simplecov
   sitemap_generator

--- a/config/initializers/scenic.rb
+++ b/config/initializers/scenic.rb
@@ -1,5 +1,25 @@
 # typed: false
 
+scenic_multidb_adapter = Class.new do
+  def initialize
+    @mysql = Scenic::Adapters::MySQL.new
+    @sqlite = Scenic::Adapters::Sqlite.new
+  end
+
+  def method_missing(...)
+    adapter = case ActiveRecord::Base.connection
+    when ActiveRecord::ConnectionAdapters::TrilogyAdapter
+      @mysql
+    when ActiveRecord::ConnectionAdapters::SQLite3Adapter
+      @sqlite
+    else
+      raise "Unsupported adapter"
+    end
+
+    adapter.__send__(...)
+  end
+end
+
 Scenic.configure do |config|
-  config.database = Scenic::Adapters::MySQL.new
+  config.database = scenic_multidb_adapter.new
 end

--- a/db/cache_schema.rb
+++ b/db/cache_schema.rb
@@ -1,3 +1,14 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[8.0].define(version: 1) do
   create_table "solid_cache_entries", force: :cascade do |t|
@@ -11,4 +22,3 @@ ActiveRecord::Schema[8.0].define(version: 1) do
     t.index ["key_hash"], name: "index_solid_cache_entries_on_key_hash", unique: true
   end
 end
-

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_01_24_063340) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_03_223624) do
   create_table "action_mailbox_inbound_emails", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "status", default: 0, null: false
     t.string "message_id", null: false


### PR DESCRIPTION
## What?

- [x] Add proxy object to swap between MySQL and SQLite adapters for Scenic gem

## Why?

#1458 exposes the fact we can't run `bin/rails db:schema:dump` successfully on master. We can dump the primary database (MySQL), but we run into an error dumping the cache database (SQLite). This is because the Scenic MySQL adapter runs queries against the SQLite database it doesn't understand so errors out.

Attempt to patch this quickly by adding a proxy object that picks between both depending on what the current connection to a database is.

This works for `bin/rails db:schema:dump`, but I've not tested the app otherwise. It may well break in other places!