### PR TITLE
Sort 'vibecoding' above 'ai' in TomSelect

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -354,7 +354,10 @@ export class _LobstersFunction {
       hideSelected: true,
       closeAfterSelect: true,
       selectOnTab: true,
-      sortField: {field: "data-value"},
+      sortField: [
+        {field: "sortWeight", direction: "desc"},
+        {field: "value", direction: "asc"}
+      ],
       onInitialize: function() {
         const parent = qS('.ts-control');
         parent.appendChild(qS('.ts-dropdown'));

--- a/app/views/stories/_form.html.erb
+++ b/app/views/stories/_form.html.erb
@@ -57,7 +57,7 @@
           (t.filtered_count == 1 ? "" : "s") << " filtering</em>"
       end
 
-      [ "#{t.tag} - #{t.description}", t.tag, { "data-title" => raw(html), "data-tag-css" => t.css_class } ]},
+      [ "#{t.tag} - #{t.description}", t.tag, { "data-title" => raw(html), "data-tag-css" => t.css_class, "data-sort-weight" => (t.tag == "vibecoding") ? 1 : 0 } ]},
     f.object.tags.map(&:tag)), {}, { :multiple => true } %>
   </div>
 


### PR DESCRIPTION
I don't think I explained this very well during office hours, but it turns out TomSelect uses the `dataset` of the `<option>`s, which [converts kebab-case names from the HTML into camelCase names in JS](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/dataset#in_javascript). You have to use the latter to refer to attributes for sorting.

I don't think the prior `data-value` sort was working before, but because the elements were in the right order to begin with, it didn't matter.

Closes #1595

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
