### PR TITLE
Fix 'last_read_newest' and 'Last Read' marker 

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -77,6 +77,7 @@ class HomeController < ApplicationController
 
     @title = "Newest Stories"
     @above = {partial: "stories/subnav"}
+    @last_read_story = find_last_read_story
 
     @rss_link = {
       title: "RSS 2.0 - Newest Items",
@@ -95,7 +96,7 @@ class HomeController < ApplicationController
       format.json { render json: @stories }
     end
 
-    @user&.touch(:last_read_newest)
+    @user&.touch(:last_read_newest) if @last_read_story || @user&.last_read_newest.nil?
   end
 
   def newest_by_user
@@ -375,5 +376,9 @@ class HomeController < ApplicationController
 
   def tags_with_description_for_rss(tags)
     tags.map { |tag| "#{tag.tag} (#{tag.description})" }.join(" ")
+  end
+
+  def find_last_read_story
+    @stories.find { |story| @user&.last_read_newest&.after?(story.created_at) }
   end
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -4,9 +4,9 @@
 <% already_printed_newest_line = false %>
 <ol class="stories list <%= action_name == "hidden" ? "show_hidden" : "" %>">
   <% @stories.each do |story| %>
-    <% if action_name == "newest" &&
-        !already_printed_newest_line &&
-        @user&.last_read_newest&.after?(story.created_at) %>
+    <% if action_name == "newest" && 
+      !already_printed_newest_line && 
+      @last_read_story == story %>
       <div class="last_read_newest">Last Read</div>
       <% already_printed_newest_line = true %>
     <% end %>

--- a/spec/features/newest_spec.rb
+++ b/spec/features/newest_spec.rb
@@ -14,10 +14,31 @@ RSpec.feature "Reading Homepage", type: :feature do
       expect(body.index("older_story")).to be > body.index("newer story")
     end
 
-    it "updates the user's last-read line" do
-      user = create(:user, last_read_newest: 3.days.ago)
+    it "displays 'Last Read' marker at the last loaded position and update 'last_read_newest' accordingly" do
+      user = create(:user, last_read_newest: 2.hours.ago)
+
       stub_login_as user
+
+      stub_const "StoriesPaginator::STORIES_PER_PAGE", 3
+
+      create(:story, title: "story 1", created_at: 3.hours.ago)
+      create(:story, title: "story 2", created_at: 3.hours.ago)
+      create(:story, title: "story 3", created_at: 1.hours.ago)
+      create(:story, title: "story 4", created_at: 1.hours.ago)
+      create(:story, title: "story 5", created_at: 1.hours.ago)
+      create(:story, title: "story 6", created_at: 1.hours.ago)
+
       visit "/newest"
+      expect(page.body).not_to include("Last Read")
+      expect(user.reload.last_read_newest).not_to be_within(1.second).of Time.zone.now
+
+      visit "/newest/page/2"
+      expect(page.body).to include("Last Read")
+      page_html = page.body
+      last_read_index = page_html.index("Last Read")
+      story_2_index = page_html.index("story 2")
+
+      expect(last_read_index).to be < story_2_index, "'Last Read' should appear before 'story 2'"
       expect(user.reload.last_read_newest).to be_within(1.second).of Time.zone.now
     end
   end


### PR DESCRIPTION
#1394 Fixed second part of issue related to `last_read_newest` and` Last Read` marker.

<!--
Issues and PRs are typically reviewed Wednesday and most weekend mornings.
-->
