### PR TITLE
Port `fill_flagged_cache` to an ActiveJob

### DIFF
--- a/app/jobs/fill_flagged_cache_job.rb
+++ b/app/jobs/fill_flagged_cache_job.rb
@@ -1,0 +1,8 @@
+class FillFlaggedCacheJob < ApplicationJob
+  queue_as :default
+
+  # fills the cache - used by app/views/users/show.html.erb for mods
+  def perform(*args)
+    FlaggedCommenters.new("1m").commenters
+  end
+end

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -15,6 +15,10 @@ production:
     class: ClearFinishedJobsJob
     queue: background
     schedule: every day at 3:00am
+  fill_flagged_cache:
+    class: FillFlaggedCacheJob
+    queue: background
+    schedule: every 10 minutes
 
 development:
   expire_old_ribbons:
@@ -33,3 +37,7 @@ development:
     class: ClearFinishedJobsJob
     queue: background
     schedule: every day at 3:00am
+  fill_flagged_cache:
+    class: FillFlaggedCacheJob
+    queue: background
+    schedule: every 10 minutes

--- a/script/fill_flagged_cache.rb
+++ b/script/fill_flagged_cache.rb
@@ -1,7 +1,0 @@
-#!/usr/bin/env ruby
-
-require File.expand_path("../../config/environment", __FILE__)
-
-# fills the cache - used by app/views/users/show.html.erb for mods
-
-FlaggedCommenters.new("1m").commenters


### PR DESCRIPTION
Howdy! This PR resolves one small chunk of issue #1548. I start by porting only the `fill_flagged_cache` job, because my Rails is a tad rusty and I wanted to make sure I'm doin' it right before I tackle a larger chunk.

See the `lobsters-ansible` sister PR for cleanup of the cron job: lobsters/lobsters-ansible#89

Wasn't sure what order you'd prefer to ship the ActiveJob vs. the cron removal. I figure if you shipped the ActiveJob first, `fill_flagged_cache` would run twice for a while and I wasn't sure if it was idempotent. So I structured this as though the cron job would be taken offline first in the other PR, then this would ship second. Let me know if this is incorrect and I can restructure accordingly.

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
