### PR TITLE
fix(unvote): clear arrow highlight after unvoting

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -469,7 +469,7 @@ div.voters {
 	-webkit-text-stroke: 1px var(--color-fg-contrast-4-5);
 }
 .upvoted .upvoter:before, .upvoter:hover:before {
-	color: var(--color-fg-accent) !important;
+	color: var(--color-fg-accent);
 	-webkit-text-stroke: 1px var(--color-fg-accent);
 }
 .upvoter {
@@ -1651,10 +1651,12 @@ input[type="submit"].link_post.pushover_button {
 	/* explicitly reset color when not upvoted, since previously-upvoted arrow
 	 * will still be triggering :hover until next tap */
 	div.voters .upvoter:hover:before {
-		color: var(--color-fg-shape);
+		color: transparent;
+		-webkit-text-stroke: 1px var(--color-fg-contrast-4-5);
 	}
 	.upvoted div.voters .upvoter:before {
 		color: var(--color-fg-accent);
+		-webkit-text-stroke: 1px var(--color-fg-accent);
 	}
 
 	ol.stories.list {


### PR DESCRIPTION
Fix #1680 

That bug i think was introduced by #1645, previously there is a logic for mobile device to explicitly clear the highlight color, however that logic was ignored by the `!important`.

This PR reverts the change made in #1645 and provides another solution to fix the original issue described in #1645