### PR TITLE
Update the frontend code that renders newly posted comments (fixes #1466)

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -90,6 +90,17 @@ const removeExtraInputs = () => {
   }
 }
 
+const createChildList = (comment) => {
+  let children = qS(comment, '.comments')
+  if (!children) {
+    children = document.createElement('ol')
+    children.classList.add('comments')
+    // currently this is the layout
+    comment.append(children)
+  }
+  return children
+}
+
 class _LobstersFunction {
   constructor (username) {
     this.curUser = null;
@@ -664,7 +675,9 @@ onPageLoad(() => {
 
     let div = document.createElement('div');
     div.innerHTML = '';
-    comment.lastElementChild.append(div);
+    div.classList.add('reply_form_root')
+    const children = createChildList(comment)
+    children.prepend(div)
 
     fetchWithCSRF('/comments/' + comment.getAttribute('data-shortid') + '/reply')
       .then(response => {

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -27,13 +27,21 @@ const onPageLoad = (callback) => {
   document.addEventListener('DOMContentLoaded', callback);
 };
 
-const parentSelector = (target, selector) => {
+const parentSelectorOrNull = (target, selector) => {
   let parent = target;
   while (!parent.matches(selector)) {
     parent = parent.parentElement;
     if (parent === null) {
-      throw new Error(`Did not match a parent of ${target} with the selector ${selector}`);
+      return null;
     }
+  }
+  return parent;
+};
+
+const parentSelector = (target, selector) => {
+  let parent = parentSelectorOrNull(target, selector)
+  if (parent === null) {
+    throw new Error(`Did not match a parent of ${target} with the selector ${selector}`);
   }
   return parent;
 };
@@ -90,13 +98,12 @@ const removeExtraInputs = () => {
   }
 }
 
-const createChildList = (comment) => {
-  let children = qS(comment, '.comments')
+const createChildList = (parent) => {
+  let children = qS(parent, '.comments')
   if (!children) {
     children = document.createElement('ol')
     children.classList.add('comments')
-    // currently this is the layout
-    comment.append(children)
+    parent.append(children)
   }
   return children
 }
@@ -256,7 +263,57 @@ class _LobstersFunction {
       body: formData
     })
       .then(response => {
-        response.text().then(text => replace(form.parentElement, text));
+        response.text().then(text => {
+
+          // must keep this behavior up to date as the website's templates change:
+          //   app/views/comments/_comment.html.erb
+          //   app/views/comments/_threads.html.erb
+          //   app/views/stories/show.html.erb
+
+          const wrappedComment = document.createElement('p')
+          wrappedComment.innerHTML = text
+          const comment = qS(wrappedComment, '.comments_subtree')
+
+          const replyForm = parentSelectorOrNull(form, '.reply_form_temporary')
+          if (replyForm) {
+            // user submitted from a temporary reply form, so this is a reply to an existing comment
+            const parentComment = parentSelector(replyForm, '.comments_subtree')
+            replyForm.remove()
+
+            const children = createChildList(parentComment)
+            children.prepend(comment)
+
+            /// update styles to exactly reflect what would be generated on the backend
+
+            // comments/_comment.html.erb:
+            //   <%= comment.reply_count.to_i == 0 ? "no_children" : "" %>
+            const parentTreeline = qS(parentComment, '.comment_parent_tree_line')
+            parentTreeline.classList.remove('no_children')
+
+            // comments/_threads.html.erb:
+            //   <% if comment.depth != top_comment_depth %>
+            //     <div class="comment_siblings_tree_line"></div>
+            //   <% end %>
+            const treeline = document.createElement('div')
+            treeline.classList.add('comment_siblings_tree_line')
+            comment.append(treeline)
+
+            // comments/_threads.html.erb:
+            //   <% if !previous_depth || comment.depth > previous_depth %>
+            //     <span class="prior_comment_has_children"></span>
+            const span = document.createElement('span')
+            span.classList.add("prior_comment_has_children")
+            parentComment.insertBefore(span, children)
+
+          } else {
+            // there is no temporary reply form, so user must have created a "top-level" comment
+            parentSelector(form, '.comment_form_container').remove()
+            const storyComments = qS('#story_comments')
+            const comments = createChildList(storyComments)
+            comments.prepend(comment)
+          }
+
+        })
       })
   }
 
@@ -660,8 +717,8 @@ onPageLoad(() => {
     event.preventDefault();
     if (!Lobster.curUser) return Lobster.bounceToLogin();
 
-    const comment = parentSelector(event.target, '.comment');
-    const commentId = comment.getAttribute('id');
+    const commentInfo = parentSelector(event.target, '.comment');
+    const commentId = commentInfo.getAttribute('id');
 
     // guard: don't create multiple reply boxes to one comment
     if (qS('#reply_form_' + commentId)) { return false; }
@@ -675,11 +732,12 @@ onPageLoad(() => {
 
     let div = document.createElement('div');
     div.innerHTML = '';
-    div.classList.add('reply_form_root')
+    div.classList.add('reply_form_temporary')
+    const comment = parentSelector(commentInfo, '.comments_subtree');
     const children = createChildList(comment)
     children.prepend(div)
 
-    fetchWithCSRF('/comments/' + comment.getAttribute('data-shortid') + '/reply')
+    fetchWithCSRF('/comments/' + commentInfo.getAttribute('data-shortid') + '/reply')
       .then(response => {
         response.text().then(text => {
           // guard: don't create multiple reply boxes to one comment

--- a/app/views/comments/_postedreply.html.erb
+++ b/app/views/comments/_postedreply.html.erb
@@ -2,5 +2,4 @@
 <li class="comments_subtree">
   <%= render "comments/comment", :comment => comment,
     :show_tree_lines => true %>
-  <ol class="comments"></ol>
 </li>

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -4,7 +4,6 @@
   <% @comments.each do |comment| %>
     <li><%= render "comments/comment", :comment => comment,
       :show_story => true %>
-      <ol class="comments"></ol>
     </li>
   <% end %>
 </ol>

--- a/app/views/replies/show.html.erb
+++ b/app/views/replies/show.html.erb
@@ -11,7 +11,6 @@
             show_story: true,
             is_unread: reply.is_unread,
             show_tree_lines: false %>
-        <ol class="comments"></ol>
       </li>
     <% end %>
   </ol>

--- a/app/views/stories/show.html.erb
+++ b/app/views/stories/show.html.erb
@@ -48,7 +48,7 @@
       <li class="comments_subtree"><%= render partial: "comments/commentbox", locals: { comment: @comment, story: @story } %></li>
     <% end %>
 
-    <li class="comments_subtree">
+    <li class="comments_subtree" id="story_comments">
       <% if @user && @comments.size > 0 %>
         <div class="thread_summary">
           <%= pluralize(@comments.size, "comment") %>,


### PR DESCRIPTION
Background: https://github.com/lobsters/lobsters/issues/1466#issuecomment-2670096125

These commits aim to fix the bug by updating the frontend code to match the current design
- create the reply form inside the list of child comments (this seems to have been the original intention and makes it easier to cleanly remove)
- don't wrap newly posted comments in a `<div>`
- update the styles and add tree lines to parent & child comments when posting a reply

On the backend, I thought we should also modify the comment views so that a comment will only have a list of child comments `<ol class="comments">` if it has replies. This is not absolutely necessary but it's consistent with how comment threads are  generated in `_threads.html.erb`.

`_threads.html.erb` will only conditionally insert the `ol.comments` tag:

https://github.com/lobsters/lobsters/blob/2cb0baab355e7fabe26abc2a9a043a1d1a5986bd/app/views/comments/_threads.html.erb#L6-L19

Whereas before this change, several other comment views would always insert the tag, even if it's known to be empty, like when rendering a newly posted reply:

https://github.com/lobsters/lobsters/blob/2cb0baab355e7fabe26abc2a9a043a1d1a5986bd/app/views/comments/_postedreply.html.erb#L2-L6

If we adopt all of these changes, posting a comment should produce a DOM that looks the same as if the page was generated by the backend.

<!--
Issues and PRs are typically reviewed Wednesday and most weekend mornings.
-->
