### PR TITLE
Close top-level comment tags

### DIFF
--- a/app/views/comments/_threads.html.erb
+++ b/app/views/comments/_threads.html.erb
@@ -15,6 +15,7 @@
           </li>
         </ol>
       <% end %>
+      </li>
     <% end %>
     <% previous_depth = comment.depth %>
     <% top_comment_depth ||= comment.depth %>
@@ -216,4 +217,5 @@
     </li>
   </ol>
 <% end %>
+</li>
 </ol> <%# matches very first comment %>


### PR DESCRIPTION
When serializing a thread, the top-level comment `<li>` tags were accidentally left unclosed (such that there was no matching `</li>` tag), unlike the child comments. But HTML5 does not require that `<li>` tags be explicitly closed, and will use heuristics to infer where a missing `</li>` tag probably should be inserted. Such heuristics are sometimes wrong and lead to strange UI issues with nested comments on pages with a thread view (like on stories and user profiles). To fix this issue, we insert the missing `</li>` tags.

We can verify the fix by comparing the resultant HTML output before/after, using an unclosed tags checker such as [this one](https://www.aliciaramirez.com/closing-tags-checker/).

Fun fact, I only noticed this problem is because I have been writing a scraper from scratch, and HTML parsing comes with its own surprises...

<!--
Issues and PRs are typically reviewed Wednesday and most weekend mornings.
-->
