### PR TITLE
Allow nav to spill into the right padding on mobile

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1555,7 +1555,7 @@ input[type="submit"].link_post.pushover_button {
 	}
 
 	body {
-		grid-template-columns: [begin] max-content [main] 1fr [right] max-content [end] 0.5rem;
+		grid-template-columns: [begin] max-content [main] 1fr [right] max-content [end] 0.5rem [padding];
 	}
 
 	#inside {
@@ -1580,6 +1580,7 @@ input[type="submit"].link_post.pushover_button {
 		height: 44px;
 		min-width: 100%;
 		padding-top: 0.75rem;
+		grid-column: begin / padding;
 	}
 	header#nav nav.links {
 		flex-wrap: nowrap;
@@ -1612,7 +1613,7 @@ input[type="submit"].link_post.pushover_button {
 	}
 	header#subnav {
 		background-color: var(--color-box-bg-shaded);
-		grid-column: begin / -1;
+		grid-column: begin / padding;
 	}
 	header#subnav a:last-child {
 		margin-right: 0.5rem;


### PR DESCRIPTION
I forgot that the nav's `grid-column: 1 / -1` was load-bearing, in that the last column on mobile is some right padding. I've made it more clear what's going on there.

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
