### PR TITLE
Fix sitemap generation

### DIFF
--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -6,7 +6,7 @@ check_hourly = 4.days.ago
 check_daily = 2.weeks.ago
 top_score = Story.all.maximum("score")
 
-SitemapGenerator::Sitemap.create! do
+SitemapGenerator::Sitemap.create do
   %w[/about /chat].each do |path|
     add path, changefreq: "monthly", lastmod: nil
   end


### PR DESCRIPTION
Fix this issue over here - https://github.com/lobsters/lobsters/issues/1496

It's not my first PR here so my apologies for stealing `good first issue` from other people. I just wanted to generate a sitemap locally and noticed this issue which I then found already created. 

The issue was introduced here - https://github.com/lobsters/lobsters/commit/2332d2802254af5d77ff4808a69b42523fdae4c3 
I'm unable to find reasoning behind this change and I can't find proofs that `create!` has ever existed in `sitemap_generator` gem. Probably that `!` was just introduced by accident. 

Hope it's gonna fix the cronjob you have in prod.

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
