### PR TITLE
wip on /cabinet view of partials

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ gem "stackprof"
 gem "prosopite"
 
 gem "builder" # for rss
+gem "faker" # for factory data and /cabinet
 gem "oauth" # for linking accounts
 gem "mail" # for parsing incoming mail
 gem "sitemap_generator" # for better search engine indexing
@@ -70,7 +71,6 @@ group :test, :development do
   gem "standard-performance"
   gem "standard-rails"
   gem "super_diff"
-  gem "faker"
   gem "byebug"
   gem "rb-readline"
   gem "vcr"

--- a/app/controllers/cabinet_controller.rb
+++ b/app/controllers/cabinet_controller.rb
@@ -1,0 +1,4 @@
+class CabinetController < ApplicationController
+  def index
+  end
+end

--- a/app/helpers/cabinet_helper.rb
+++ b/app/helpers/cabinet_helper.rb
@@ -1,0 +1,8 @@
+module CabinetHelper
+  def debug_render *args
+    capture do
+      concat render(*args)
+      concat content_tag(:pre, "render #{args.join(" ")}")
+    end
+  end
+end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -53,7 +53,7 @@ module UsersHelper
     end
     html_options.delete(:class) if html_options[:class].empty?
 
-    link_to(user.username, user, html_options)
+    link_to(user.username, user_path(user), html_options)
   end
 
   def user_karma(user)

--- a/app/views/cabinet/index.html.erb
+++ b/app/views/cabinet/index.html.erb
@@ -1,0 +1,40 @@
+<%
+story_without_merges = Story.new(
+  short_id: 'st0mrg',
+  user: User.new(username: Faker::Internet.user_name),
+  title: Faker::Lorem.sentence(word_count: 3),
+  tags_a: [Tag.last],
+  url: Faker::Internet.url,
+  created_at: Time.current,
+)
+
+story_with_merges = story_without_merges.dup
+# dup doesn't copy associations or default timestamps
+story_with_merges.user = story_without_merges.user
+story_with_merges.created_at = story_without_merges.created_at
+# add merged stories
+story_with_merges.stories_count = 2
+story_with_merges.merged_stories << story_without_merges
+story_with_merges.merged_stories << story_without_merges
+
+%>
+
+<h1>story _listdetail in a list, as on homepage, 0 merged stories</h1>
+<ol class="stories">
+<%= debug_render partial: 'stories/listdetail', locals: { story: story_without_merges } %>
+</ol>
+
+<h1>story _listdetail, as header for single story view, 0 merged stories</h1>
+<ol class="stories">
+<%= debug_render partial: 'stories/listdetail', locals: { story: story_without_merges, single_story: true } %>
+</ol>
+
+<h1>story _listdetail in a list, as on homepage, 2 merged stories</h1>
+<ol class="stories">
+<%= debug_render partial: 'stories/listdetail', locals: { story: story_with_merges } %>
+</ol>
+
+<h1>story _listdetail, as header for single story view, 2 merged</h1>
+<ol class="stories">
+<%= debug_render partial: 'stories/listdetail', locals: { story: story_with_merges, single_story: true } %>
+</ol>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -122,7 +122,7 @@ class="story <%= story.current_upvoted? ? "upvoted" : "" %>
 
     <div class="byline">
       <% if (@user && @user.show_avatars?) || !@user %>
-        <%= link_to avatar_img(story.user, 16), story.user %>
+        <%= link_to avatar_img(story.user, 16), user_path(story.user) %>
       <% end %>
       <% if story.previewing %>
         <% if story.user_is_author? %>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -244,7 +244,7 @@ class="story <%= story.current_upvoted? ? "upvoted" : "" %>
 
     <div class="byline">
       <% if (@user && @user.show_avatars?) || !@user %>
-        <%= link_to avatar_img(story.user, 16), story.user %>
+        <%= link_to avatar_img(story.user, 16), user_path(story.user) %>
       <% end %>
       <% if story.previewing %>
         <% if story.user_is_author? %>

--- a/app/views/stories/_listdetail.html.erb
+++ b/app/views/stories/_listdetail.html.erb
@@ -108,7 +108,7 @@ class="story <%= story.current_upvoted? ? "upvoted" : "" %>
 
     <div class="byline">
       <% if (@user && @user.show_avatars?) || !@user %>
-        <%= link_to avatar_img(story.user, 16), story.user %>
+        <%= link_to avatar_img(story.user, 16), user_path(story.user) %>
       <% end %>
       <% if story.previewing %>
         <% if story.user_is_author? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -278,5 +278,7 @@ Rails.application.routes.draw do
 
   get "/stats" => "stats#index"
 
+  get "/cabinet" => "cabinet#index"
+
   post "/csp-violation-report" => "csp#violation_report"
 end

--- a/spec/helpers/cabinet_helper_spec.rb
+++ b/spec/helpers/cabinet_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the CabinetHelper. For example:
+#
+# describe CabinetHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe CabinetHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/cabinet_spec.rb
+++ b/spec/requests/cabinet_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Cabinets", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
Just wanted to add visibility here, this is a [Storybook-like](https://5f27fec87f827f00226fd51a-mkzlawwyms.chromatic.com/?path=/story/components-button-iconbutton--variants&globals=colorScheme:dark) view of our templates in different states.

Our templates are reused in several different states, some of which are different enough they should probably be different partials... but then without something like this it's very hard to make sure they're getting revised in sync.

The partial I'm listing here is setup for the `listdetail` improvements planned in #1456. I started shotgunning conditionals around `single_story` and `stories_count > 0` throughout the partial and I realized I had very low odds of producing reasonable output unless I could see all the variants alongside each other.