### PR TITLE
Improve Upvote Arrow Visibility

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -455,14 +455,14 @@ div.voters {
 }
 
 .upvoter:before {
-	content: "\25b2";
+  content: "\25b2";
 	color: transparent;
-	font-size: 12pt;
-	-webkit-text-stroke: 1px var(--color-fg-shape);
+	font-size: 14pt;
+	-webkit-text-stroke: 1.5px var(--color-fg-contrast-4-5);
 }
 .upvoted .upvoter:before, .upvoter:hover:before {
 	color: var(--color-fg-accent);
-	-webkit-text-stroke: 1px var(--color-fg-accent);
+	-webkit-text-stroke: 1.5px var(--color-fg-accent);
 }
 .upvoter {
 	color: var(--color-fg-contrast-4-5);


### PR DESCRIPTION
To continue our bikeshedding, I thickened and lightened the border (color now shared with the reply/edit line) embiggened the arrows(' font).

I tested it on Chrome's blindness tools from a few distances. I tested many arrows and mathematical symbols, but the original is best. N.b. 2px was too bold and attention-grabbing (especially on the front page. This color change greatly increases distinctiveness compared to the background and the smaller border requirement makes the filled out arrow more distinct from the empty one.)