### PR TITLE
Fix migrations/schema

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_01_24_063340) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_03_223624) do
   create_table "action_mailbox_inbound_emails", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "status", default: 0, null: false
     t.string "message_id", null: false


### PR DESCRIPTION
The build currently fails because the timestamp in `db/schema.rb` is earlier than that of the latest migration.

Fixes #1458.