### PR TITLE
Fix styling of "Banned user" on users/show

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -15,8 +15,7 @@
 
   <div class="labelled_grid">
     <label class="required">Status</label>
-    <span>
-    <%= @showing_user.is_banned? ? raw("style=\"color: red;\"") : "" %>
+    <span <%= @showing_user.is_banned? ? raw("style=\"color: red;\"") : "" %>>
       <% if @showing_user.is_banned? %>
         Banned user
       <% elsif !@showing_user.is_active? %>


### PR DESCRIPTION
This fixes the regression in  c4a68b9d4c9547e38350a9027262e5e341b7f7c7 (see show.html.erb:18) that rendered style attribute outside of tag.
