### PR TITLE
Add support for OTP recovery codes

### DIFF
--- a/app/controllers/login_controller.rb
+++ b/app/controllers/login_controller.rb
@@ -203,10 +203,11 @@ class LoginController < ApplicationController
       session.delete(:twofa_u)
       redirect_to "/"
     elsif (tmpu = find_twofa_user) && tmpu.authenticate_totp_recovery(params[:totp_code])
-      flash[:error] = "You used a OTP recovery code to log in. Please update your OTP device to ensure continued access to your account."
+      flash[:error] = "You used a OTP recovery code to log in and as such we have disabled MFA. Please add a new OTP device to your ensure continued multifactor authentication for your account."
 
       session[:u] = tmpu.session_token
       session.delete(:twofa_u)
+      tmpu.disable_2fa
 
       redirect_to "/settings/2fa"
     else

--- a/app/controllers/login_controller.rb
+++ b/app/controllers/login_controller.rb
@@ -202,6 +202,13 @@ class LoginController < ApplicationController
       session[:u] = tmpu.session_token
       session.delete(:twofa_u)
       redirect_to "/"
+    elsif (tmpu = find_twofa_user) && tmpu.authenticate_totp_recovery(params[:totp_code])
+      flash[:error] = "You used a OTP recovery code to log in. Please update your OTP device to ensure continued access to your account."
+
+      session[:u] = tmpu.session_token
+      session.delete(:twofa_u)
+      
+      redirect_to "/settings/2fa"
     else
       flash[:error] = "Your TOTP code did not match.  Please try again."
       redirect_to "/login/2fa"

--- a/app/controllers/login_controller.rb
+++ b/app/controllers/login_controller.rb
@@ -207,7 +207,7 @@ class LoginController < ApplicationController
 
       session[:u] = tmpu.session_token
       session.delete(:twofa_u)
-      
+
       redirect_to "/settings/2fa"
     else
       flash[:error] = "Your TOTP code did not match.  Please try again."

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -127,13 +127,14 @@ class SettingsController < ApplicationController
 
     @user.totp_secret = session[:totp_secret]
     if @user.authenticate_totp(params[:totp_code])
+      @user.totp_recovery_codes = Array.new(3).map{ |_| Utils.random_str(20) }
       # re-roll, just in case
       @user.session_token = nil
       @user.save!
 
       session[:u] = @user.session_token
 
-      flash[:success] = "Two-Factor Authentication has been enabled on your account."
+      flash[:success] = "Two-Factor Authentication has been enabled on your account. Your recovery codes are #{@user.totp_recovery_codes.join(', ')}. They can be used to access your account in the event that you loose access to your TOTP device. Store these in a safe place, "
       session.delete(:totp_secret)
       redirect_to "/settings"
     else

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -127,7 +127,7 @@ class SettingsController < ApplicationController
 
     @user.totp_secret = session[:totp_secret]
     if @user.authenticate_totp(params[:totp_code])
-      @user.totp_recovery_codes = Array.new(3).map { |_| Utils.random_str(20) }
+      @user.totp_recovery_codes = Array.new(6) { |_| Utils.random_str(20) }
       # re-roll, just in case
       @user.session_token = nil
       @user.save!

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -134,7 +134,7 @@ class SettingsController < ApplicationController
 
       session[:u] = @user.session_token
 
-      flash[:success] = "Two-Factor Authentication has been enabled on your account. Your recovery codes are #{@user.totp_recovery_codes.join(", ")}. They can be used to access your account in the event that you loose access to your TOTP device. Store these in a safe place, "
+      flash[:success] = "Two-Factor Authentication has been enabled on your account. Your recovery codes are #{@user.totp_recovery_codes.join(", ")}. They can be used to access your account in the event that you lose access to your TOTP device. Store these in a safe place, separate from your TOTP device."
       session.delete(:totp_secret)
       redirect_to "/settings"
     else

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -127,14 +127,14 @@ class SettingsController < ApplicationController
 
     @user.totp_secret = session[:totp_secret]
     if @user.authenticate_totp(params[:totp_code])
-      @user.totp_recovery_codes = Array.new(3).map{ |_| Utils.random_str(20) }
+      @user.totp_recovery_codes = Array.new(3).map { |_| Utils.random_str(20) }
       # re-roll, just in case
       @user.session_token = nil
       @user.save!
 
       session[:u] = @user.session_token
 
-      flash[:success] = "Two-Factor Authentication has been enabled on your account. Your recovery codes are #{@user.totp_recovery_codes.join(', ')}. They can be used to access your account in the event that you loose access to your TOTP device. Store these in a safe place, "
+      flash[:success] = "Two-Factor Authentication has been enabled on your account. Your recovery codes are #{@user.totp_recovery_codes.join(", ")}. They can be used to access your account in the event that you loose access to your TOTP device. Store these in a safe place, "
       session.delete(:totp_secret)
       redirect_to "/settings"
     else

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -83,6 +83,7 @@ class User < ApplicationRecord
     s.string :mastodon_username
     s.any :keybase_signatures, array: true
     s.string :homepage
+    s.string :totp_recovery_codes, array: true, default: [], null: false
   end
 
   validates :prefers_color_scheme, inclusion: %w[system light dark]
@@ -231,9 +232,16 @@ class User < ApplicationRecord
     h
   end
 
+  def authenticate_totp_recovery(code)
+    return false unless totp_recovery_codes.include?(code)
+    
+    totp_recovery_codes.delete(code)
+    save!
+  end
+
   def authenticate_totp(code)
-    totp = ROTP::TOTP.new(totp_secret)
-    totp.verify(code)
+      totp = ROTP::TOTP.new(totp_secret)
+      totp.verify(code)
   end
 
   def avatar_path(size = 100)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -234,14 +234,14 @@ class User < ApplicationRecord
 
   def authenticate_totp_recovery(code)
     return false unless totp_recovery_codes.include?(code)
-    
+
     totp_recovery_codes.delete(code)
     save!
   end
 
   def authenticate_totp(code)
-      totp = ROTP::TOTP.new(totp_secret)
-      totp.verify(code)
+    totp = ROTP::TOTP.new(totp_secret)
+    totp.verify(code)
   end
 
   def avatar_path(size = 100)


### PR DESCRIPTION
Resolves #342 

I've added basic support for generating recovery codes when a user sets up a TOTP device.