### PR TITLE
Add the <div> workaround everywhere comments are rendered

### DIFF
--- a/app/views/comments/_postedreply.html.erb
+++ b/app/views/comments/_postedreply.html.erb
@@ -1,5 +1,5 @@
 <%# locals: (comment:, show_tree_lines: true) -%>
 <li class="comments_subtree">
   <%= render "comments/comment", :comment => comment, :show_tree_lines => show_tree_lines %>
-  <ol class="comments"></ol>
+  <div><ol class="comments"></ol></div>
 </li>

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -12,7 +12,7 @@
     <% end %>
     <li><%= render "comments/comment", :comment => comment,
       :show_story => true %>
-      <ol class="comments"></ol>
+      <div><ol class="comments"></ol></div>
     </li>
   <% end %>
 </ol>

--- a/app/views/replies/show.html.erb
+++ b/app/views/replies/show.html.erb
@@ -11,7 +11,7 @@
             show_story: true,
             is_unread: reply.is_unread,
             show_tree_lines: false %>
-        <ol class="comments"></ol>
+        <div><ol class="comments"></ol></div>
       </li>
     <% end %>
   </ol>


### PR DESCRIPTION
In several places, we fake a thread by manually creating an empty list of children. Add the `<div>` workaround in those places so the styling can apply consistently.

This is yet another commit to revert when we solve this properly. On the bright side, that should be all the more satisfying.

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
