### PR TITLE
Fix preview comment indent

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -908,10 +908,6 @@ div.comment_text code {
 	font-size: 9pt;
 }
 
-.comment .preview {
-	padding-left: 17px;
-}
-
 div#story_preview {
 	margin-top: 2em;
 	margin-left: 3.5em;
@@ -952,9 +948,6 @@ div#story_box textarea {
 	width: 600px;
 }
 
-div.comment_form_container {
-	margin-left: -11px;
-}
 
 div.comment_form_container form {
 	margin-left: 40px;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -628,13 +628,8 @@ li .comment_parent_tree_line {
         left: 1em;
 	bottom: 0;
 }
-
 li .comment_parent_tree_line.score_shown {
 	top: 3.6lh;
-}
-/* hide for comments that don't have children */
-li:not(:has(> .comments > li)) > .comment > .comment_parent_tree_line {
-	border-left-color: transparent;
 }
 li .comment_siblings_tree_line {
 	position: absolute;

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -15,7 +15,10 @@
 
       <% can_flag = @user && @user.can_flag?(comment) %>
       <% score_display = comment.score_for_user(@user) %>
-      <div class="comment_parent_tree_line
+      <% tree_line = !comment.previewing && comment.reply_count > 0 %>
+
+      <div class="
+        <%= tree_line ? "comment_parent_tree_line" : "" %>
         <%= can_flag ? "can_flag" : "" %>
         <%= score_display != "&nbsp;" ? "score_shown" : "" %>
       "></div>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -15,10 +15,10 @@
 
       <% can_flag = @user && @user.can_flag?(comment) %>
       <% score_display = comment.score_for_user(@user) %>
-      <% tree_line = !comment.previewing && comment.reply_count > 0 %>
+      <% draw_tree_line = comment.reply_count > 0 %>
 
       <div class="
-        <%= tree_line ? "comment_parent_tree_line" : "" %>
+        <%= draw_tree_line ? "comment_parent_tree_line" : "" %>
         <%= can_flag ? "can_flag" : "" %>
         <%= score_display != "&nbsp;" ? "score_shown" : "" %>
       "></div>

--- a/app/views/comments/_commentbox.html.erb
+++ b/app/views/comments/_commentbox.html.erb
@@ -68,8 +68,8 @@
   </div>
 
   <p></p>
-
-  <%# placeholder to render preview into %>
-  <%= render partial: 'comments/preview', locals: { comment: show_comment } %>
 <% end %>
+
+<%# placeholder to render preview into %>
+<%= render partial: 'comments/preview', locals: { comment: show_comment } %>
 </div>

--- a/app/views/comments/_threads.html.erb
+++ b/app/views/comments/_threads.html.erb
@@ -59,10 +59,10 @@
 
       <% can_flag = @user && @user.can_flag?(comment) %>
       <% score_display = comment.score_for_user(@user) %>
-      <% tree_line = !comment.previewing && comment.reply_count > 0 %>
+      <% draw_tree_line = comment.reply_count > 0 %>
 
       <div class="
-        <%= tree_line ? "comment_parent_tree_line" : "" %>
+        <%= draw_tree_line ? "comment_parent_tree_line" : "" %>
         <%= can_flag ? "can_flag" : "" %>
         <%= score_display != "&nbsp;" ? "score_shown" : "" %>
       "></div>

--- a/app/views/comments/_threads.html.erb
+++ b/app/views/comments/_threads.html.erb
@@ -59,7 +59,10 @@
 
       <% can_flag = @user && @user.can_flag?(comment) %>
       <% score_display = comment.score_for_user(@user) %>
-      <div class="comment_parent_tree_line
+      <% tree_line = !comment.previewing && comment.reply_count > 0 %>
+
+      <div class="
+        <%= tree_line ? "comment_parent_tree_line" : "" %>
         <%= can_flag ? "can_flag" : "" %>
         <%= score_display != "&nbsp;" ? "score_shown" : "" %>
       "></div>
@@ -191,11 +194,6 @@
 
 <%#/heinous_inline_partial(comments/_comment.html.erb)%>
 
-    <%
-    #  If you edit this structure, update the incredibly brittle css selector
-    #    li.comments_subtree > .comment:nth-last-of-type(2) .comment_parent_tree_line
-    #  (or refactor the whole parent/sibling lines implementation)
-    %>
     <% if comment.depth != top_comment_depth %>
       <div class="comment_siblings_tree_line"></div>
     <% end %>


### PR DESCRIPTION
Fixes #1639

This PR does 2 things and I'm happy to split it into 2 PRs if you decide to merge this.
  1. When moving the preview comment back left, the preview line was still displayed and completely off. You probably don't want it there in the first place.
  2. Removes the dotted line for comments that aren't children.

I checked [wayback machine](https://web.archive.org/web/20250105171457/https://lobste.rs/s/9anym5/what_was_best_research_paper_you_read_2024) and based on the codebase, it seems like the intention was to draw the dotted line only on comments that have replies.

The current implementation on the website seems a bit off (there's dotted lines everywhere, even over upvote arrows). Side note - think the comment form should be moved to the left as well.

After:
![2025-07-03_20-07-1751590153](https://github.com/user-attachments/assets/a55323d1-5655-4c5c-bab7-201c3a016f8e)
Nested replies
![2025-07-03_20-07-1751590171](https://github.com/user-attachments/assets/4c7722bd-9171-414e-b3eb-096408bf0535)

Before:
![2025-07-03_20-07-1751589673](https://github.com/user-attachments/assets/1f45c127-402d-43d4-bedc-d558f3d34256)



<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
