### PR TITLE
Remove unused nested selector rules

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -237,9 +237,6 @@ input[type="submit"].disowner-form,
 	text-decoration: none;
 	cursor: pointer;
 	outline: none;
-	&:not(.disable):hover {
-		color: var(--color-fg-contrast-4-5);
-	}
 }
 
 button,


### PR DESCRIPTION
Originally noticed this because it uses the CSS nested selector: a more recent addition. The colour is the same as applied without :hover, and as far as I can see there is no "disable" class, so I don't believe we need this block.

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
