### PR TITLE
Lay out the pages for private messages using CSS Grid

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1203,6 +1203,12 @@ label.required {
 	vertical-align: middle;
 }
 
+.row {
+	display: flex;
+	gap: 1rem;
+	flex-wrap: wrap;
+}
+
 .labelled_grid {
 	display: grid;
 	grid-template-columns: minmax(10rem, min-content) 1fr;
@@ -1211,7 +1217,8 @@ label.required {
 	row-gap: 12px;
 }
 
-.labelled_grid textarea {
+.labelled_grid textarea,
+.labelled_grid input[type="text"] {
 	width: 100%;
 	box-sizing: border-box;
 }
@@ -1219,6 +1226,7 @@ label.required {
 .labelled_grid input[type="checkbox"] {
 	margin: 0;
 	vertical-align: middle;
+	width: min-content;
 }
 
 .labelled_grid input[type="radio"] {

--- a/app/views/messages/_form.html.erb
+++ b/app/views/messages/_form.html.erb
@@ -2,42 +2,31 @@
 <%= form_with model: new_message, url: new_message, method: :post do |f| %>
   <%= errors_for new_message %>
 
-  <% if replying %>
-      <%= f.hidden_field :recipient_username  %>
-  <% else %>
-    <div class="boxline">
-      <%= f.label :recipient_username, "To:", :class => "required" %>
-      <%= f.text_field :recipient_username, :size => 20 %>
-    </div>
-  <% end %>
+  <div class="labelled_grid">
+    <% if replying %>
+        <%= f.hidden_field :recipient_username  %>
+    <% else %>
+      <%= f.label :recipient_username, "To", :class => "required" %>
+      <%= f.text_field :recipient_username %>
+    <% end %>
 
-  <div class="boxline">
-    <%= f.label :subject, "Subject:", :class => "required" %>
-    <%= f.text_field :subject, :style => "width: 500px;",
-      :maxlength => 100 %>
-  </div>
+    <%= f.label :subject, "Subject", :class => "required" %>
+    <%= f.text_field :subject, :maxlength => 100 %>
 
-  <div class="boxline">
-    <%= f.label :body, "Message:", :class => "required" %>
-    <%= f.text_area :body, :style => "width: 500px;", :rows => 5 %>
-  </div>
+    <%= f.label :body, "Message", :class => "required" %>
+    <%= f.text_area :body, :rows => 5 %>
 
-  <% if @user.wearable_hats.load.any? %>
-    <div class="boxline">
-      <%= f.label :hat_id, 'Put on hat:' %>
+    <% if @user.wearable_hats.load.any? %>
+      <%= f.label :hat_id, 'Put on hat' %>
       <%= f.select :hat_id, options_for_select( [['','']] +
         @user.wearable_hats.map{|h| [h.hat, { 'data-modnote' => h.modlog_use }, h.short_id] }
       ) %>
       <% if @user.is_moderator? %>
-        &nbsp;&nbsp;
-        <%= f.check_box 'mod_note', class: 'normal' %>
         <%= f.label :mod_note, 'ModNote', class: 'normal' %>
+        <%= f.check_box 'mod_note', class: 'normal' %>
       <% end %>
-    </div>
-  <% end %>
-
-  <div class="boxline">
-    <p></p>
-    <%= f.submit replying ? "Reply" : "Send Message" %>
+    <% end %>
   </div>
+
+  <%= f.submit replying ? "Reply" : "Send Message" %>
 <% end %>

--- a/app/views/messages/index.html.erb
+++ b/app/views/messages/index.html.erb
@@ -1,54 +1,48 @@
 <%= render partial: 'subnav' %>
 
-<div class="box wide">
-  <% if @messages.any? %>
-    <%= form_with url: batch_delete_messages_path do |f| %>
-      <table class="data zebra with_select_all" width="100%" cellspacing=0>
-      <tr>
-        <th width="3%"></th>
-        <th width="15%"><%= @direction == :in ? "From" : "To" %></th>
-        <th width="17%"><%= @direction == :in ? "Received" : "Sent" %></th>
-        <th width="60%">Subject</th>
-      </tr>
-      <% @messages.each do |message| %>
-        <tr class="<%= message.has_been_read? ? "" : "bold" %>">
-          <td><%= check_box_tag "delete_#{message.short_id}" %></td>
-          <td>
-            <div style="white-space:nowrap;">
-              <% if @direction == :in %>
-                <% if message.author %>
-                  <%= styled_user_link message.author %>
-                <% else %>
-                  <%= message.author_username %>
-                <% end %>
-                <%= message.hat.to_html_label if message.hat %>
+<% if @messages.any? %>
+  <%= form_with url: batch_delete_messages_path do |f| %>
+    <table class="data zebra with_select_all" width="100%" cellspacing=0>
+    <tr>
+      <th width="3%"></th>
+      <th width="15%"><%= @direction == :in ? "From" : "To" %></th>
+      <th width="17%"><%= @direction == :in ? "Received" : "Sent" %></th>
+      <th width="60%">Subject</th>
+    </tr>
+    <% @messages.each do |message| %>
+      <tr class="<%= message.has_been_read? ? "" : "bold" %>">
+        <td><%= check_box_tag "delete_#{message.short_id}" %></td>
+        <td>
+          <div style="white-space:nowrap;">
+            <% if @direction == :in %>
+              <% if message.author %>
+                <%= styled_user_link message.author %>
               <% else %>
-                <%= styled_user_link message.recipient %>
+                <%= message.author_username %>
               <% end %>
-            </div>
-          </td>
-          <td><%= how_long_ago_label(message.created_at) %></td>
-          <td><a href="/messages/<%= message.short_id %>"><%= message.subject
-            %></a></td>
-        </tr>
-      <% end %>
-      </table>
-      <p>
-      <%= f.submit "Delete Selected" %>
-      </p>
+              <%= message.hat.to_html_label if message.hat %>
+            <% else %>
+              <%= styled_user_link message.recipient %>
+            <% end %>
+          </div>
+        </td>
+        <td><%= how_long_ago_label(message.created_at) %></td>
+        <td><a href="/messages/<%= message.short_id %>"><%= message.subject
+          %></a></td>
+      </tr>
     <% end %>
-  <% else %>
-    <p>
-    You do not have any <%= @direction == :in ? "" : "sent" %> private
-      messages.
-    </p>
+    </table>
+    <%= f.submit "Delete Selected" %>
   <% end %>
-
-  <br>
-
+<% else %>
   <p>
-    Compose Message
+  You do not have any <%= @direction == :in ? "" : "sent" %> private
+    messages.
   </p>
+<% end %>
 
-  <%= render partial: 'form', locals: { new_message: @new_message, replying: false } %>
-</div>
+<p>
+  Compose Message
+</p>
+
+<%= render partial: 'form', locals: { new_message: @new_message, replying: false } %>

--- a/app/views/messages/show.html.erb
+++ b/app/views/messages/show.html.erb
@@ -1,61 +1,47 @@
 <%= render partial: 'subnav' %>
 
-<div class="box wide">
-  <h2>
-    From
-    <% if @message.author %>
-      <%= styled_user_link @message.author %>
-    <% else %>
-      <%= @message.author_username %>
-    <% end %>
-    <%= @message.hat.to_html_label if @message.hat %>
-    to
-    <%= styled_user_link @message.recipient %>
-    <%= how_long_ago_label(@message.created_at) %>
-  </h2>
-
-  <div class="boxline comment_text">
-    <%= raw @message.linkified_body %>
-  </div>
-
-  <br>
-
-  <div class="boxline">
-    <div style="float: left;">
-      <%= form_with url: message_path(@message.short_id), method: :delete do |f| %>
-        <%= f.submit "Delete Message" %>
-      <% end %>
-    </div>
-
-    <div style="float: left; padding-left: 1em;">
-      <%= form_with url: message_keep_as_new_path(@message.short_id), method: :post do |f| %>
-        <%= f.submit "Keep As New" %>
-      <% end %>
-    </div>
-
-    <% if @user.is_moderator? %>
-      <div style="float: left; padding-left: 1em;">
-        <%= form_with url: message_mod_note_path(@message.short_id), method: :post do |f| %>
-          <%= f.submit "ModNote" %>
-        <% end %>
-      </div>
-    <% end %>
-  </div>
-
-  <div style="clear: both;"></div>
-
-  <br>
-
-  <% if @new_message %>
-    <p>
-      Compose Reply
-      <% if @new_message %>
-        To <%= @new_message.recipient_username %>
-      <% end %>
-    </p>
-
-    <%= render partial: 'form', locals: { new_message: @new_message, replying: true } %>
+<h2>
+  From
+  <% if @message.author %>
+    <%= styled_user_link @message.author %>
   <% else %>
-    For help with this message, contact <%= link_to 'a moderator', moderators_path %>.
+    <%= @message.author_username %>
+  <% end %>
+  <%= @message.hat.to_html_label if @message.hat %>
+  to
+  <%= styled_user_link @message.recipient %>
+  <%= how_long_ago_label(@message.created_at) %>
+</h2>
+
+<div class="comment_text">
+  <%= raw @message.linkified_body %>
+</div>
+
+<div class="row">
+  <%= form_with url: message_path(@message.short_id), method: :delete do |f| %>
+    <%= f.submit "Delete Message" %>
+  <% end %>
+
+  <%= form_with url: message_keep_as_new_path(@message.short_id), method: :post do |f| %>
+    <%= f.submit "Keep As New" %>
+  <% end %>
+
+  <% if @user.is_moderator? %>
+    <%= form_with url: message_mod_note_path(@message.short_id), method: :post do |f| %>
+      <%= f.submit "ModNote" %>
+    <% end %>
   <% end %>
 </div>
+
+<% if @new_message %>
+  <p>
+    Compose Reply
+    <% if @new_message %>
+      To <%= @new_message.recipient_username %>
+    <% end %>
+  </p>
+
+  <%= render partial: 'form', locals: { new_message: @new_message, replying: true } %>
+<% else %>
+  For help with this message, contact <%= link_to 'a moderator', moderators_path %>.
+<% end %>


### PR DESCRIPTION
This was pretty smooth, requiring only a few changes to the stylesheet itself. Hopefully as this work goes on it'll just be a matter of putting the appropriate classes in the appropriate places.

The table for the list of messages is still laid out with manual percentage widths. This might be worth changing at some point, but for now I'm aiming to standardise the common page structures, rather than the unique elements.

This is work towards #1279 

<details>
<summary>Some rather uninteresting screenshots</summary>

![image](https://github.com/user-attachments/assets/6202232e-fdee-47f8-974e-9bddd039edeb)

![Screenshot 2025-05-17 at 22-40-59 Messages Lobsters](https://github.com/user-attachments/assets/a43f1c73-b3e8-4ea8-b47a-b441bc1746b2)


![image](https://github.com/user-attachments/assets/d4c8eeef-f36f-48af-9856-a4773ab8f335)

![Screenshot 2025-05-17 at 22-41-21 test to me! Lobsters](https://github.com/user-attachments/assets/153b3e64-0018-4d76-9577-9aa0fa0ce33b)

</details>

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
