### PR TITLE
Fix lobsters emoji sponsor link

### DIFF
--- a/app/views/about/about.html.erb
+++ b/app/views/about/about.html.erb
@@ -361,7 +361,7 @@
 
   <li id="emoji" style="list-style: '🦞';">
   <p>
-  <a href="https://unicode.org/consortium/adopted-characters.html#s1f99E">Sponsor of the lobster emoji</a>:
+  <a href="https://aac.unicode.org/sponsors#silver-1f99e">Sponsor of the lobster emoji</a>:
   In February 2018, Lobsters <a href="https://lobste.rs/s/pnysdr/lobsters_emoji_adoption">held a fundraiser</a>
   to officially adopt the new lobster emoji in support of the Unicode Foundation.
   </p></li>


### PR DESCRIPTION
The old link redirects, and the anchor is different on the new page.

I did not test this because it's so trivial.