### PR TITLE
fix #1506 more bad links to modlog

### DIFF
--- a/app/views/about/about.html.erb
+++ b/app/views/about/about.html.erb
@@ -167,7 +167,7 @@
   All users have equal votes, with no special priorities or penalties for specific users or domains.
   Moderators have no ability to raise or <a href="http://www.righto.com/2013/11/how-hacker-news-ranking-really-works.html">lower</a> the rankings of stories or comments (besides voting like any user).
   Per-tag <a href="/filters">hotness modifiers</a> affect all stories with those tags;
-  these modifiers (and <a href="https://lobste.rs/moderations?utf8=%E2%9C%93&moderator=(All)&what[tags]=tags">changes</a> to them) are public.
+  these modifiers (and <a href="https://lobste.rs/moderations?moderator=(All)&what[tags]=tags">changes</a> to them) are public.
   Domains used for marketing analytics are banned and tracking parameters are removed from links
   (look for <tt>utm_</tt> in <a href="https://github.com/lobsters/lobsters/blob/master/app/models/story.rb">story.rb</a>).
   </p>
@@ -309,7 +309,7 @@
   be automatically applied to a story when a quorum of users agrees on a new
   title (such as removing a site's name, or appending the story's year of
   publication) or set of tags, without any moderator action required.
-  (<a href="https://lobste.rs/moderations?utf8=%E2%9C%93&moderator=(Users)">Log</a>)
+  (<a href="https://lobste.rs/moderations?moderator=(Users)">Log</a>)
   </p></li>
 
   <li><p>


### PR DESCRIPTION
Small followup to https://github.com/lobsters/lobsters/commit/240647f403787684e3e1c8c88e528a0a9dc3f941 - there were two other instances of this broken link format on the page