### PR TITLE
Add fake story and comment upvotes in fake_data

### DIFF
--- a/lib/tasks/fake_data.rake
+++ b/lib/tasks/fake_data.rake
@@ -174,11 +174,14 @@ class FakeDataGenerator
     end
     puts
 
-    print "Comment Flags "
+    print "Comment Flags and Votes "
     comments.each do |c|
       print "."
+      upvotes = Random.rand(20)
+      # Take one extra user to have a chance to flag the comment
+      voting_users = users.sample(upvotes + 1)
       if Random.rand(100) > 95
-        u = users[Random.rand(@users_count - 1)]
+        u = voting_users[0]
         Vote.vote_thusly_on_story_or_comment_for_user_because(
           -1,
           c.story_id,
@@ -187,20 +190,43 @@ class FakeDataGenerator
           Vote::COMMENT_REASONS.keys[Random.rand(Vote::COMMENT_REASONS.keys.length)]
         )
       end
+
+      voting_users.slice(1..).each do |u|
+        Vote.vote_thusly_on_story_or_comment_for_user_because(
+          1,
+          c.story_id,
+          c.id,
+          u.id,
+          nil
+        )
+      end
     end
     puts
 
-    print "Story Flags "
+    print "Story Flags and Votes "
     stories.each do |s|
       print "."
+      upvotes = Random.rand(20)
+      # Take one extra user to have a chance to flag the story
+      voting_users = users.sample(upvotes + 1)
       if Random.rand(100) > 95
-        u = users[Random.rand(@users_count - 1)]
+        u = voting_users[0]
         Vote.vote_thusly_on_story_or_comment_for_user_because(
           -1,
           s.id,
           nil,
           u.id,
           Vote::STORY_REASONS.keys[Random.rand(Vote::STORY_REASONS.keys.length)]
+        )
+      end
+
+      voting_users.slice(1..).each do |u|
+        Vote.vote_thusly_on_story_or_comment_for_user_because(
+          1,
+          s.id,
+          nil,
+          u.id,
+          nil
         )
       end
     end


### PR DESCRIPTION
I've found having a variety of vote counts useful while working on layout, but they weren't generated as part of `fake_data`.

This is by far the slowest part of the fake data generation, I suspect because of the repeated sampling of users. Perhaps bulk inserting votes or only processing a subset of stories/comments would be viable.

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
