### PR TITLE
Use a minus sign (U+2212) instead of hyphen to collapse

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 /* common color scheme */
 
 :root {
@@ -624,7 +625,7 @@ li .comment_folder.comment_folder_inline.force_inline {
 	display: inline-block;
 }
 li .comment_folder:before {
-	content: "[-]";
+	content: "[−]";
 }
 li .comment_folder_button:checked ~ .comment .comment_folder:before {
 	content: "[+]";


### PR DESCRIPTION
With a regular hyphen (U+002D) the `[-]` marker uses slightly less space than `[+]` in most standard fonts, resulting in unsatisfying aesthetics especially when toggling the state.

Instead, use a minus character that has the same with as the plus character.

Before
![2025-03-24-201355_100x115_scrot](https://github.com/user-attachments/assets/34be45a4-14c9-44dd-a173-efd8b8f73610)

After
![2025-03-24-201347_98x117_scrot](https://github.com/user-attachments/assets/7c9069ec-2842-4f80-a934-8ff463c97353)

(I'm not sure which variant is preferred - encoding the character as UTF-8 and declaring the use of UTF-8 as in this PR or the slightly more conservative solution of escaping the string. Happy to switch it.)