### PR TITLE
fix(mod_note): prevent creating duplicate mod note when preview

### DIFF
--- a/app/models/mod_note.rb
+++ b/app/models/mod_note.rb
@@ -209,7 +209,7 @@ class ModNote < ApplicationRecord
   # and save attempts, leading to duplicate notes
   def self.create_without_dupe!(attrs)
     latest = attrs[:user].mod_notes.last
-    return latest if latest && attrs[:moderator] == latest.moderator && attrs[:note] == latest.note
+    return latest if latest && attrs[:moderator] == latest.moderator && attrs[:note].strip == latest.note
     ModNote.create!(attrs)
   end
 end

--- a/app/models/mod_note.rb
+++ b/app/models/mod_note.rb
@@ -31,7 +31,7 @@ class ModNote < ApplicationRecord
   end
 
   def note=(n)
-    self[:note] = n.to_s.strip
+    self[:note] = n
     self.markeddown_note = generated_markeddown
   end
 
@@ -209,7 +209,7 @@ class ModNote < ApplicationRecord
   # and save attempts, leading to duplicate notes
   def self.create_without_dupe!(attrs)
     latest = attrs[:user].mod_notes.last
-    return latest if latest && attrs[:moderator] == latest.moderator && attrs[:note].strip == latest.note
+    return latest if latest && attrs[:moderator] == latest.moderator && attrs[:note] == latest.note
     ModNote.create!(attrs)
   end
 end

--- a/app/views/stories/new.html.erb
+++ b/app/views/stories/new.html.erb
@@ -21,7 +21,7 @@
 </div>
 
 <div id="story_preview">
-  <% if @story.previewing && @story.valid? %>
+  <% if @story.previewing && @story.errors.empty? %>
     <%= render :template => "stories/show" %>
   <% end %>
 </div>

--- a/spec/features/submit_story_spec.rb
+++ b/spec/features/submit_story_spec.rb
@@ -31,6 +31,22 @@ RSpec.feature "Submitting Stories", type: :feature do
     expect(page).to have_content "just now"
   end
 
+  scenario "new user previewing an unseen domain" do
+    inactive_user # TODO: remove reference after satisfying rubocop RSpec/LetSetup properly
+    user.update!(created_at: 1.day.ago)
+    refute(Domain.where(domain: "example.net").exists?)
+    expect {
+      visit "/stories/new"
+      fill_in "URL", with: "https://example.net/story"
+      fill_in "Title", with: "Example Story"
+      select :tag1, from: "Tags"
+      click_button "Preview"
+
+      expect(page).to have_content "unseen domain"
+    }.to(change { ModNote.count }.by(1))
+    expect(ModNote.last.user).to eq(user)
+  end
+
   context "submitting an inline image" do
     context "as a user who is not a moderator" do
       scenario "results in a link, not an image" do


### PR DESCRIPTION
Found a bug(creating duplicate mod notes) when a new user submit a story from a unseen domain.
