### PR TITLE
add support for notifications 

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -455,6 +455,16 @@ ol.comments1 > li.comments_subtree > ol.comments {
 	font-weight: bold;
 }
 
+.hidden-notification {
+	padding-top: 0.4em;
+    padding-bottom: 0.4em;
+}
+
+.hidden-notification .icon {
+	float: left;
+	font-size: 20px;
+}
+
 div.voters {
 	float: left;
 	margin-top: 0px;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -447,6 +447,14 @@ ol.comments1 > li.comments_subtree > ol.comments {
 	padding-left: 0;
 }
 
+.message .voters {
+	font-size: 20px;
+}
+
+.message .message-subject {
+	font-weight: bold;
+}
+
 div.voters {
 	float: left;
 	margin-top: 0px;
@@ -806,7 +814,7 @@ div.story_text blockquote {
 }
 
 /* un-italicize italics inside a blockquote */
-div.comment_text blockquote em, 
+div.comment_text blockquote em,
 .markdown_help blockquote em,
 div.story_text blockquote em {
 	font-style: normal

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -13,7 +13,7 @@ class NotificationsController < ApplicationController
       .offset((@page - 1) * notifications_per_page)
       .limit(notifications_per_page)
       .order(created_at: :desc)
-      .includes(notifiable: {story: [:tags, :user], user: [], author: []})
+      .includes(user: [:hidings, :votes], notifiable: {story: [:tags, :user], user: [:comments], author: [], parent_comment: []})
 
     @has_more = @user.notifications.count > (@page * notifications_per_page)
 
@@ -28,7 +28,7 @@ class NotificationsController < ApplicationController
       .notifications
       .where(read_at: nil)
       .order(created_at: :desc)
-      .includes(notifiable: {story: [:tags, :user], user: [], author: []})
+      .includes(user: [:hidings, :votes], notifiable: {story: [:tags, :user], user: [:comments], author: [], parent_comment: []})
 
     respond_to do |format|
       format.html { render :all }

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -13,7 +13,7 @@ class NotificationsController < ApplicationController
       .offset((@page - 1) * notifications_per_page)
       .limit(notifications_per_page)
       .order(created_at: :desc)
-      .includes(notifiable: [:user, :author])
+      .includes(notifiable: {story: [:tags, :user], user: [], author: []})
 
     @has_more = @user.notifications.count > (@page * notifications_per_page)
 
@@ -28,7 +28,7 @@ class NotificationsController < ApplicationController
       .notifications
       .where(read_at: nil)
       .order(created_at: :desc)
-      .includes(notifiable: [:user, :author])
+      .includes(notifiable: {story: [:tags, :user], user: [], author: []})
 
     respond_to do |format|
       format.html { render :all }

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,0 +1,53 @@
+# typed: false
+
+class NotificationsController < ApplicationController
+  before_action :require_logged_in_user
+  before_action :set_page, only: [:all]
+  after_action :update_read_at
+
+  def all
+    notifications_per_page = 25
+
+    @notifications = @user
+      .notifications
+      .offset((@page - 1) * notifications_per_page)
+      .limit(notifications_per_page)
+      .order(created_at: :desc)
+      .includes(notifiable: [:user, :author])
+
+    @has_more = @user.notifications.count > (@page * notifications_per_page)
+
+    respond_to do |format|
+      format.html
+      format.json { render json: @notifications }
+    end
+  end
+
+  def unread
+    @notifications = @user
+      .notifications
+      .where(read_at: nil)
+      .order(created_at: :desc)
+      .includes(notifiable: [:user, :author])
+
+    respond_to do |format|
+      format.html { render :all }
+      format.json { render json: @notifications }
+    end
+  end
+
+  private
+
+  def update_read_at
+    @notifications.update_all(read_at: Time.current)
+  end
+
+  def set_page
+    @page = params[:page].to_i
+    if @page == 0
+      @page = 1
+    elsif @page < 0 || @page > (2**32)
+      raise ActionController::RoutingError.new("page out of bounds")
+    end
+  end
+end

--- a/app/jobs/notify_message_job.rb
+++ b/app/jobs/notify_message_job.rb
@@ -1,13 +1,15 @@
 class NotifyMessageJob < ApplicationJob
   queue_as :default
 
-  def perform(*args)
-    args.each do |arg|
-      deliver_message_notifications(arg)
+  def perform(*messages)
+    messages.each do |message|
+      deliver_message_notifications(message)
     end
   end
 
   def deliver_message_notifications(message)
+    message.recipient.notifications.create(notifiable: message)
+
     if message.recipient.email_messages?
       begin
         EmailMessageMailer.notify(message, message.recipient).deliver_now

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -26,6 +26,7 @@ class Comment < ApplicationRecord
     class_name: "Link",
     inverse_of: :to_comment,
     dependent: :destroy
+  has_many :notifications, as: :notifiable
 
   include Token
   attr_accessor :current_vote, :previewing, :vote_summary

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -12,6 +12,7 @@ class Message < ApplicationRecord
     optional: true
   belongs_to :hat,
     optional: true
+  has_many :notifications, as: :notifiable
 
   include Token
 

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -4,31 +4,37 @@ class Notification < ApplicationRecord
 
   include Token
 
-  def good?
+  GoodFaithResult = Struct.new(:good_faith?, :bad_properties)
+
+  def check_good_faith
     case notifiable
     when Message
-      good_message?
+      check_good_faith_message
     when Comment
-      good_comment?
+      check_good_faith_comment
     end
   end
 
-  def good_message?
-    true
+  def check_good_faith_message
+    GoodFaithResult.new(true, [])
   end
 
-  def good_comment?
+  def check_good_faith_comment
     comment = notifiable
     story = comment.story
     parent_comment = comment.parent_comment
 
-    good_story = story.score > story.flags
-    good_comment = comment.score > comment.flags && !comment.is_gone?
-    good_parent_comment = parent_comment.nil? ? true : parent_comment.score > parent_comment.flags && !parent_comment.is_gone?
-    user_has_flagged_replier = Vote.joins(:comment).where(user: user, story: story, vote: -1, comment: {user: comment.user}).any?
-    user_has_hidden_story = HiddenStory.where(user: user, story: story).any?
-    filtered_tags = story.tags & user.tag_filter_tags
+    bad_properties_to_check = []
 
-    good_story && good_comment && good_parent_comment && !user_has_flagged_replier && !user_has_hidden_story && filtered_tags.empty?
+    bad_properties_to_check << [:bad_story, story.score <= story.flags]
+    bad_properties_to_check << [:bad_comment, comment.score <= comment.flags || comment.is_gone?]
+    bad_properties_to_check << [:bad_parent_comment, parent_comment.nil? ? false : parent_comment.score <= parent_comment.flags || parent_comment.is_gone?]
+    bad_properties_to_check << [:user_has_flagged_replier, Vote.joins(:comment).where(user: user, story: story, vote: -1, comment: {user: comment.user}).any?]
+    bad_properties_to_check << [:user_has_hidden_story, HiddenStory.where(user: user, story: story).any?]
+    bad_properties_to_check << [:user_has_filtered_tags_on_story, !(story.tags & user.tag_filter_tags).empty?]
+
+    bad_properties = bad_properties_to_check.filter_map { |reason, flag| flag && reason }
+
+    GoodFaithResult.new(bad_properties.empty?, bad_properties)
   end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,0 +1,33 @@
+class Notification < ApplicationRecord
+  belongs_to :user
+  belongs_to :notifiable, polymorphic: true
+
+  include Token
+
+  def good?
+    case notifiable
+    when Message
+      good_message?
+    when Comment
+      good_comment?
+    end
+  end
+
+  def good_message?
+    true
+  end
+
+  def good_comment?
+    comment = notifiable
+    story = comment.story
+    parent_comment = comment.parent_comment
+
+    good_story = story.score > story.flags
+    good_comment = comment.score > comment.flags && !comment.is_gone?
+    good_parent_comment = parent_comment.nil? ? true : parent_comment.score > parent_comment.flags && !parent_comment.is_gone?
+    user_has_flagged_replier = Vote.joins(:comment).where(user: user, story: story, vote: -1, comment: {user: comment.user}).any?
+    user_has_hidden_story = HiddenStory.where(user: user, story: story).any?
+
+    good_story && good_comment && good_parent_comment && !user_has_flagged_replier && !user_has_hidden_story
+  end
+end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -29,8 +29,9 @@ class Notification < ApplicationRecord
     bad_properties_to_check << [:bad_story, story.score <= story.flags]
     bad_properties_to_check << [:bad_comment, comment.score <= comment.flags || comment.is_gone?]
     bad_properties_to_check << [:bad_parent_comment, parent_comment.nil? ? false : parent_comment.score <= parent_comment.flags || parent_comment.is_gone?]
-    bad_properties_to_check << [:user_has_flagged_replier, Vote.joins(:comment).where(user: user, story: story, vote: -1, comment: {user: comment.user}).any?]
-    bad_properties_to_check << [:user_has_hidden_story, HiddenStory.where(user: user, story: story).any?]
+    replier_comment_ids = comment.user.comments.filter_map { |c| (c.story_id == story.id) ? c.id : nil }
+    bad_properties_to_check << [:user_has_flagged_replier, !user.votes.filter { |v| v.story_id == story.id && v.vote == -1 && replier_comment_ids.include?(v.comment_id) }.empty?]
+    bad_properties_to_check << [:user_has_hidden_story, !user.hidings.filter { |h| h.story_id == story.id }.empty?]
     bad_properties_to_check << [:user_has_filtered_tags_on_story, !(story.tags & user.tag_filter_tags).empty?]
 
     bad_properties = bad_properties_to_check.filter_map { |reason, flag| flag && reason }

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -27,7 +27,8 @@ class Notification < ApplicationRecord
     good_parent_comment = parent_comment.nil? ? true : parent_comment.score > parent_comment.flags && !parent_comment.is_gone?
     user_has_flagged_replier = Vote.joins(:comment).where(user: user, story: story, vote: -1, comment: {user: comment.user}).any?
     user_has_hidden_story = HiddenStory.where(user: user, story: story).any?
+    filtered_tags = story.tags & user.tag_filter_tags
 
-    good_story && good_comment && good_parent_comment && !user_has_flagged_replier && !user_has_hidden_story
+    good_story && good_comment && good_parent_comment && !user_has_flagged_replier && !user_has_hidden_story && filtered_tags.empty?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -55,6 +55,7 @@ class User < ApplicationRecord
   has_many :wearable_hats, -> { where(doffed_at: nil) },
     class_name: "Hat",
     inverse_of: :user
+  has_many :notifications
 
   include Token
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -56,6 +56,10 @@ class User < ApplicationRecord
     class_name: "Hat",
     inverse_of: :user
   has_many :notifications
+  has_many :hidings,
+    class_name: "HiddenStory",
+    inverse_of: :user,
+    dependent: :destroy
 
   include Token
 

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (comment:, force_open: false, show_tree_lines: false, show_story: false, was_merged: false, is_unread: false) -%>
+<%# locals: (comment:, force_open: false, show_tree_lines: false, show_story: false, was_merged: false, is_unread: false, show_folder_control: true) -%>
 <%
   # partial inputs:
   # force_open: this comment is allowed to collapse
@@ -6,6 +6,7 @@
   # show_story: show "on: story title" end of byline
   # was_merged: show merged icon start of byline
   # is_unread: show (unread) in byline
+  # show_folder_control: whether to display the control to hide the comment
 %>
 <input id="comment_folder_<%= comment.short_id %>"
   class="comment_folder_button" type="checkbox"
@@ -28,7 +29,9 @@
   ">
 
   <div class="voters">
-    <label for="comment_folder_<%= comment.short_id %>" class="comment_folder"></label>
+    <% if show_folder_control %>
+      <label for="comment_folder_<%= comment.short_id %>" class="comment_folder"></label>
+    <% end %>
     <% if !comment.is_gone? %>
       <%= link_to comment.score_for_user(@user), (@user ? '': login_path), :class => "upvoter" %>
     <% elsif @user&.is_moderator? %>

--- a/app/views/comments/_threads.html.erb
+++ b/app/views/comments/_threads.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (thread:, story: nil, ribbon: nil) -%>
+<%# locals: (thread:, story: nil, ribbon: nil, show_folder_control: true) -%>
 <% previous_depth = nil %>
 <% top_comment_depth = nil %>
 <%# open list of threads %>
@@ -42,7 +42,7 @@
 
 <%#heinous_inline_partial(comments/_comment.html.erb)%>
 <%# Do not edit, the content before /heinous_inline_partial comes from the named partial %>
-<%# locals: (comment:, force_open: false, show_tree_lines: false, show_story: false, was_merged: false, is_unread: false) -%>
+<%# locals: (comment:, force_open: false, show_tree_lines: false, show_story: false, was_merged: false, is_unread: false, show_folder_control: true) -%>
 <%
   # partial inputs:
   # force_open: this comment is allowed to collapse
@@ -50,6 +50,7 @@
   # show_story: show "on: story title" end of byline
   # was_merged: show merged icon start of byline
   # is_unread: show (unread) in byline
+  # show_folder_control: whether to display the control to hide the comment
 %>
 <input id="comment_folder_<%= comment.short_id %>"
   class="comment_folder_button" type="checkbox"
@@ -72,7 +73,9 @@
   ">
 
   <div class="voters">
-    <label for="comment_folder_<%= comment.short_id %>" class="comment_folder"></label>
+    <% if show_folder_control %>
+      <label for="comment_folder_<%= comment.short_id %>" class="comment_folder"></label>
+    <% end %>
     <% if !comment.is_gone? %>
       <%= link_to comment.score_for_user(@user), (@user ? '': login_path), :class => "upvoter" %>
     <% elsif @user&.is_moderator? %>

--- a/app/views/messages/_subnav.html.erb
+++ b/app/views/messages/_subnav.html.erb
@@ -7,4 +7,7 @@
   |
   <%= link_to_different_page 'Messages', messages_path %>
   <%= link_to_different_page 'Sent', messages_sent_path %>
+  |
+  <%= link_to_different_page 'All Notifications', notifications_path %>
+  <%= link_to_different_page 'Unread Notifications', notifications_unread_path %>
 <% end %>

--- a/app/views/notifications/_message.html.erb
+++ b/app/views/notifications/_message.html.erb
@@ -1,0 +1,16 @@
+<div class="message">
+  <div class="voters">✉</div>
+  <div class="details">
+    <div class="byline">
+      <%= inline_avatar_for @user, message.author %> <%= styled_user_link message.author %>
+      <a href="/messages/<%= message.short_id %>"><%= how_long_ago_label(message.created_at) %></a>
+      <%= raw "<span class='comment_unread'>(unread)</span>" if is_unread %>
+    </div>
+    <div class="message-subject">
+      <%= message.subject %>
+    </div>
+    <div class="message-body">
+      <%= message.body %>
+    </div>
+  </div>
+</div>

--- a/app/views/notifications/all.html.erb
+++ b/app/views/notifications/all.html.erb
@@ -1,0 +1,41 @@
+<%= render partial: 'messages/subnav' %>
+
+<%= possible_flag_warning(@user, @user) %>
+
+<% if @notifications.present? %>
+  <ol class="comments comments1">
+    <% @notifications.filter(&:good?).each do |notification| %>
+      <% case notification.notifiable %>
+      <% when Comment %>
+      <% comment = notification.notifiable %>
+        <li class="comments_subtree">
+          <%= render "comments/comment", comment: comment, show_story: true, is_unread: notification.read_at.nil?, show_tree_lines: false, show_folder_control: false %>
+          <ol class="comments"></ol>
+        </li>
+      <% when Message %>
+      <% message = notification.notifiable %>
+        <li class="comments_subtree">
+          <%= render "message", message: message, is_unread: notification.read_at.nil? %>
+        </li>
+      <% end %>
+    <% end %>
+  </ol>
+<% else %>
+  <p class="help">No notifications to show.</p>
+<% end %>
+
+<% if @has_more || (@page && @page > 1)%>
+  <div class="morelink">
+    <% if @page && @page > 1 %>
+      <a href="/notifications<%= @page == 2 ? "" : "/page/#{@page - 1}" %>">&lt;&lt; Page <%= @page - 1 %></a>
+    <% end %>
+
+    <% if @has_more %>
+      <% if @page && @page > 1 %>
+        |
+      <% end %>
+
+      <a href="/notifications/page/<%= @page + 1 %>">Page <%= @page + 1 %> &gt;&gt;</a>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/notifications/all.html.erb
+++ b/app/views/notifications/all.html.erb
@@ -4,19 +4,48 @@
 
 <% if @notifications.present? %>
   <ol class="comments comments1">
-    <% @notifications.filter(&:good?).each do |notification| %>
-      <% case notification.notifiable %>
-      <% when Comment %>
-      <% comment = notification.notifiable %>
-        <li class="comments_subtree">
-          <%= render "comments/comment", comment: comment, show_story: true, is_unread: notification.read_at.nil?, show_tree_lines: false, show_folder_control: false %>
-          <ol class="comments"></ol>
-        </li>
-      <% when Message %>
-      <% message = notification.notifiable %>
-        <li class="comments_subtree">
-          <%= render "message", message: message, is_unread: notification.read_at.nil? %>
-        </li>
+    <% @notifications.each do |notification| %>
+      <% good_faith_result = notification.check_good_faith %>
+      <% if good_faith_result.good_faith? %>
+        <% case notification.notifiable %>
+        <% when Comment %>
+        <% comment = notification.notifiable %>
+          <li class="comments_subtree">
+            <%= render "comments/comment", comment: comment, show_story: true, is_unread: notification.read_at.nil?, show_tree_lines: false, show_folder_control: false %>
+            <ol class="comments"></ol>
+          </li>
+        <% when Message %>
+        <% message = notification.notifiable %>
+          <li class="comments_subtree">
+            <%= render "message", message: message, is_unread: notification.read_at.nil? %>
+          </li>
+        <% end %>
+      <% else %>
+        <% good_faith_result.bad_properties.each do |bad_property| %>
+          <li class="comments_subtree">
+            <div class="hidden-notification">
+              <div class="icon">🛑</div>
+              <div class="details">
+                <% case bad_property %>
+                <% when :bad_story %>
+                  The story has been flagged too many times.
+                <% when :bad_comment %>
+                  The comment has been flagged too many times or is gone.
+                <% when :bad_parent_comment %>
+                  The parent comment has been flagged too many times or is gone.
+                <% when :user_has_flagged_replier %>
+                  You have previously flagged another comment belonging to this comment's author.
+                <% when :user_has_hidden_story %>
+                  You have hidden the story for this comment.
+                <% when :user_has_filtered_tags_on_story %>
+                  You have filtered tags that are on this comment's story.
+                <% else %>
+                  Hidden for a different reason: <%= bad_property %>
+                <% end %>
+              </div>
+            </div>
+          </li>
+        <% end%>
       <% end %>
     <% end %>
   </ol>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -139,6 +139,9 @@ Rails.application.routes.draw do
     post "mod_note"
   end
 
+  get "/notifications(/page/:page)" => "notifications#all", :as => "notifications"
+  get "/notifications/unread" => "notifications#unread"
+
   get "/inbox" => "inbox#index"
 
   get "/c/:id.json" => "comments#show_short_id", :format => "json"

--- a/db/migrate/20250628172500_create_notifications.rb
+++ b/db/migrate/20250628172500_create_notifications.rb
@@ -1,0 +1,16 @@
+class CreateNotifications < ActiveRecord::Migration[8.0]
+  def change
+    create_table :notifications, id: {type: :bigint, unsigned: true} do |t|
+      # We shouldn't need an index on the user_id alone because the unique index below provides user_id in the leftmost column
+      t.references :user, null: false, foreign_key: true, type: :bigint, unsigned: true, index: false
+      t.references :notifiable, polymorphic: true, null: false, type: :bigint, unsigned: true
+      t.datetime :read_at
+      t.string :token, null: false
+
+      t.timestamps
+
+      t.index [:user_id, :notifiable_type, :notifiable_id], unique: true
+      t.index [:token], unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -269,6 +269,19 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_30_123615) do
     t.index ["user_id"], name: "index_moderations_on_user_id"
   end
 
+  create_table "notifications", id: { type: :bigint, unsigned: true }, charset: "utf8mb4", collation: "utf8mb4_uca1400_ai_ci", force: :cascade do |t|
+    t.bigint "user_id", null: false, unsigned: true
+    t.string "notifiable_type", null: false
+    t.bigint "notifiable_id", null: false, unsigned: true
+    t.datetime "read_at"
+    t.string "token", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["notifiable_type", "notifiable_id"], name: "index_notifications_on_notifiable"
+    t.index ["token"], name: "index_notifications_on_token", unique: true
+    t.index ["user_id", "notifiable_type", "notifiable_id"], name: "idx_on_user_id_notifiable_type_notifiable_id_ffac34041e", unique: true
+  end
+
   create_table "origins", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.bigint "domain_id", null: false
     t.string "identifier", null: false
@@ -494,6 +507,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_30_123615) do
   add_foreign_key "moderations", "tags", name: "moderations_tag_id_fk"
   add_foreign_key "moderations", "users"
   add_foreign_key "moderations", "users", column: "moderator_user_id", name: "moderations_moderator_user_id_fk"
+  add_foreign_key "notifications", "users"
   add_foreign_key "origins", "domains"
   add_foreign_key "origins", "users", column: "banned_by_user_id"
   add_foreign_key "read_ribbons", "stories", name: "read_ribbons_story_id_fk"

--- a/lib/tasks/backfill_notifications.rake
+++ b/lib/tasks/backfill_notifications.rake
@@ -1,0 +1,42 @@
+desc "backfills missing notifications for both comments and messages"
+task backfill_notifications: :environment do
+  read_at = Time.current
+
+  Notification.transaction do
+    started_at = Time.current
+    Comment.includes(story: [:user], parent_comment: [:user]).find_each do |comment|
+      if comment.parent_comment.nil?
+        # top level comment
+        if comment.story.user_is_following?
+          Notification.create(
+            user: comment.story.user,
+            notifiable: comment,
+            read_at: read_at
+          )
+        end
+      else
+        # child comment
+        Notification.create(
+          user: comment.parent_comment.user,
+          notifiable: comment,
+          read_at: read_at
+        )
+      end
+    rescue ActiveRecord::RecordNotUnique
+    end
+    finished_at = Time.current
+    puts "Created missing comment notifications, the time it took was #{finished_at - started_at} seconds"
+
+    started_at = Time.current
+    Message.includes(:recipient).find_each do |message|
+      Notification.create(
+        user: message.recipient,
+        notifiable: message,
+        read_at: read_at
+      )
+    rescue ActiveRecord::RecordNotUnique
+    end
+    finished_at = Time.current
+    puts "Created missing message notifications, the time it took was #{finished_at - started_at} seconds"
+  end
+end

--- a/lib/tasks/backfill_notifications.rake
+++ b/lib/tasks/backfill_notifications.rake
@@ -32,7 +32,7 @@ task backfill_notifications: :environment do
       Notification.create(
         user: message.recipient,
         notifiable: message,
-        read_at: read_at
+        read_at: message.has_been_read ? read_at : nil
       )
     rescue ActiveRecord::RecordNotUnique
     end

--- a/spec/factories/hidden_story.rb
+++ b/spec/factories/hidden_story.rb
@@ -1,0 +1,6 @@
+# typed: false
+
+FactoryBot.define do
+  factory :hidden_story do
+  end
+end

--- a/spec/factories/notification.rb
+++ b/spec/factories/notification.rb
@@ -1,0 +1,6 @@
+# typed: false
+
+FactoryBot.define do
+  factory :notification do
+  end
+end

--- a/spec/jobs/notify_comment_job_spec.rb
+++ b/spec/jobs/notify_comment_job_spec.rb
@@ -3,9 +3,10 @@ require "rails_helper"
 RSpec.describe NotifyCommentJob, type: :job do
   describe "comment notifications" do
     it "sends reply notification" do
-      recipient = create(:user)
+      recipient = build(:user)
       recipient.settings["email_notifications"] = true
       recipient.settings["email_replies"] = true
+      recipient.save!
 
       sender = create(:user)
       # Story under which the comments are posted.
@@ -23,10 +24,12 @@ RSpec.describe NotifyCommentJob, type: :job do
 
       expect(sent_emails.size).to eq(1)
       expect(sent_emails[0].subject).to match(/Reply from #{sender.username}/)
+      expect(recipient.notifications.count).to eq(1)
+      expect(recipient.notifications.first.notifiable).to eq(c2)
     end
 
     it "sends mention notification" do
-      recipient = create(:user)
+      recipient = build(:user)
       recipient.settings["email_notifications"] = true
       recipient.settings["email_mentions"] = true
       recipient.save!
@@ -40,10 +43,12 @@ RSpec.describe NotifyCommentJob, type: :job do
 
       expect(sent_emails.size).to eq(1)
       expect(sent_emails[0].subject).to match(/Mention from #{sender.username}/)
+      expect(recipient.notifications.count).to eq(1)
+      expect(recipient.notifications.first.notifiable).to eq(c)
     end
 
     it "also sends mentions with ~username" do
-      recipient = create(:user)
+      recipient = build(:user)
       recipient.settings["email_notifications"] = true
       recipient.settings["email_mentions"] = true
       recipient.save!
@@ -54,11 +59,13 @@ RSpec.describe NotifyCommentJob, type: :job do
       NotifyCommentJob.perform_now(c)
 
       expect(sent_emails.size).to eq(1)
+      expect(recipient.notifications.count).to eq(1)
+      expect(recipient.notifications.first.notifiable).to eq(c)
     end
 
     it "sends only reply notification on reply with mention" do
       # User being mentioned and replied to.
-      recipient = create(:user)
+      recipient = build(:user)
       recipient.settings["email_notifications"] = true
       recipient.settings["email_mentions"] = true
       recipient.settings["email_replies"] = true
@@ -81,6 +88,8 @@ RSpec.describe NotifyCommentJob, type: :job do
 
       expect(sent_emails.size).to eq(1)
       expect(sent_emails[0].subject).to match(/Reply from #{sender.username}/)
+      expect(recipient.notifications.count).to eq(1)
+      expect(recipient.notifications.first.notifiable).to eq(c2)
     end
   end
 end

--- a/spec/jobs/notify_message_job_spec.rb
+++ b/spec/jobs/notify_message_job_spec.rb
@@ -2,12 +2,14 @@ require "rails_helper"
 
 RSpec.describe NotifyMessageJob, type: :job do
   describe "message notifications" do
-    it "sends a message notification" do
-      recipient = create(:user)
+    it "creates & sends a message notification" do
+      recipient = build(:user)
       recipient.settings["email_messages"] = true
       recipient.save!
       message = create(:message, recipient: recipient)
       NotifyMessageJob.perform_now(message)
+      expect(recipient.notifications.count).to eq(1)
+      expect(recipient.notifications.first.notifiable).to eq(message)
       expect(sent_emails.size).to eq(1)
       expect(sent_emails[0].subject).to match(/Private Message from #{message.author_username}/)
     end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -1,0 +1,157 @@
+# typed: false
+
+require "rails_helper"
+
+describe Notification do
+  describe "good?" do
+    context "messages" do
+      it "is good for all messages" do
+        user = create(:user)
+        message = create(:message)
+        notification = create(:notification, user: user, notifiable: message)
+        expect(notification.good?).to eq(true)
+      end
+    end
+
+    context "comments" do
+      it "is not good for stories with more flags than upvotes" do
+        author = create(:user)
+        story = create(:story, user: author)
+        reader = create(:user)
+        Vote.vote_thusly_on_story_or_comment_for_user_because(-1, story.id, nil, reader.id, nil)
+        story.reload
+        expect(story.score).to eq(1)
+        expect(story.flags).to eq(1)
+        comment = create(:comment, user: reader, story: story)
+        notification = create(:notification, user: author, notifiable: comment)
+        expect(notification.good?).to eq(false)
+      end
+
+      it "is good for stories with more upvotes than flags" do
+        author = create(:user)
+        story = create(:story, user: author)
+        reader = create(:user)
+        expect(story.score).to eq(1)
+        expect(story.flags).to eq(0)
+        comment = create(:comment, user: reader, story: story)
+        notification = create(:notification, user: author, notifiable: comment)
+        expect(notification.good?).to eq(true)
+      end
+
+      it "is not good for comments with more flags than upvotes" do
+        author = create(:user)
+        story = create(:story, user: author)
+        reader = create(:user)
+        comment = create(:comment, user: reader, story: story)
+        Vote.vote_thusly_on_story_or_comment_for_user_because(-1, story.id, comment.id, author.id, nil)
+        comment.reload
+        expect(comment.flags).to eq(1)
+        notification = create(:notification, user: author, notifiable: comment)
+        expect(notification.good?).to eq(false)
+      end
+
+      it "is not good for deleted comments" do
+        author = create(:user)
+        story = create(:story, user: author)
+        reader = create(:user)
+        comment = create(:comment, user: reader, story: story, is_deleted: true)
+        notification = create(:notification, user: author, notifiable: comment)
+        expect(notification.good?).to eq(false)
+      end
+
+      it "is not good for moderated comments" do
+        author = create(:user)
+        story = create(:story, user: author)
+        reader = create(:user)
+        comment = create(:comment, user: reader, story: story, is_moderated: true)
+        notification = create(:notification, user: author, notifiable: comment)
+        expect(notification.good?).to eq(false)
+      end
+
+      it "is good for other comments" do
+        author = create(:user)
+        story = create(:story, user: author)
+        reader = create(:user)
+        comment = create(:comment, user: reader, story: story)
+        notification = create(:notification, user: author, notifiable: comment)
+        expect(notification.good?).to eq(true)
+      end
+
+      it "is not good for comments with parent comments with more flags than upvotes" do
+        author = create(:user)
+        story = create(:story, user: author)
+        reader1 = create(:user)
+        comment1 = create(:comment, user: reader1, story: story)
+        reader2 = create(:user)
+        comment2 = create(:comment, user: reader2, story: story, parent_comment: comment1)
+        Vote.vote_thusly_on_story_or_comment_for_user_because(-1, story.id, comment1.id, reader2.id, nil)
+        comment1.reload
+        expect(comment1.flags).to eq(1)
+        notification = create(:notification, user: reader1, notifiable: comment2)
+        expect(notification.good?).to eq(false)
+      end
+
+      it "is not good for comments with parent comments that are deleted" do
+        author = create(:user)
+        story = create(:story, user: author)
+        reader1 = create(:user)
+        comment1 = create(:comment, user: reader1, story: story)
+        reader2 = create(:user)
+        comment2 = create(:comment, user: reader2, story: story, parent_comment: comment1)
+        comment1.is_deleted = true
+        comment1.save!
+        notification = create(:notification, user: reader1, notifiable: comment2)
+        expect(notification.good?).to eq(false)
+      end
+
+      it "is not good for comments with parent comments that are moderated" do
+        author = create(:user)
+        story = create(:story, user: author)
+        reader1 = create(:user)
+        comment1 = create(:comment, user: reader1, story: story)
+        reader2 = create(:user)
+        comment2 = create(:comment, user: reader2, story: story, parent_comment: comment1)
+        comment1.is_moderated = true
+        comment1.save!
+        notification = create(:notification, user: reader1, notifiable: comment2)
+        expect(notification.good?).to eq(false)
+      end
+
+      it "is good for comments with all other parent comments" do
+        author = create(:user)
+        story = create(:story, user: author)
+        reader1 = create(:user)
+        comment1 = create(:comment, user: reader1, story: story)
+        reader2 = create(:user)
+        comment2 = create(:comment, user: reader2, story: story, parent_comment: comment1)
+        notification = create(:notification, user: reader1, notifiable: comment2)
+        expect(notification.good?).to eq(true)
+      end
+
+      it "is not good if the recipient has flagged the any comment belong to the author" do
+        author = create(:user)
+        story = create(:story, user: author)
+        reader1 = create(:user)
+        comment1 = create(:comment, user: reader1, story: story)
+        reader2 = create(:user)
+        comment2 = create(:comment, user: reader2, story: story, parent_comment: comment1)
+        comment3 = create(:comment, user: reader2, story: story)
+        notification = create(:notification, user: author, notifiable: comment3)
+        expect(notification.good?).to eq(true)
+        Vote.vote_thusly_on_story_or_comment_for_user_because(-1, story.id, comment2.id, author.id, nil)
+        expect(notification.good?).to eq(false)
+      end
+
+      it "is not good if the recipient has hidden the story" do
+        author = create(:user)
+        story = create(:story, user: author)
+        reader = create(:user)
+        comment = create(:comment, user: reader, story: story)
+        notification = create(:notification, user: author, notifiable: comment)
+        expect(notification.good?).to eq(true)
+        _hidden_story = create(:hidden_story, user: author, story: story)
+        expect(notification.good?).to eq(false)
+      end
+    end
+  end
+end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -142,7 +142,7 @@ describe Notification do
         expect(notification.check_good_faith.good_faith?).to eq(true)
       end
 
-      it "is not good if the recipient has flagged the any comment belong to the author" do
+      it "is not good if the recipient has flagged any comment belonging to the author" do
         author = create(:user)
         story = create(:story, user: author)
         reader1 = create(:user)
@@ -153,6 +153,7 @@ describe Notification do
         notification = create(:notification, user: author, notifiable: comment3)
         expect(notification.check_good_faith.good_faith?).to eq(true)
         Vote.vote_thusly_on_story_or_comment_for_user_because(-1, story.id, comment2.id, author.id, nil)
+        notification.reload
         result = notification.check_good_faith
         expect(result.good_faith?).to eq(false)
         expect(result.bad_properties).to eq([:user_has_flagged_replier])
@@ -166,6 +167,7 @@ describe Notification do
         notification = create(:notification, user: author, notifiable: comment)
         expect(notification.check_good_faith.good_faith?).to eq(true)
         _hidden_story = create(:hidden_story, user: author, story: story)
+        notification.reload
         result = notification.check_good_faith
         expect(result.good_faith?).to eq(false)
         expect(result.bad_properties).to eq([:user_has_hidden_story])

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -152,6 +152,20 @@ describe Notification do
         _hidden_story = create(:hidden_story, user: author, story: story)
         expect(notification.good?).to eq(false)
       end
+
+      it "is not good if the recipient has filtered the story tag" do
+        author = create(:user)
+        story = create(:story, user: author)
+        reader = create(:user)
+        comment = create(:comment, user: reader, story: story)
+        notification = create(:notification, user: author, notifiable: comment)
+        expect(notification.good?).to eq(true)
+        tag = create(:tag)
+        story.tags << tag
+        _tag_filter = TagFilter.create!(tag: tag, user: author)
+        notification.reload
+        expect(notification.good?).to eq(false)
+      end
     end
   end
 end


### PR DESCRIPTION
Work for https://github.com/lobsters/lobsters/issues/1076

<img width="705" alt="lobsters_wip" src="https://github.com/user-attachments/assets/da431b95-e5ed-4c5b-869a-9f1e27e39522" />

Currently notifications are isolated from the other parts of the site like unread messages/unread comments because I'm not yet sure what the migration / integration will look like so I'm going to leave it open for now. This is why you might see "1" unread at the top, but the screenshot has 5 unread notifications.

For messages, the bold text under the byline is the subject, to differentiate it from the body.

Clicking on unread works as expected for both messages and comments.

Added pagination to all notifications, but not the unread, since we clear them out after clicking on the tab.

I might have found a bug while taking some of the pagination code from the replies. The replies controller limits to [REPLIES_PER_PAGE](https://github.com/lobsters/lobsters/blob/master/app/controllers/replies_controller.rb#L17) but the replies view only shows the pagination if there are [more than REPLIES_PER_PAGE replies](https://github.com/lobsters/lobsters/blob/master/app/views/replies/show.html.erb#L22). I tested this out locally and I couldn't get the pagination to display when set to a small number like 2.

Looking for lots of feedback, especially around how you would like to rollout this feature.