### PR TITLE
Allow unflagging a story from a fresh page

### DIFF
--- a/app/views/stories/_singledetail.html.erb
+++ b/app/views/stories/_singledetail.html.erb
@@ -6,7 +6,7 @@ classes = [
   :story,
   merged_stories.first.negativity_class,
   merged_stories.first.current_upvoted? && 'upvoted',
-  merged_stories.first.current_flagged? && 'flageed',
+  merged_stories.first.current_flagged? && 'flagged',
   merged_stories.first.is_hidden_by_cur_user && 'hidden',
   merged_stories.first.is_saved_by_cur_user && 'saved',
   merged_stories.first.is_deleted? && 'deleted',


### PR DESCRIPTION
A typo in the class name meant the JavaScript wasn't handling this correctly.

Fixes: 426bce9

Closes #1500