### PR TITLE
use explicit callback instead of `touch: :last_reply_at` as to not change `parent_comment.updated_at`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,6 +70,7 @@ group :test, :development do
   gem "standard-performance"
   gem "standard-rails"
   gem "super_diff"
+  gem "timecop"
   gem "faker"
   gem "byebug"
   gem "rb-readline"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -409,6 +409,7 @@ GEM
       patience_diff
     svg-graph (2.2.2)
     thor (1.3.2)
+    timecop (0.9.10)
     timeout (0.4.3)
     trilogy (2.9.0)
     ttfunk (1.8.0)
@@ -499,6 +500,7 @@ DEPENDENCIES
   standard-rails
   super_diff
   svg-graph
+  timecop
   trilogy
   vcr
   webmock


### PR DESCRIPTION
Using touch with `belongs_to :parent_comment` will automatically modify parent_comment's `updated_at`, causing #1467.
Use an explicit `after_create` callback instead.
fix #1467.

There is another use of [belongs_to :story, touch: :last_comment_at](https://github.com/lobsters/lobsters/blob/cb650ed40fad0d4ea8df24b3ced2dcb66e90b1a2/app/models/comment.rb#L5) Is that (modifying `updated_at` on story) an issue?