### PR TITLE
Fix 1+n query on /mod

### DIFF
--- a/app/controllers/mod_controller.rb
+++ b/app/controllers/mod_controller.rb
@@ -11,7 +11,7 @@ class ModController < ApplicationController
   def index
     @title = "Activity by Other Mods"
     @moderations = Moderation
-      .eager_load(:moderator, :story, :tag, :user, comment: [:story, :user])
+      .eager_load(:category, :moderator, :story, :tag, :user, comment: [:story, :user])
       .where.not(moderator_user_id: @user.id)
       .or(Moderation.where(moderator_user_id: nil))
       .where({moderations: {created_at: 1.month.ago..}})


### PR DESCRIPTION
Ran into this while working on #1508

```
N+1 queries detected:
SELECT `categories`.* FROM `categories` WHERE `categories`.`id` = 11 LIMIT 1 /*action='index',controller='mod'*/
SELECT `categories`.* FROM `categories` WHERE `categories`.`id` = 10 LIMIT 1 /*action='index',controller='mod'*/
SELECT `categories`.* FROM `categories` WHERE `categories`.`id` = 9 LIMIT 1 /*action='index',controller='mod'*/
SELECT `categories`.* FROM `categories` WHERE `categories`.`id` = 8 LIMIT 1 /*action='index',controller='mod'*/
SELECT `categories`.* FROM `categories` WHERE `categories`.`id` = 7 LIMIT 1 /*action='index',controller='mod'*/
Call stack:
app/views/moderations/_table.html.erb:29
app/views/moderations/_table.html.erb:8
app/views/mod/index.html.erb:4
app/controllers/application_controller.rb:143:in 'ApplicationController#n_plus_one_detection'
```

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
