### PR TITLE
Fix top stories page linking to RSS

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,9 +30,8 @@ Rails.application.routes.draw do
   get "/upvoted", to: redirect("/upvoted/stories")
   get "/upvoted/page/:page", to: redirect("/upvoted/stories/page/%{page}")
 
-  get "/top/rss" => "home#top", :format => "rss"
-  get "/top(/:length(/page/:page))" => "home#top", :as => "top"
   get "/top(/:length)/rss" => "home#top", :format => "rss"
+  get "/top(/:length(/page/:page))" => "home#top", :as => "top"
 
   get "/threads" => "comments#user_threads"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,8 +30,9 @@ Rails.application.routes.draw do
   get "/upvoted", to: redirect("/upvoted/stories")
   get "/upvoted/page/:page", to: redirect("/upvoted/stories/page/%{page}")
 
-  get "/top(/:length(/page/:page))/rss" => "home#top", :format => "rss"
+  get "/top/rss" => "home#top", :format => "rss"
   get "/top(/:length(/page/:page))" => "home#top", :as => "top"
+  get "/top(/:length(/page/:page))/rss" => "home#top", :format => "rss"
 
   get "/threads" => "comments#user_threads"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,7 +32,7 @@ Rails.application.routes.draw do
 
   get "/top/rss" => "home#top", :format => "rss"
   get "/top(/:length(/page/:page))" => "home#top", :as => "top"
-  get "/top(/:length(/page/:page))/rss" => "home#top", :format => "rss"
+  get "/top(/:length)/rss" => "home#top", :format => "rss"
 
   get "/threads" => "comments#user_threads"
 

--- a/spec/routing/home_spec.rb
+++ b/spec/routing/home_spec.rb
@@ -41,5 +41,9 @@ describe "home routing" do
     it "routes /top/1w/page/2/rss" do
       expect(get("/top/1w/page/2/rss")).to route_to("home#top", length: "1w", page: "2", format: "rss")
     end
+
+    it "generates the correct path for paginated top stories" do
+      expect(url_for(controller: "home", action: "top", length: "1w", page: 2, only_path: true)).to eq("/top/1w/page/2")
+    end
   end
 end

--- a/spec/routing/home_spec.rb
+++ b/spec/routing/home_spec.rb
@@ -38,10 +38,6 @@ describe "home routing" do
       expect(get("/top/1w/page/2")).to route_to("home#top", length: "1w", page: "2")
     end
 
-    it "routes /top/1w/page/2/rss" do
-      expect(get("/top/1w/page/2/rss")).to route_to("home#top", length: "1w", page: "2", format: "rss")
-    end
-
     it "generates the correct path for paginated top stories" do
       expect(url_for(controller: "home", action: "top", length: "1w", page: 2, only_path: true)).to eq("/top/1w/page/2")
     end


### PR DESCRIPTION
<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
The change in #1629 caused the previous and next page links on the Top Stories pages to link to the RSS pages instead.

I think it's because the new top RSS route matches before the regular top HTML route matches. I fixed this by swapping the order of the top page routes and adding a more specific `/top/rss` route for the case where that's requested. I also added a test to make sure the URL generated for the previous and next page links is correct.

I rarely write Ruby and have never contributed to a Rails codebase so please let me know if my approach is idiomatic.