### PR TITLE
Remove unknown cookies and end empty session 1594

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,10 +9,7 @@ class ApplicationController < ActionController::Base
   before_action :prepare_exception_notifier
   before_action :mini_profiler
   before_action :set_traffic_style
-
   before_action :remove_non_lobster_cookies
-  # 2023-10-07 one user in one of their browser envs is getting a CSRF failure, I'm reverting
-  # because I'll be AFK a while.
   after_action :clear_session_cookie
 
   # match this nginx config for bypassing the file cache

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,7 +9,7 @@ class ApplicationController < ActionController::Base
   before_action :prepare_exception_notifier
   before_action :mini_profiler
   before_action :set_traffic_style
-  before_action :remove_non_lobster_cookies
+  before_action :remove_unknown_cookies
   after_action :clear_session_cookie
 
   # match this nginx config for bypassing the file cache
@@ -61,7 +61,7 @@ class ApplicationController < ActionController::Base
     true
   end
 
-  def remove_non_lobster_cookies
+  def remove_unknown_cookies
     cookies.each do |key, _value|
       next if key == TAG_FILTER_COOKIE.to_s # don't clear tag filters cookie
       next if key == Rails.application.config.session_options[:key] # don't clear session cookie

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -65,6 +65,7 @@ class ApplicationController < ActionController::Base
     cookies.each do |key, _value|
       next if key == TAG_FILTER_COOKIE.to_s # don't clear tag filters cookie
       next if key == Rails.application.config.session_options[:key] # don't clear session cookie
+      next if key == "__profilin" && (Rails.env.development? || @user&.is_moderator?) # don't clear Rack::MiniProfiler cookie
       cookies.delete(key)
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -65,9 +65,8 @@ class ApplicationController < ActionController::Base
   end
 
   def remove_non_lobster_cookies
-    # clear all cookies except the tag filters cookie and the session cookie
     cookies.each do |key, _value|
-      next if key == TAG_FILTER_COOKIE # don't clear tag filters cookie
+      next if key == TAG_FILTER_COOKIE.to_s # don't clear tag filters cookie
       next if key == Rails.application.config.session_options[:key] # don't clear session cookie
       cookies.delete(key)
     end 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -66,8 +66,8 @@ class ApplicationController < ActionController::Base
       next if key == TAG_FILTER_COOKIE.to_s # don't clear tag filters cookie
       next if key == Rails.application.config.session_options[:key] # don't clear session cookie
       cookies.delete(key)
-    end 
-  end 
+    end
+  end
 
   # clear Rails session cookie if not logged in so nginx uses the page cache
   # https://ryanfb.xyz/etc/2021/08/29/going_cookie-free_with_rails.html

--- a/docs/setup_with_docker.md
+++ b/docs/setup_with_docker.md
@@ -68,3 +68,7 @@ Solution:
     * `--rm` ensures that you do not create orphaned containers
 * Add `byebug` to the file you wish to add a break point and debug.
 * Happy debugging!
+
+# Running tests in Docker
+
+* Run `docker compose run app rspec`

--- a/spec/features/homepage_spec.rb
+++ b/spec/features/homepage_spec.rb
@@ -23,11 +23,17 @@ RSpec.feature "Reading Homepage", type: :feature do
     scenario "homepage" do
       visit "/"
 
+      expect(page).to have_content(story.title)
+    end
+    
+    scenario "homepage with unknown cookies" do
+      page.driver.request.cookies[:unknown_cookie] = "value"
+      visit "/" # should clear unknown cookies    
+
       expect(page.driver.request.cookies.length).to be(2)
       expect(page.driver.request.cookies["lobster_trap"]).to_not be_nil
-      expect(page.driver.request.cookies["__profilin"]).to_not be_nil
-
-      expect(page).to have_content(story.title)
+      expect(page.driver.request.cookies["__profilin"]).to_not be_nil # Cookie set by Rack::MiniProfiler. This can not be cleared.
+      expect(page.driver.request.cookies["unknown_cookie"]).to be_nil # should be cleared
     end
 
     scenario "shows previews if the user wants" do

--- a/spec/features/homepage_spec.rb
+++ b/spec/features/homepage_spec.rb
@@ -25,10 +25,10 @@ RSpec.feature "Reading Homepage", type: :feature do
 
       expect(page).to have_content(story.title)
     end
-    
+
     scenario "homepage with unknown cookies" do
       page.driver.request.cookies[:unknown_cookie] = "value"
-      visit "/" # should clear unknown cookies    
+      visit "/" # should clear unknown cookies
 
       expect(page.driver.request.cookies.length).to be(2)
       expect(page.driver.request.cookies["lobster_trap"]).to_not be_nil

--- a/spec/features/homepage_spec.rb
+++ b/spec/features/homepage_spec.rb
@@ -8,6 +8,9 @@ RSpec.feature "Reading Homepage", type: :feature do
   feature "when logged out" do
     scenario "homepage" do
       visit "/"
+
+      expect(page.driver.request.cookies).to be_empty
+
       expect(page).to have_content(story.title)
     end
   end
@@ -19,6 +22,11 @@ RSpec.feature "Reading Homepage", type: :feature do
 
     scenario "homepage" do
       visit "/"
+
+      expect(page.driver.request.cookies.length).to be(2)
+      expect(page.driver.request.cookies["lobster_trap"]).to_not be_nil
+      expect(page.driver.request.cookies["__profilin"]).to_not be_nil
+
       expect(page).to have_content(story.title)
     end
 


### PR DESCRIPTION
**Issue**: https://github.com/lobsters/lobsters/issues/1594 

**To do:** 

- [x] Add an ApplicationController before_action to delete any cookies that aren't the two we use. 
- [x] Reference the names using TAG_FILTER_COOKIE and Rails.application.config.session_options[:key].
- [x] If the session is empty because the user logged out or never logged in, delete it. ApplicationController has clear_lobster_trap but it's not working. 
- [x] Rename to clear_session_cookie for clarity and generality.
- [x] Write tests
- [x] Verify all tests pass locally
- [x] Update docker notes with command on how to run tests locally via docker. 