### PR TITLE
Fix comment editing to work with and without JS

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -104,7 +104,7 @@ class CommentsController < ApplicationController
       render partial: "commentbox", layout: false,
         content_type: "text/html", locals: {comment: comment}
     else
-      render "_commentbox", locals: {comment: comment, parents: comment.parents}
+      render "_commentbox", locals: {comment: comment, parents: comment.parents, redirect_on_submit: true}
     end
   end
 
@@ -207,7 +207,15 @@ class CommentsController < ApplicationController
       # touch the updated_at columns up the reply chain to the story once
       comment.parent_comment&.touch(:last_reply_at)
 
-      render_created_comment(comment, params[:show_tree_lines])
+      if !request.xhr?
+        return redirect_to comment.path
+      end
+
+      if params[:redirect_on_submit].present?
+        head :ok, x_location: comment.path
+      else
+        render_created_comment(comment, params[:show_tree_lines])
+      end
     else
       comment.current_vote = {vote: 1}
 

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -782,7 +782,7 @@ onPageLoad(() => {
     event.preventDefault();
     let comment = parentSelector(event.target, '.comment');
     const commentId = comment.getAttribute('data-shortid')
-    fetch('/comments/' + commentId + '/edit')
+    fetchWithCSRF('/comments/' + commentId + '/edit')
       .then(response => {
         response.text().then(text => {
           replace(comment, text);

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -87,7 +87,13 @@ const fetchWithCSRF = (url, params) => {
   params['headers'] = params['headers'] || new Headers;
   params['headers'].append('X-CSRF-Token', csrfToken());
   params['headers'].append('X-Requested-With', 'XMLHttpRequest'); // request.xhr?
-  return fetch(url, params);
+  return fetch(url, params).then(response => {
+    const x_location = response.headers.get('X-Location');
+    if(x_location !== null) {
+      window.location.replace(x_location);
+    }
+    return response;
+  });
 }
 
 const removeExtraInputs = () => {

--- a/app/views/comments/_commentbox.html.erb
+++ b/app/views/comments/_commentbox.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (comment:, story: nil, show_comment: nil, show_tree_lines: false, parents: nil) -%>
+<%# locals: (comment:, story: nil, show_comment: nil, show_tree_lines: false, redirect_on_submit: false, parents: nil) -%>
 <% if parents %>
   <ol class="comments comments1">
     <li class="comments_subtree">
@@ -15,6 +15,10 @@
 
   <%= f.hidden_field "story_id", value: comment.story.short_id %>
   <%= f.hidden_field "_method", value: "#{comment.new_record?? 'post' : 'patch'}" %>
+
+  <% if redirect_on_submit %>
+    <%= f.hidden_field "redirect_on_submit", value: true %>
+  <% end %>
 
   <% if comment.parent_comment %>
     <%= f.hidden_field "parent_comment_short_id", value: comment.parent_comment.short_id %>


### PR DESCRIPTION
The first commit here fixes b122213f2b99c922fd86fc50cf5c1a7cb19d0eb4 to correctly render the edit box with JavaScript enabled. Using `fetch` doesn't set the `X-Requested-By` header, so `request.xhr?` will return false. Instead of adding this header manually I've switched to using `fetchWithCSRF` which already added it, for reasons I'll explain at the end.

The second commit fixes #1487 by choosing to either send a redirect or a partial in response to an update request. Note that the fetch API does not allow introspecting on 302 responses, either omitting them entirely or (with `redirect: 'manual'`) redacting them. Therefore, I introduced an `X-Location` header which can be sent in any response to be handled as a redirect by the JavaScript. At present this is sent in another code path, there may be some Rails magic to handle this automatically when a normal redirect is sent from an XHR request.

I introduced handling for this in `fetchWithCSRF`. In sites where I've used progressive enhancement I've often found it useful to have a `fetch` wrapper that "does the right thing" with typical web framework responses.

Please note this is the first Rails (and Ruby!) I've ever written - here be dragons!