### PR TITLE
Make /comments tree compatible with comment JS

### DIFF
--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -1,20 +1,22 @@
 <%= render partial: @above if @above %>
 
 <% already_printed_newest_line = false %>
-<ol class="comments comments1">
-  <% @comments.each do |comment| %>
-    <% if action_name == "index" && 
-       !already_printed_newest_line && 
-       @last_read_comment == comment %>
-       <div class="last_read_newest">Last Read</div>
-       <% already_printed_newest_line = true %>
+<div id="story_comments">
+  <ol class="comments comments1">
+    <% @comments.each do |comment| %>
+      <% if action_name == "index" &&
+         !already_printed_newest_line &&
+         @last_read_comment == comment %>
+         <div class="last_read_newest">Last Read</div>
+         <% already_printed_newest_line = true %>
+      <% end %>
+      <li class="comments_subtree"><%= render "comments/comment", :comment => comment,
+        :show_story => true %>
+        <ol class="comments"></ol>
+      </li>
     <% end %>
-    <li><%= render "comments/comment", :comment => comment,
-      :show_story => true %>
-      <ol class="comments"></ol>
-    </li>
-  <% end %>
-</ol>
+  </ol>
+</div>
 
 <div class="morelink">
   <% if @comments.any? %>

--- a/app/views/comments/user_threads.html.erb
+++ b/app/views/comments/user_threads.html.erb
@@ -2,8 +2,10 @@
 
 <%= possible_flag_warning(@showing_user, @user) %>
 
-<ol class="comments comments1">
-  <li class="comments_subtree">
-    <%= render partial: 'threads', locals: { thread: @threads } %>
-  </li>
-</ol>
+<div id="story_comments">
+  <ol class="comments comments1">
+    <li class="comments_subtree">
+      <%= render partial: 'threads', locals: { thread: @threads } %>
+    </li>
+  </ol>
+</div>

--- a/app/views/mod/flagged_comments.html.erb
+++ b/app/views/mod/flagged_comments.html.erb
@@ -1,13 +1,15 @@
 <%= render partial: 'subnav', locals: { periods: @periods } %>
 
 <% if @comments.present? %>
-  <ol class="comments comments1">
-    <% @comments.each do |comment| %>
-      <li>
-      <%= render "comments/comment", :comment => comment, :show_story => true, force_open: true %>
-      </li>
-    <% end %>
-  </ol>
+  <div id="story_comments">
+    <ol class="comments comments1">
+      <% @comments.each do |comment| %>
+        <li class="comments_subtree">
+        <%= render "comments/comment", :comment => comment, :show_story => true, force_open: true %>
+        </li>
+      <% end %>
+    </ol>
+  </div>
 <% else %>
   <div class="nominal">🦞</div>
 <% end %>

--- a/app/views/replies/show.html.erb
+++ b/app/views/replies/show.html.erb
@@ -3,18 +3,20 @@
 <%= possible_flag_warning(@user, @user) %>
 
 <% if @replies.present? %>
-  <ol class="comments comments1">
-    <% @replies.each do |reply| %>
-      <li class="comments_subtree">
-        <%= render "comments/comment",
-            comment: reply.comment,
-            show_story: true,
-            is_unread: reply.is_unread,
-            show_tree_lines: false %>
-        <ol class="comments"></ol>
-      </li>
-    <% end %>
-  </ol>
+  <div id="story_comments">
+    <ol class="comments comments1">
+      <% @replies.each do |reply| %>
+        <li class="comments_subtree">
+          <%= render "comments/comment",
+              comment: reply.comment,
+              show_story: true,
+              is_unread: reply.is_unread,
+              show_tree_lines: false %>
+          <ol class="comments"></ol>
+        </li>
+      <% end %>
+    </ol>
+  </div>
 <% else %>
   <p class="help">No replies to show.</p>
 <% end %>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -367,11 +367,13 @@ class="story <%= story.current_upvoted? ? "upvoted" : "" %>
       <% end %>
     </ol>
   <% elsif @search.what == :comments %>
-    <ol class="comments comments1">
-      <% @search.results.each do |res| %>
-        <li><%= render "comments/comment", :comment => res, :show_story => true %></li>
-      <% end %>
-    </ol>
+    <div id="story_comments">
+      <ol class="comments comments1">
+        <% @search.results.each do |res| %>
+          <li class="comments_subtree"><%= render "comments/comment", :comment => res, :show_story => true %></li>
+        <% end %>
+      </ol>
+    </div>
   <% end %>
 
   <% if @search.results_count > @search.per_page %>

--- a/app/views/users/standing.html.erb
+++ b/app/views/users/standing.html.erb
@@ -63,8 +63,10 @@
   </p>
 </div>
 
-<ol class="comments comments1">
-  <% @flagged_comments.each do |comment| %>
-    <li><%= render "comments/comment", :comment => comment, :show_story => true, force_open: true %></li>
-  <% end %>
-</ol>
+<div id="story_comments">
+  <ol class="comments comments1">
+    <% @flagged_comments.each do |comment| %>
+      <li class="comments_subtree"><%= render "comments/comment", :comment => comment, :show_story => true, force_open: true %></li>
+    <% end %>
+  </ol>
+</div>


### PR DESCRIPTION
Adding `.comments_subtree` and `#story_comments` allows the same comment JS that runs on the story page to work appropriately here as well.

With this PR, replying to a comment on `/comments` will nest it under its parent - it will be hoisted to the top on a refresh. Editing it whilst nested will leave it in position. Editing a comment at top-level on this page will move it to the top of the list.

Note that there is still a slight visual issue where the markup inserted by the JS will have `show_tree_lines` enabled, so the reply/edited comment will be the only one on the page with the collapsing button shown.

Closes #1491

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
