### PR TITLE
Fix display of story _singledetail

### DIFF
--- a/app/views/stories/_singledetail.html.erb
+++ b/app/views/stories/_singledetail.html.erb
@@ -96,6 +96,7 @@ classes = [
             <span> | </span><%= link_to "unhide", story_unhide_path(ms.short_id), :class => "hider" %>
           <% else %>
             <span> | </span><%= link_to "hide", story_hide_path(ms.short_id), :class => "hider" %>
+          <% end %>
 
           <% if ms.disownable_by_user?(@user) %>
             |
@@ -144,8 +145,7 @@ classes = [
             <span> | <%= ms.vote_summary_for(@user).downcase %> </span>
           <% end %>
         <% end %>
-      <% end %>
-    </div>
+      </div>
     </div>
   <% end %>
 

--- a/app/views/stories/_singledetail.html.erb
+++ b/app/views/stories/_singledetail.html.erb
@@ -109,14 +109,6 @@ classes = [
           <% end %>
         <% end %>
 
-        <% if merged_stories.count == 1 %>
-          <span class="comments_label">
-            |
-            <% cc = merged_stories.map(&:comments_count).sum %>
-            <%= (cc == 0) ? "no" : cc %> <%= 'comment'.pluralize(cc) %></a>
-          </span>
-        <% end %>
-
         <% if ms.hider_count > 0 %>
           <% if ms.is_hidden_by_cur_user %>
             (hidden by you and <%= pluralize(ms.hider_count - 1, "other user") %> )
@@ -141,10 +133,12 @@ classes = [
             </span>
           <% end %>
 
-          <span class="comments_label">
-            |
-            <%= (ms.comments_count == 0) ? "no" : ms.comments_count %> <%= 'comment'.pluralize(ms.comments_count) %></a>
-          </span>
+          <% if merged_stories.count == 1 %>
+            <span class="comments_label">
+              |
+              <%= (ms.comments_count == 0) ? "no" : ms.comments_count %> <%= 'comment'.pluralize(ms.comments_count) %></a>
+            </span>
+          <% end %>
 
           <% if ((@user&.is_moderator? && ms.flags > 0) || (ms.flags >= 3 || ms.score <= 0)) %>
             <span> | <%= ms.vote_summary_for(@user).downcase %> </span>


### PR DESCRIPTION
The first commit fixes displaying a duplicated comment count for unmerged stories (one a sum of all the merged stories, one the comment count on the story itself). We still render only a total comment count for merged stories.

The second commit fixes some unclosed control flow that was skipping more of the template for logged-out users than intended. I've checked this over a few times and I think it's correct now, but it's probably worth another skim over.

Closes #1502 
