### PR TITLE
Fall back to current time for tag created_at and updated_at

### DIFF
--- a/db/migrate/20250521131204_temporal_tokens.rb
+++ b/db/migrate/20250521131204_temporal_tokens.rb
@@ -12,8 +12,8 @@ class TemporalTokens < ActiveRecord::Migration[8.0]
       first_use = tag.stories.order(created_at: :asc).pick(:created_at)
       latest_edit = Moderation.where(tag: tag).order(created_at: :desc).pick(:created_at)
       tag.update_columns({
-        created_at: first_use,
-        updated_at: latest_edit || first_use
+        created_at: first_use || Time.current,
+        updated_at: latest_edit || first_use || Time.current
       })
     end
     change_column :tags, :created_at, :datetime, null: false


### PR DESCRIPTION
If a tag isn't used on any stories, created_at and updated_at would be null, which would error when the NOT NULL constraints are added.

(marked @pushcx as author, the patch was originally in non-machine-readable form over IRC)

Closes #1583 

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
