### PR TITLE
Close the top-level comment tags

### DIFF
--- a/app/views/comments/_threads.html.erb
+++ b/app/views/comments/_threads.html.erb
@@ -15,6 +15,7 @@
           </li>
         </ol>
       <% end %>
+      </li>
     <% end %>
     <% previous_depth = comment.depth %>
     <% top_comment_depth ||= comment.depth %>
@@ -216,4 +217,5 @@
     </li>
   </ol>
 <% end %>
+</li>
 </ol> <%# matches very first comment %>


### PR DESCRIPTION
The `<li class="comment_subtree">` tag of the first comment in each comment tree was accidentally left unclosed: it doesn't have a matching  `</li>` tag, but all its child comments do. We should fix this because when a `<li>` element has a missing end tag, HTML5 infers where to place the end tag using heuristics. The heuristics may fail at times, leading to subtle UI bugs on pages that display nested trees of comments (such as stories and user profiles).

We can use a [closing tag checker](https://www.aliciaramirez.com/closing-tags-checker/) to verify that this commit closes these open tags.

(I think github deleted the old pull request because my throwaway email made me look like a bot account. Sorry about the confusion.)

<!--
Issues and PRs are typically reviewed Wednesday and most weekend mornings.
-->
