### PR TITLE
fix: hidden by info should come after hide link

### DIFF
--- a/app/views/stories/_singledetail.html.erb
+++ b/app/views/stories/_singledetail.html.erb
@@ -92,6 +92,14 @@ classes = [
             <span> | </span><%= link_to "hide", story_hide_path(ms.short_id), :class => "hider" %>
           <% end %>
 
+          <% if ms.hider_count > 0 %>
+            <% if ms.is_hidden_by_cur_user %>
+              (hidden by you and <%= pluralize(ms.hider_count - 1, "other user") %>)
+            <% else %>
+              (hidden by <%= pluralize(ms.hider_count, "user") %>)
+            <% end %>
+          <% end %>
+
           <% if ms.disownable_by_user?(@user) %>
             |
             <%= link_post "disown", story_disown_path(ms.short_id), { confirm: "Are you sure you want to disown this story?"} %>
@@ -101,14 +109,6 @@ classes = [
             <span> | </span><%= link_to "save", story_save_path(ms.short_id), :class => "saver" %>
           <% else %>
             <span> | </span><%= link_to "unsave", story_unsave_path(ms.short_id), :class => "saver" %>
-          <% end %>
-        <% end %>
-
-        <% if ms.hider_count > 0 %>
-          <% if ms.is_hidden_by_cur_user %>
-            (hidden by you and <%= pluralize(ms.hider_count - 1, "other user") %> )
-          <% else %>
-            (hidden by <%= pluralize(ms.hider_count, "user") %>)
           <% end %>
         <% end %>
 


### PR DESCRIPTION
When testing the hide/unhide feature locally, i found the "hidden by" info is displayed after "save/unsave" section, ideally it should come after the "hide/unhide" section?

Since i don't have an account on lobste.rs, i'm not sure if current behaviour is expected or not. if it's on purpose please feel free to close the PR.

---

Before:

<img width="1830" height="293" alt="image" src="https://github.com/user-attachments/assets/38824035-45f7-477c-8411-ef7d8264f6cc" />

After:

<img width="1830" height="293" alt="image" src="https://github.com/user-attachments/assets/0f19b1d9-f66f-44a1-b1e8-faa057b9fce9" />
