### PR TITLE
Stop inserting the custom lobster emoji list marker manually

### DIFF
--- a/app/views/about/about.html.erb
+++ b/app/views/about/about.html.erb
@@ -359,9 +359,8 @@
     There is an <a href="https://push.cx/stream">archive with transcripts</a> available.
   </li>
 
-  <li id="emoji" style="list-style: none; position: relative; left: -1em;">
-  <span style="float: left; line-height: 1.5em;">🦞</span>
-  <p style="padding-left: 1em;">
+  <li id="emoji" style="list-style: '🦞';">
+  <p>
   <a href="https://unicode.org/consortium/adopted-characters.html#s1f99E">Sponsor of the lobster emoji</a>:
   In February 2018, Lobsters <a href="https://lobste.rs/s/pnysdr/lobsters_emoji_adoption">held a fundraiser</a>
   to officially adopt the new lobster emoji in support of the Unicode Foundation.


### PR DESCRIPTION
This makes things line up a bit nicer, though sadly for me the aesthetic center of the lobster emoji still doesn't match that of the disc markers.

Before:
![image](https://github.com/user-attachments/assets/13f4d1be-15b8-457f-b6bc-630383e782a3)

After:
![image](https://github.com/user-attachments/assets/e8c03469-6e48-4ae7-9b62-ef28f2b56b91)


<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
