### PR TITLE
Fix upvote hover state on iOS

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -461,7 +461,7 @@ div.voters {
 	-webkit-text-stroke: 1px var(--color-fg-shape);
 }
 .upvoted .upvoter:before, .upvoter:hover:before {
-	color: var(--color-fg-accent);
+	color: var(--color-fg-accent) !important;
 	-webkit-text-stroke: 1px var(--color-fg-accent);
 }
 .upvoter {


### PR DESCRIPTION
I usually don't like fixing CSS bugs with `!important`, but it seems to do the trick here:

| Before | After |
| --- | --- |
| ![IMG_7648](https://github.com/user-attachments/assets/7287f6e5-f0a5-4a1b-ac08-0f03a21d74e2) | ![IMG_7649](https://github.com/user-attachments/assets/2cbb69cc-8820-4bd9-b183-fd1c54d8e34a) |

Feel free to close this if you can think of another way of fixing this!

/cc @veqqq