### PR TITLE
Refactor StoryRepository: newest_by_user method

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -112,7 +112,7 @@ class HomeController < ApplicationController
   def newest_by_user
     by_user = User.find_by!(username: params[:user])
 
-    @stories, @show_more = paginate stories.newest_by_user(by_user)
+    @stories, @show_more = paginate Story.newest_by_user(@user, by_user)
 
     @title = "Newest Stories by #{by_user.username}"
     @above = {partial: "newest_by_user", locals: {newest_by_user: by_user}}

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -148,6 +148,14 @@ class Story < ApplicationRecord
       .order(:hotness)
   }
 
+  scope :newest_by_user, ->(user, submitter) {
+    where(user: submitter)
+      .includes(:tags)
+      .not_deleted(user)
+      .mod_preload?(user)
+      .order(id: :desc)
+  }
+
   include Token
 
   validates :title, length: {in: 3..150}, presence: true

--- a/app/models/story_repository.rb
+++ b/app/models/story_repository.rb
@@ -12,11 +12,6 @@ class StoryRepository
     Story.base(@user).positive_ranked.where(id: tagged_story_ids).order(created_at: :desc)
   end
 
-  def newest_by_user(user)
-    # Story.base without unmerged scope
-    Story.where(user: user).includes(:tags).not_deleted(@user).mod_preload?(@user).order(id: :desc)
-  end
-
   def tagged(tags)
     tagged_story_ids = Tagging.select(:story_id).where(tag_id: tags.map(&:id))
 

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -109,6 +109,21 @@ describe HomeController do
     end
   end
 
+  describe "#newest_by_user" do
+    it "includes stories" do
+      by_user = create :user, username: "by_user"
+
+      story = create :story, user: by_user, title: "By user story"
+
+      stub_login_as user
+      get :newest_by_user, params: {user: by_user}
+
+      expect(response).to be_successful
+      expect(@controller.view_assigns["title"]).to eq("Newest Stories by #{by_user.username}")
+      expect(@controller.view_assigns["stories"].map(&:title)).to include(story.title)
+    end
+  end
+
   describe "#saved" do
     it "includes only saved stories by user" do
       saved_story = create(:story)

--- a/spec/models/story_repository_spec.rb
+++ b/spec/models/story_repository_spec.rb
@@ -6,46 +6,6 @@ describe StoryRepository do
   let(:submitter) { create(:user) }
   let(:repo) { StoryRepository.new(submitter) }
 
-  describe ".newest_by_user" do
-    context "when submitter is viewing their own stories" do
-      it "sees their stories" do
-        create(:story, user: submitter, title: "Own story")
-        expect(story_titles_from(submitter)).to include("Own story")
-      end
-
-      it "sees their own deleted stories" do
-        create(:story, user: submitter, title: "deleted story", is_deleted: 1)
-        expect(story_titles_from(submitter)).to include("deleted story")
-      end
-
-      it "sees stories that were merged into others' stories" do
-        by_other = create(:story, title: "other story")
-        create(:story, user: submitter, title: "merged story", merged_into_story: by_other)
-
-        expect(story_titles_from(submitter)).to include("merged story")
-        expect(story_titles_from(submitter)).to_not include("other story")
-      end
-
-      it "sees their own stories merged into a story they submitted" do
-        own = create(:story, user: submitter, title: "own story")
-        create(:story, user: submitter, title: "merged story", merged_into_story: own)
-        expect(story_titles_from(submitter)).to include("own story")
-        expect(story_titles_from(submitter)).to include("merged story")
-      end
-
-      it "does not see stories by others merged into a story they submitted" do
-        own = create(:story, user: submitter, title: "own story")
-        create(:story, title: "by other", merged_into_story: own)
-        expect(story_titles_from(submitter)).to_not include("by other")
-      end
-    end
-
-    it "users don't see others' deleted stories" do
-      create(:story, user: submitter, title: "deleted story", is_deleted: 1)
-      expect(StoryRepository.new(nil).newest_by_user(submitter)).to_not include("deleted story")
-    end
-  end
-
   describe ".tagged" do
     it "selects unique tagged stories" do
       tag1 = create(:tag)

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -597,6 +597,53 @@ describe Story do
         expect(Story.saved(user)).to eq([first_story])
       end
     end
+
+    describe "newest_by_user" do
+      let(:user) { create(:user) }
+      let(:submitter) { create(:user) }
+
+      def story_titles_from(submitter:, basic: user)
+        Story.newest_by_user(basic, submitter).map(&:title)
+      end
+
+      context "when submitter is viewing their own stories" do
+        it "sees their stories" do
+          create(:story, user: submitter, title: "Own story")
+          expect(story_titles_from(submitter:)).to include("Own story")
+        end
+
+        it "sees their own deleted stories" do
+          create(:story, user: submitter, title: "deleted story", is_deleted: 1)
+          expect(story_titles_from(basic: submitter, submitter:)).to include("deleted story")
+        end
+
+        it "sees stories that were merged into others' stories" do
+          by_other = create(:story, title: "other story")
+          create(:story, user: submitter, title: "merged story", merged_into_story: by_other)
+
+          expect(story_titles_from(submitter:)).to include("merged story")
+          expect(story_titles_from(submitter:)).to_not include("other story")
+        end
+
+        it "sees their own stories merged into a story they submitted" do
+          own = create(:story, user: submitter, title: "own story")
+          create(:story, user: submitter, title: "merged story", merged_into_story: own)
+          expect(story_titles_from(submitter:)).to include("own story")
+          expect(story_titles_from(submitter:)).to include("merged story")
+        end
+
+        it "does not see stories by others merged into a story they submitted" do
+          own = create(:story, user: submitter, title: "own story")
+          create(:story, title: "by other", merged_into_story: own)
+          expect(story_titles_from(basic: nil, submitter:)).to_not include("by other")
+        end
+      end
+
+      it "users don't see others' deleted stories" do
+        create(:story, user: submitter, title: "deleted story", is_deleted: 1)
+        expect(story_titles_from(basic: nil, submitter:)).not_to include("deleted story")
+      end
+    end
   end
 
   describe "suggestions" do


### PR DESCRIPTION
removed `newest_by_user` method
<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
