### PR TITLE
Stop using JavaScript for Markdown help

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -294,6 +294,10 @@ input.deletion {
 	border: 1px solid var(--color-fg-negative);
 }
 
+summary {
+	cursor: pointer;
+}
+
 #qrsvg {
 	background-color: white;
 	display: inline-block;
@@ -796,7 +800,7 @@ div.comment_text {
 }
 
 div.comment_text blockquote,
-div.markdown_help blockquote,
+.markdown_help blockquote,
 div.story_text blockquote {
 	font-style: italic;
 	margin: 0.25em 0 0 0.5em;
@@ -806,7 +810,7 @@ div.story_text blockquote {
 
 /* un-italicize italics inside a blockquote */
 div.comment_text blockquote em, 
-div.markdown_help blockquote em, 
+.markdown_help blockquote em,
 div.story_text blockquote em {
 	font-style: normal
 }
@@ -815,7 +819,7 @@ div#collapsed_story_text div.story_text blockquote {
 	font-style: normal;
 }
 div.comment_text pre,
-div.markdown_help pre {
+.markdown_help pre {
 	margin-left: 1em;
 }
 div.comment_text ol {
@@ -899,18 +903,11 @@ div.comment_text code {
 .markdown_help {
 	background-color: var(--color-box-bg-shaded);
 	border: 1px solid var(--color-box-border);
-	padding: 0 1em;
-	margin-top: 0.5em;
-	display: none;
+	padding-left: 0.25rem;
 }
 
-div.markdown_help_label {
-	float: right;
+.markdown_help summary {
 	font-size: 9pt;
-	line-height: 2em;
-	color: var(--color-fg-contrast-4-5);
-	text-decoration: underline;
-	cursor: pointer;
 }
 
 .comment .preview {
@@ -1756,14 +1753,6 @@ input[type="submit"].link_post.pushover_button {
 	div.boxline input[type="text"],
 	div.comment textarea {
 		max-width: 90%;
-	}
-
-	div.markdown_help_label {
-		display: none;
-	}
-	div.markdown_help_label_mobile {
-		display: inline !important;
-		margin-right: 2em;
 	}
 
 	div#story_box input,

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -534,10 +534,6 @@ onPageLoad(() => {
 
   // Global
 
-  on('click', '.markdown_help_label', (event) => {
-    qS(parentSelector(event.target, '.markdown_help_toggler'), '.markdown_help').classList.toggle('display-block');
-  });
-
   on('click', '#modal_backdrop', () => {
     Lobster.removeFlagModal()
   });

--- a/app/views/comments/_commentbox.html.erb
+++ b/app/views/comments/_commentbox.html.erb
@@ -40,15 +40,9 @@
 
     <p></p>
 
-    <div class="markdown_help_toggler">
+    <div>
       <% if @user %>
-        <div class="markdown_help_label">
-          Markdown formatting available
-        </div>
-        <div class="markdown_help_label markdown_help_label_mobile"
-        style="display: none;">
-          [M&darr;]
-        </div>
+        <%= render :partial => "global/markdownhelp" %>
       <% end %>
 
       <%= f.submit "#{comment.new_record?? "Post" : "Update"}",
@@ -69,12 +63,6 @@
           options_from_collection_for_select(@user.wearable_hats, "short_id", "hat",
           comment.hat&.short_id), :include_blank => true %>
         </div>
-      <% end %>
-
-      <div style="clear: both;"></div>
-
-      <% if @user %>
-        <%= render :partial => "global/markdownhelp" %>
       <% end %>
     </div>
   </div>

--- a/app/views/global/_markdownhelp.html.erb
+++ b/app/views/global/_markdownhelp.html.erb
@@ -1,5 +1,6 @@
 <%# locals: (allow_images: false) -%>
-<div class="markdown_help">
+<details class="markdown_help">
+  <summary>Markdown formatting available</summary>
   <table>
   <tr>
     <td width="125"><em>emphasized text</em></td>
@@ -39,4 +40,4 @@
     </tr>
   <% end %>
   </table>
-</div>
+</details>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,7 +31,7 @@
   <%= stylesheet_link_tag "tom-select", "data-turbo-track": "reload" %>
   <%= stylesheet_link_tag "TomSelect_remove_button", "data-turbo-track": "reload" %>
 
-  <% if @user || @new_user %>
+  <% if @user %>
     <%= javascript_importmap_tags %>
   <% end %>
 

--- a/app/views/mod/stories/edit.html.erb
+++ b/app/views/mod/stories/edit.html.erb
@@ -28,10 +28,8 @@
       <p></p>
 
       <div class="box">
-        <div class="boxline actions markdown_help_toggler">
-          <div class="markdown_help_label">
-            Markdown formatting available
-          </div>
+        <div class="boxline actions">
+          <%= render :partial => "global/markdownhelp", :locals => { allow_images: @story.can_have_images? } %>
 
           <%= f.submit "Save" %>
 
@@ -48,10 +46,6 @@
                 :class => "deletion", :data => { :confirm => "Delete this story?" } %>
             <% end %>
           <% end %>
-
-          <div style="clear: both;"></div>
-
-          <%= render :partial => "global/markdownhelp", :locals => { allow_images: @story.can_have_images? } %>
         </div>
       </div>
     <% end %>

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -40,13 +40,7 @@
         <div>
           <%= f.text_area :about %>
 
-          <div class="markdown_help_toggler">
-            <div class="markdown_help_label">
-              Markdown formatting available
-            </div>
-
-            <%= render :partial => "global/markdownhelp" %>
-          </div>
+          <%= render :partial => "global/markdownhelp" %>
         </div>
       </div>
 

--- a/app/views/signup/invited.html.erb
+++ b/app/views/signup/invited.html.erb
@@ -47,13 +47,7 @@
     <div>
       <%= f.text_area :about%>
 
-      <div class="markdown_help_toggler">
-        <div class="markdown_help_label">
-          Markdown formatting available
-        </div>
-
-        <%= render :partial => "global/markdownhelp" %>
-      </div>
+      <%= render :partial => "global/markdownhelp" %>
     </div>
   </div>
 

--- a/app/views/stories/edit.html.erb
+++ b/app/views/stories/edit.html.erb
@@ -5,10 +5,9 @@
         :f => f } %>
 
       <div class="box">
-        <div class="boxline actions markdown_help_toggler">
-          <div class="markdown_help_label">
-            Markdown formatting available
-          </div>
+        <div class="boxline actions">
+          <%= render :partial => "global/markdownhelp",
+            :locals => { allow_images: @story.can_have_images? } %>
 
           <%= f.submit "Save" %>
 
@@ -21,11 +20,6 @@
             <%= f.submit "Delete", formaction: story_destroy_path(@story.short_id),
               :class => "deletion", :data => { :confirm => "Delete this story?" } %>
           <% end %>
-
-          <div style="clear: both;"></div>
-
-          <%= render :partial => "global/markdownhelp",
-            :locals => { allow_images: @story.can_have_images? } %>
         </div>
       </div>
     <% end %>

--- a/app/views/stories/new.html.erb
+++ b/app/views/stories/new.html.erb
@@ -6,20 +6,14 @@
       <p></p>
 
       <div class="box">
-        <div class="boxline actions markdown_help_toggler">
-          <div class="markdown_help_label">
-            Markdown formatting available
-          </div>
+        <div class="boxline actions">
+          <%= render :partial => "global/markdownhelp",
+            :locals => { allow_images: @story.can_have_images? } %>
 
           <%= f.submit "Submit" %>
 
           &nbsp;
           <%= f.submit "Preview", class: 'story-preview', name: 'preview' %>
-
-          <div style="clear: both;"></div>
-
-          <%= render :partial => "global/markdownhelp",
-            :locals => { allow_images: @story.can_have_images? } %>
         </div>
       </div>
     <% end %>


### PR DESCRIPTION
Switch to using a `<details>` element for this help, so it doesn't require JavaScript. I elected for this over the checkbox hack as it's more semantically appropriate.

The look of the dropdown has changed (though I matched the font size so it remains less distracting). Personally, I like the new look as it more clearly communicates what's going to happen, and leans on the native browser rendering, in line with the rest of the site. I'm not opposed to trying to more closely match the existing design, however.

![image](https://github.com/user-attachments/assets/a883ec5e-faa4-4ef0-a18a-b26fe90fb927)

![image](https://github.com/user-attachments/assets/be13a1e0-cdd2-4794-acb1-59a372450da1)


<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
