### PR TITLE
Don't ignore other classes on current_page in link_to_different_page

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -89,7 +89,7 @@ module ApplicationHelper
   def link_to_different_page(text, path, options = {})
     current = request.path.sub(/\/page\/\d+$/, "")
     path.sub!(/\/page\/\d+$/, "")
-    options[:class] = :current_page if current == path
+    options[:class] = class_names(options[:class], current_page: current == path)
     link_to text, path, options
   end
 


### PR DESCRIPTION
This fixes an issue on /login on mobile where the login link appears in the navbar twice, because `current_page` beats out `corner` in the first list of links.

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
