### PR TITLE
Add a CSP header in report-only mode

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -7,21 +7,25 @@
 # https://guides.rubyonrails.org/security.html#content-security-policy-header
 
 Rails.application.configure do
-  #  18 inline styles to clean up before enabling this
-  #  config.content_security_policy do |policy|
-  #    policy.connect_src :self, :https
-  #    policy.default_src :self, :https
-  #    policy.font_src :self, :https, :data
-  #    policy.img_src :self, :https, :data
-  #    policy.object_src :none
-  #    policy.script_src :self, :https
-  #    policy.style_src :self, :https
-  #    policy.report_uri "/csp-violation-report"
-  #  end
+  config.content_security_policy do |policy|
+    policy.default_src :none
 
-  # Generate session nonces for permitted importmap, inline scripts, and inline styles.
-  config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-  config.content_security_policy_nonce_directives = %w[script-src style-src]
+    # Needed for AJAX calls, mini-profiler
+    policy.connect_src :self
+
+    # Data URL used for Pushover logo in settings
+    policy.img_src :self, :data
+    policy.script_src :self
+
+    # 18 inline styles to clean up before enabling this
+    policy.style_src :self, :unsafe_inline
+
+    policy.report_uri "/csp-violation-report"
+  end
+
+  # Generate session nonces for permitted importmap and inline scripts.
+  config.content_security_policy_nonce_generator = ->(request) { SecureRandom.base64(16) }
+  config.content_security_policy_nonce_directives = %w[script-src]
 
   # Report violations without enforcing the policy.
   config.content_security_policy_report_only = true

--- a/hatchbox/Caddyfile.pre
+++ b/hatchbox/Caddyfile.pre
@@ -57,3 +57,5 @@ redir @www_domain https://lobste.rs{uri} 302
 rewrite @visitor /cache/{file_match.relative}
 # header @visitor X-Lobsters-Visitor {file_match.relative}
 # header X-Lobsters-Hello "World 8"
+
+header @visitor ?Content-Security-Policy-Report-Only "default-src 'none'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; report-uri /csp-violation-report"


### PR DESCRIPTION
This is a tighter policy than the one commented out before. Due to the JavaScript importmap counting as an inline script, we need to use nonces to allow that without also allowing all inline scripts.

This switches to a random nonce rather than deriving it from the session. The benefit of the session ID approach is to enable conditional caching, but the site does not make use of this. Using a random nonce reduces the chance of security issues (for example, logging in currently doesn't reset the session as far as I can see) and means we can generate nonces for guest requests who hit Rails.

For guest users who hit the cache, we need to set a CSP in Caddy as well. As we can't use nonces here, I've opted to disallow scripts altogether. This approach fails an edge case on the signup page, where a guest user is served JavaScript for the markdown formatting dropdown. In this situation, that script and functionality won't work. I've marked this PR a draft for that reason, so we can discuss how we want to handle that.

For now this is all using report-only mode so that any oversights don't break the site for users.

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
