### PR TITLE
Clarify participation/self-promo text wording

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -172,7 +172,7 @@
     <div class="user-stats flash-notice">
       <p>
         Comments posted in the last 6 months: <%= @showing_user.comments.recent.count %><br>
-        &nbsp;&nbsp;...posted on stories you didn't author: <%= @showing_user.comments.recent.on_stories_not_authored_by(@showing_user).count %><br>
+        &nbsp;&nbsp;...posted on stories you didn't mark as self-authored: <%= @showing_user.comments.recent.on_stories_not_authored_by(@showing_user).count %><br>
         &nbsp;&nbsp;&nbsp;&nbsp;...received above average score: <%= @showing_user.comments.recent.on_stories_not_authored_by(@showing_user).above_average.count %>
       </p>
 


### PR DESCRIPTION
It took me literally completely finishing a bug report to realize that this text meant stories marked as "I am the author of the story at this URL", _not_, stories submitted by you (i.e. "_submissions_ authored by you").

So, try and make this text a bit more unambiguous.

This wording probably isn't the best. Feel free to bikeshed and feel free to force-push to my branch. I just went to file an (alternate) issue and then realized it was super easy to just at least propose a strawman.

This was a drive-by GitHub web UI patch and I did not test it at all. It's trivial so I'm assuming CI will take care of it.