### PR TITLE
fix make docker-server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ lint:
 	bundle exec standardrb --fix-unsafely
 
 docker-serve:
-	export RUBY_VERSION=`cat .ruby-version`
+	export RUBY_VERSION=`cat .ruby-version` && \
 	docker compose up --build
 
 all: lint test


### PR DESCRIPTION
I try follow the steps for docker in [`setup_with_docker.md`](https://github.com/lobsters/lobsters/blob/master/docs/setup_with_docker.md) and I found the following error when I try to build:

```bash
$  make docker-serve
export RUBY_VERSION=`cat .ruby-version`
docker compose up --build
WARN[0000] The "RUBY_VERSION" variable is not set. Defaulting to a blank string.
Compose now can delegate build to bake for better performances
Just set COMPOSE_BAKE=true
[+] Building 0.0s (1/1) FINISHED                                                    docker:default
 => [app internal] load build definition from Dockerfile.dev                                  0.0s
 => => transferring dockerfile: 616B                                                          0.0s
 => WARN: InvalidDefaultArgInFrom: Default value for ARG ruby:${RUBY_VERSION} results in emp  0.0s
failed to solve: failed to parse stage name "ruby:": invalid reference format
make: *** [Makefile:12: docker-serve] Error 1
```

Looks like `${RUBY_VERSION}` is empty because the `export` don't share the envars with the next line (see [this Stack Exchange](https://unix.stackexchange.com/a/656439)). The fix is do both in the same shell invocation. 

