### PR TITLE
Port over the sitemap refresh cron job to an ActiveJob

### DIFF
--- a/app/jobs/refresh_sitemap_job.rb
+++ b/app/jobs/refresh_sitemap_job.rb
@@ -1,0 +1,7 @@
+class RefreshSitemapJob < ApplicationJob
+  queue_as :default
+
+  def perform(*args)
+    SitemapGenerator::Interpreter.run(config_file: ENV["CONFIG_FILE"], verbose: false)
+  end
+end

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -19,6 +19,10 @@ production:
     class: FillFlaggedCacheJob
     queue: background
     schedule: every 10 minutes
+  refresh_sitemap:
+    class: RefreshSitemapJob
+    queue: background
+    schedule: every day at 12:00am
 
 development:
   expire_old_ribbons:
@@ -41,3 +45,7 @@ development:
     class: FillFlaggedCacheJob
     queue: background
     schedule: every 10 minutes
+  refresh_sitemap:
+    class: RefreshSitemapJob
+    queue: background
+    schedule: every day at 12:00am


### PR DESCRIPTION
This PR does another chunk of #1548: the sitemap job. A sister PR, lobsters/lobsters-ansible#90, cleans up the cron.