### PR TITLE
fix(story): check for ascii only titles

### DIFF
--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -244,7 +244,7 @@ class Story < ApplicationRecord
     if title.match(GRAPHICS_RE)
       errors.add(:title, " may not contain emoji, dingbats, or other graphics")
     end
-    if !title.empty? && title == title.upcase
+    if !title.empty? && title.ascii_only? && title == title.upcase
       errors.add(:title, " doesn't need to scream, ASCII has supported lowercase since June 17, 1963.")
     end
 


### PR DESCRIPTION
When submitting a story with Japanese title in local dev env, met the validation error.

The background is I'm planning to run a non-English speaking site using Lobsters code base, when exploring the features the code base provides, I was stopped at submitting stories.