### PR TITLE
Use the <time> element for display how_long_ago_labels

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -164,11 +164,10 @@ module ApplicationHelper
 
   def how_long_ago_label(time)
     ago = how_long_ago(time)
-    content_tag(:span, ago, title: time.strftime("%F %T %z"))
+    content_tag(:time, ago, title: time.strftime("%F %T %z"), datetime: time.strftime("%F %T%z"))
   end
 
   def how_long_ago_link(url, time)
-    ago = how_long_ago(time)
-    content_tag(:a, ago, href: url, title: time.strftime("%F %T %z"))
+    content_tag(:a, how_long_ago_label(time), href: url)
   end
 end


### PR DESCRIPTION
Use `<time>` instead of `<span>` for these labels, to ensure the times are machine-readable. This doesn't affect the text that appears when a user hovers, though that has a different format than the machine-readable portion.

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
