### PR TITLE
Restore previous upvoter sizing

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -469,6 +469,7 @@ div.voters {
 	align-items: center;
 	justify-self: center;
 	text-decoration: none;
+	font-size: 9.5pt;
 }
 
 li.story {
@@ -1621,7 +1622,7 @@ input[type="submit"].link_post.pushover_button {
 	div.voters {
 		margin-left: 0.25em;
 		margin-top: 0px;
-		width: 20px;
+		width: 30px;
 	}
 
 	div.comment_form_container {
@@ -1721,7 +1722,7 @@ input[type="submit"].link_post.pushover_button {
 	}
 
 	li div.details {
-		margin: 0 0 0 26px;
+		margin: 0 0 0 36px;
 	}
 	div.story_content {
 		margin: 0 0 0 28px;


### PR DESCRIPTION
As part of the revert of the grid, these sizes changed from what they were beforehand. This has caused stories with three-digit scores to break onto a new line on mobile.

Closes #1599

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
