### PR TITLE
feat: update github actions setup

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,6 +12,7 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       fail-fast: false
 
@@ -33,6 +34,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
+          ruby-version: 3.4.1
           bundler-cache: true
 
       - name: Workaround for inability to templatize credentials (#1380)
@@ -52,6 +54,7 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       fail-fast: false
 
@@ -59,6 +62,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
+          ruby-version: 3.4.1
           bundler-cache: true
 
       - name: Run linters
@@ -67,6 +71,7 @@ jobs:
 
   security:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       fail-fast: false
 
@@ -74,6 +79,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
+          ruby-version: 3.4.1
           bundler-cache: true
 
       - name: Run brakeman
@@ -82,6 +88,7 @@ jobs:
 
   leak-check:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       fail-fast: false
 
@@ -89,6 +96,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
+          ruby-version: 3.4.1
           bundler-cache: true
 
       - name: Find leaky gems

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -34,7 +34,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.4.1
           bundler-cache: true
 
       - name: Workaround for inability to templatize credentials (#1380)

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
     branches: [ master ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -13,7 +17,7 @@ jobs:
 
     services:
       mariadb:
-        image: mariadb:10.6
+        image: mariadb:10.11.11
         env:
           MARIADB_ROOT_PASSWORD: root
           MARIADB_DATABASE: lobsters_dev
@@ -26,7 +30,7 @@ jobs:
       RUBY_YJIT_ENABLE: "1"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
@@ -52,7 +56,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
@@ -67,7 +71,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
@@ -82,7 +86,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -62,7 +62,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.4.1
           bundler-cache: true
 
       - name: Run linters
@@ -79,7 +78,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.4.1
           bundler-cache: true
 
       - name: Run brakeman
@@ -96,7 +94,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.4.1
           bundler-cache: true
 
       - name: Find leaky gems

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,7 +15,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-    - uses: actions/stale@v5
+    - uses: actions/stale@v9
       with:
         stale-pr-message: "This PR has had no activity for 21 days. Please leave a comment or commit to indicate you're still actively working on it."
         close-pr-message: "This PR was closed because it was open for 28 days with no activity. Please reopen when you'd like to continue work on this."


### PR DESCRIPTION
This commit does following

- bump mariadb to be in sync with the latest setup on prod to 10.11.11
- update all actions/checkout to v4
- update the state action to v9 (latest stable)
- Also, implement a cocurrency check to cancel in progress CI runs when a new commit is pushed to cancel the old run.

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
