### PR TITLE
fix: replace hardcoded paths outside hatchbox dir

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,7 +89,7 @@ GEM
     benchmark (0.4.0)
     benchmark-perf (0.6.0)
     bigdecimal (3.1.9)
-    brakeman (7.0.2)
+    brakeman (7.1.0)
       racc
     builder (3.3.0)
     byebug (11.1.3)

--- a/app/jobs/restic_job.rb
+++ b/app/jobs/restic_job.rb
@@ -3,6 +3,11 @@ class ResticJob < ApplicationJob
 
   def perform(*args)
     shared = "/home/deploy/lobsters/shared"
+    # Check if the shared directory exists
+    unless File.directory?(shared)
+      Rails.logger.warn "ResticJob: Shared path '#{shared}' does not exist. Skipping backup."
+      return
+    end
     system("source #{shared}/etc/restic-env ; restic backup --no-scan #{shared}/etc #{shared}/log")
   end
 end

--- a/config/database.yml.sample
+++ b/config/database.yml.sample
@@ -44,9 +44,9 @@ production:
     database: lobsters
   cache:
     <<: *sqlite3
-    database: /home/deploy/lobsters/shared/storage/cache.sqlite3
+    database: storage/cache.sqlite3
     migrations_paths: db/cache_migrate
   queue:
     <<: *sqlite3
-    database: /home/deploy/lobsters/shared/storage/queue.sqlite3
+    database: storage/queue.sqlite3
     migrations_paths: db/queue_migrate

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -68,7 +68,7 @@ Rails.application.configure do
   # https://hatchbox.relationkit.io/articles/61-accessing-your-server-logs-in-hatchbox
   config.logger = ActiveSupport::BroadcastLogger.new(
     ActiveSupport::Logger.new($stdout),
-    ActiveSupport::Logger.new("/home/deploy/lobsters/shared/log/rails.log")
+    ActiveSupport::Logger.new(Rails.root.join("log/rails.log"))
   )
   config.logger.formatter = config.log_formatter
 
@@ -78,7 +78,7 @@ Rails.application.configure do
   # SolidQueue log to stdout for hatchbox UI and a file for grep
   config.solid_queue.logger = ActiveSupport::BroadcastLogger.new(
     ActiveSupport::Logger.new($stdout),
-    ActiveSupport::Logger.new("/home/deploy/lobsters/shared/log/solid_queue.log")
+    ActiveSupport::Logger.new(Rails.root.join("log/solid_queue.log"))
   )
 
   # Use a different cache store in production.
@@ -122,7 +122,7 @@ Rails.application.configure do
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 
-  config.active_storage.service = :production
+  config.active_storage.service = :local
 end
 
 # disable some excessive logging in production

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -5,7 +5,7 @@ require "silencer/rails/logger"
 
 Rails.application.configure do
   config.lograge.formatter = Lograge::Formatters::Json.new
-  config.lograge.logger = ActiveSupport::Logger.new(Rails.env.production? ? "/home/deploy/lobsters/shared/log/action.log" : $stdout, skip_header: true)
+  config.lograge.logger = ActiveSupport::Logger.new(Rails.env.production? ? Rails.root.join("log/action.log") : $stdout, skip_header: true)
 
   filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)
   config.lograge.custom_options = lambda do |event|

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -1,7 +1,3 @@
 local:
   service: Disk
   root: <%= Rails.root.join("storage") %>
-
-production:
-  service: Disk
-  root: /home/deploy/lobsters/shared/shared/storage


### PR DESCRIPTION
This PR is to replace all hardcoded paths outside of hatchbox & script dirs.

Although there is one more case in `config/puma.rb`,  it can be bypassed by using `PIDFILE` env variable.(or maybe we can just remove the path there for production env, let target deployment set the PIDFILE explicitly) 

https://github.com/lobsters/lobsters/blob/d6194605f17fd2354f524077f9875ec2ce1fc26c/config/puma.rb#L30

Background: https://github.com/lobsters/lobsters/pull/1667#issuecomment-3080262996

