### PR TITLE
Fix /top pagination

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,8 +30,9 @@ Rails.application.routes.draw do
   get "/upvoted", to: redirect("/upvoted/stories")
   get "/upvoted/page/:page", to: redirect("/upvoted/stories/page/%{page}")
 
-  get "/top(/:length(/page/:page))/rss" => "home#top", :format => "rss"
+  get "/top/rss" => "home#top", :format => "rss"
   get "/top(/:length(/page/:page))" => "home#top", :as => "top"
+  get "/top(/:length(/page/:page))/rss" => "home#top", :format => "rss"
 
   get "/threads" => "comments#user_threads"
 


### PR DESCRIPTION
Fixes #1650 

The newly added RSS route
`/top(/:length(/page/:page))/rss` was placed above the non-RSS route 
`/top(/:length(/page/:page))`, and it's matching too greedily. 
Tried reversing the route order, but that would match "rss" as length.
Added an explicit /top/rss route to make it more explicit and clear.

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
