### PR TITLE
Improve accessibility for upvotes, fix #1641

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -455,16 +455,13 @@ div.voters {
 }
 
 .upvoter:before {
-	content: "\25b2";
+	content: "\25b3";
 	color: var(--color-fg-shape);
 	font-size: 12pt;
 }
-/* hotfix for https://github.com/lobsters/lobsters/issues/1641 */
-.upvoted .upvoter {
-	font-weight: bold;
-}
 .upvoted .upvoter:before,
 .upvoter:hover:before {
+	content: "\25b2";
 	color: var(--color-fg-accent);
 }
 .upvoter {


### PR DESCRIPTION
Now, △ becomes ▲ when upvoting. Previously,▲was always used.

N.b. for #1494 ◭ `\25ed` could be used, until the server confirms the upvote (pushcx recommended this on twitch.)