### PR TITLE
disable transactions in fake_data task

### DIFF
--- a/lib/tasks/fake_data.rake
+++ b/lib/tasks/fake_data.rake
@@ -356,5 +356,8 @@ task fake_data: :environment do
     fail "Cancelled" if $stdin.gets.chomp != "y"
   end
 
-  FakeDataGenerator.new.generate
+  # Disable transactions for better performance
+  ActiveRecord::Base.transaction(requires_new: false) do
+    FakeDataGenerator.new.generate
+  end
 end


### PR DESCRIPTION
As discussed, we can turn off AR transactions which will speed up the insertion for fake_data task. Tailing the development logs with this change will confirm explicit transactions are no longer used:
![image](https://github.com/user-attachments/assets/8abbd832-8dc8-4063-9675-c8469951ac76)


BEFORE (on my machine):

real    3m45.308s
user    2m0.959s
sys     0m26.652s

AFTER:

real    2m32.567s
user    1m37.593s
sys     0m21.596s

A modest speedup but probably still worth it?
