### PR TITLE
Fix error on moderations filter with no results

### DIFF
--- a/app/controllers/moderations_controller.rb
+++ b/app/controllers/moderations_controller.rb
@@ -52,7 +52,7 @@ class ModerationsController < ApplicationController
     @pages = helpers.page_count(@moderations.count, ENTRIES_PER_PAGE)
     @page = moderation_params.fetch(:page) { 1 }.to_i
 
-    if @page <= 0 || @page > (2**32) || @page > @pages
+    if @page <= 0 || @page > (2**32) || (@pages > 0 && @page > @pages)
       raise ActionController::RoutingError.new("page out of bounds")
     end
 

--- a/spec/requests/moderations_spec.rb
+++ b/spec/requests/moderations_spec.rb
@@ -64,5 +64,19 @@ RSpec.describe "moderations", type: :request do
         expect(response.body).to include("Page 2")
       end
     end
+    
+    context "when filtering with no matching results" do
+      it "shows an empty page without error", :aggregate_failures do
+        # Create some domain moderations but no user moderations
+        Moderation.create!(domain: domain, action: "Updated domain")
+        
+        # Filter for user moderations which don't exist
+        get "/moderations", params: {what: {users: "users"}}
+        
+        expect(response).to be_successful
+        expect(response.body).to include("Moderation Log")
+        expect(response.body).not_to include(domain.domain)
+      end
+    end
   end
 end

--- a/spec/requests/moderations_spec.rb
+++ b/spec/requests/moderations_spec.rb
@@ -64,15 +64,15 @@ RSpec.describe "moderations", type: :request do
         expect(response.body).to include("Page 2")
       end
     end
-    
+
     context "when filtering with no matching results" do
       it "shows an empty page without error", :aggregate_failures do
         # Create some domain moderations but no user moderations
         Moderation.create!(domain: domain, action: "Updated domain")
-        
+
         # Filter for user moderations which don't exist
         get "/moderations", params: {what: {users: "users"}}
-        
+
         expect(response).to be_successful
         expect(response.body).to include("Moderation Log")
         expect(response.body).not_to include(domain.domain)


### PR DESCRIPTION
This is not urgent as I assume you will never run into this error on the actual site. 

I setup a newer docker instance and went to the moderation log. I removed all the filters except the user filter. http://localhost:3000/moderations?moderator=%28All%29&what%5Busers%5D=users

Docker output:
```
lobsters-app-1  | Started GET "/moderations?moderator=%28All%29&what%5Busers%5D=users" for 172.20.0.1 at 2025-07-22 01:57:17 +0000
lobsters-app-1  | Processing by ModerationsController#index as HTML
lobsters-app-1  |   Parameters: {"moderator" => "(All)", "what" => {"users" => "users"}}
lobsters-app-1  |   User Load (1.1ms)  SELECT `users`.* FROM `users` WHERE `users`.`session_token` = 'JmLib2xPwmGLT1QpGsVY1bgx8jGGIs1P4efuxPacR9OENC97p0rADg0dnTEh' LIMIT 1 /*action='index',controller='moderations'*/
lobsters-app-1  |   ↳ app/controllers/concerns/authenticatable.rb:17:in 'Authenticatable#authenticate_user'
lobsters-app-1  |   Keystore Pluck (1.2ms)  SELECT `keystores`.`value` FROM `keystores` WHERE `keystores`.`key` = 'traffic:intensity' LIMIT 1 /*action='index',controller='moderations'*/
lobsters-app-1  |   ↳ app/models/keystore.rb:15:in 'Keystore.value_for'
lobsters-app-1  |   User Load (1.2ms)  SELECT `users`.* FROM `users` WHERE (
lobsters-app-1  |       is_moderator = True OR
lobsters-app-1  |       users.id IN (select distinct moderator_user_id from moderations where token not in ('moderation_01j6ax48wpfb4vas8qgv8vmg20', 'moderation_01j79djrajfa5a56bbpmb6msde', 'moderation_01j8myn90rey8axkbw0hntxfqe', 'moderation_01j8n06kdrf5n92txy802evnz3', 'moderation_01jajsjdd5fva8qdwgmc2es9gp', 'moderation_01jat93zq7fgmr8dm6fc411g2c', 'moderation_01jdgt4btvfvear3hphy79104f', 'moderation_01jhzbz2mafxrsbmmr3trh760c', 'moderation_01jmsbwaqxf2bbwws92cv8688k', 'moderation_01jnywh2rxekqa61seqmk8z3f7'))
lobsters-app-1  |     ) /*action='index',controller='moderations'*/
lobsters-app-1  |   ↳ app/controllers/moderations_controller.rb:10:in 'Enumerable#map'
lobsters-app-1  |   Moderation Count (1.0ms)  SELECT COUNT(DISTINCT `moderations`.`id`) FROM `moderations` LEFT OUTER JOIN `users` ON `users`.`id` = `moderations`.`moderator_user_id` LEFT OUTER JOIN `stories` ON `stories`.`id` = `moderations`.`story_id` LEFT OUTER JOIN `comments` ON `comments`.`id` = `moderations`.`comment_id` LEFT OUTER JOIN `stories` `stories_comments` ON `stories_comments`.`id` = `comments`.`story_id` LEFT OUTER JOIN `users` `users_comments` ON `users_comments`.`id` = `comments`.`user_id` LEFT OUTER JOIN `tags` ON `tags`.`id` = `moderations`.`tag_id` LEFT OUTER JOIN `users` `users_moderations` ON `users_moderations`.`id` = `moderations`.`user_id` LEFT OUTER JOIN `domains` ON `domains`.`id` = `moderations`.`domain_id` LEFT OUTER JOIN `origins` ON `origins`.`id` = `moderations`.`origin_id` LEFT OUTER JOIN `categories` ON `categories`.`id` = `moderations`.`category_id` WHERE `moderations`.`story_id` IS NULL AND `moderations`.`comment_id` IS NULL AND `moderations`.`tag_id` IS NULL AND `moderations`.`domain_id` IS NULL AND `moderations`.`origin_id` IS NULL AND `moderations`.`category_id` IS NULL /*action='index',controller='moderations'*/
lobsters-app-1  |   ↳ app/controllers/moderations_controller.rb:52:in 'ModerationsController#index'
lobsters-app-1  | Completed 404 Not Found in 27ms (ActiveRecord: 2.6ms (4 queries, 0 cached) | GC: 0.0ms)
lobsters-app-1  | 
lobsters-app-1  | 
lobsters-app-1  | {"method":"GET","path":"/moderations?moderator=%28All%29&what%5Busers%5D=users","format":"html","controller":"ModerationsController","action":"index","status":404,"allocations":4970,"duration":27.14,"view":0.0,"db":2.62,"timestamp":"2025-07-22T01:57:17.813Z","params":{"moderator":"(All)","what":{"users":"users"}},"exception":"ActionController::RoutingError","exception_message":"page out of bounds","remote_ip":"172.20.0.1","user_id":2,"username":"test"}
lobsters-app-1  |   
lobsters-app-1  | ActionController::RoutingError (page out of bounds):
lobsters-app-1  |   
lobsters-app-1  | app/controllers/moderations_controller.rb:56:in 'ModerationsController#index'
```

I confirmed this error occurs via the unit test as well. If I revert the pages check the test fails - see below:
```
Failures:

  1) moderations #index when filtering with no matching results shows an empty page without error
     Failure/Error: raise ActionController::RoutingError.new("page out of bounds")

     ActionController::RoutingError:
       page out of bounds
     # ./app/controllers/moderations_controller.rb:56:in 'ModerationsController#index'
     # /Users/twodayslate/.rvm/gems/ruby-3.4.3/gems/turbo-rails-2.0.11/lib/turbo-rails.rb:24:in 'Turbo.with_request_id'
     # /Users/twodayslate/.rvm/gems/ruby-3.4.3/gems/turbo-rails-2.0.11/app/controllers/concerns/turbo/request_id_tracking.rb:10:in 'Turbo::RequestIdTracking#turbo_tracking_request_id'
     # /Users/twodayslate/.rvm/gems/ruby-3.4.3/gems/sentry-rails-5.24.0/lib/sentry/rails/rescued_exception_interceptor.rb:11:in 'Sentry::Rails::RescuedExceptionInterceptor#call'
     # /Users/twodayslate/.rvm/gems/ruby-3.4.3/gems/request_store-1.7.0/lib/request_store/middleware.rb:19:in 'RequestStore::Middleware#call'
     # ./spec/requests/moderations_spec.rb:74:in 'block (4 levels) in <top (required)>'
```

pages is 0, page is 1 and moderations.count is also 0 in the error case I experienced. You get the error due to only checking that page > pages but if pages is zero nothing should display