### PR TITLE
Replace Markdown links with HTML links

### DIFF
--- a/app/views/about/chat.html.erb
+++ b/app/views/about/chat.html.erb
@@ -64,8 +64,8 @@
   </p>
 
   <p>
-  If you are interested in working on the Lobsters codebase or using it to run your own site, as of February 2025 we have a [Zulip-based chat room](https://lobsters.zulipchat.com/).
-  If you run a [sister site](https://github.com/lobsters/lobsters/wiki) please ask to be added to the `#security-notifications` stream for any vulnerability announcements.
+  If you are interested in working on the Lobsters codebase or using it to run your own site, as of February 2025 we have a <a href="https://lobsters.zulipchat.com/">Zulip-based chat room</a>.
+  If you run a <a href="https://github.com/lobsters/lobsters/wiki">sister site</a> please ask to be added to the `#security-notifications` stream for any vulnerability announcements.
   This is also an experiment to evaluate whether we should move the primary Lobsters chat room over to Zulip.
   </p>
 


### PR DESCRIPTION
This file seems unparsed by a Markdown parser.

<!--
Issues and PRs are typically reviewed Wednesday and most weekend mornings.
-->
