### PR TITLE
Reinstate `/top/rss` and allow RSS for any `/top/…/rss` path

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -290,7 +290,11 @@ class HomeController < ApplicationController
   def top
     length = time_interval(params[:length])
     if length[:placeholder]
-      return redirect_to(top_path(length: "1w"))
+      respond_to do |format|
+        format.html { redirect_to top_path(length: "1w") }
+        format.rss { redirect_to "/top/1w/rss" }
+      end
+      return
     end
 
     @stories, @show_more = get_from_cache(top: true, length: length) {
@@ -307,7 +311,7 @@ class HomeController < ApplicationController
 
     @rss_link ||= {
       title: "RSS 2.0 - " + @title,
-      href: "/top/rss"
+      href: "/top/#{length[:param]}/rss"
     }
 
     respond_to do |format|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,7 @@ Rails.application.routes.draw do
   get "/upvoted", to: redirect("/upvoted/stories")
   get "/upvoted/page/:page", to: redirect("/upvoted/stories/page/%{page}")
 
-  get "/top/rss" => "home#top", :format => "rss"
+  get "/top(/:length(/page/:page))/rss" => "home#top", :format => "rss"
   get "/top(/:length(/page/:page))" => "home#top", :as => "top"
 
   get "/threads" => "comments#user_threads"

--- a/spec/routing/home_spec.rb
+++ b/spec/routing/home_spec.rb
@@ -16,4 +16,30 @@ describe "home routing" do
       "/domains/example.com.rss"
     )
   end
+
+  describe "top" do
+    it "routes /top" do
+      expect(get("/top")).to route_to("home#top")
+    end
+
+    it "routes /top/rss" do
+      expect(get("/top/rss")).to route_to("home#top", format: "rss")
+    end
+
+    it "routes /top/1w" do
+      expect(get("/top/1w")).to route_to("home#top", length: "1w")
+    end
+
+    it "routes /top/1w/rss" do
+      expect(get("/top/1w/rss")).to route_to("home#top", length: "1w", format: "rss")
+    end
+
+    it "routes /top/1w/page/2" do
+      expect(get("/top/1w/page/2")).to route_to("home#top", length: "1w", page: "2")
+    end
+
+    it "routes /top/1w/page/2/rss" do
+      expect(get("/top/1w/page/2/rss")).to route_to("home#top", length: "1w", page: "2", format: "rss")
+    end
+  end
 end


### PR DESCRIPTION
## What?

- [x] Added routing specs to ensure we end up in the right action with correct params
- [x] Wire up any `/top/…/rss` path to controller endpoint
- [x] Add controller specs for HTML/RSS feeds
- [x] Fix redirect bug in `home#top` when accessing with `format: "rss"`

## Why?

Fixes #1602, and adds additional functionality for the top feeds because its easier to do that than only allow the `/top/:length/rss` feeds.

Technically `/top/rss` isn't a valid feed anymore, but it redirects to `/top/1w/rss` which is now a valid feed and any well behaved feed reader should handle that. The upside is you can subscribe to a feed of any length you want now, eg `/top/1m/rss` or `/top/3d/rss`.

Closes #1606 I think, one of the tests is incorrect and the other is better tested in the routing/controller specs here.