### PR TITLE
Mention on /chat that IRC keeps no history

### DIFF
--- a/app/views/about/chat.html.erb
+++ b/app/views/about/chat.html.erb
@@ -22,15 +22,20 @@
   </p>
 
   <p>
-  If you're new to IRC, you'll have the easiest time joining with the official <a href="https://web.libera.chat/#lobsters">Libera web chat</a>.
+  If you're new to IRC, bear in mind that the channel may appear empty; you won't see any messages that were sent before you joined or whilst you were away.
+  The channel is most active during US work hours and there are usually 100&ndash;1000 messages a day.
+  If you leave the channel open you'll probably catch a discussion.
+  The channel isn't busy enough that there's always someone talking, so don't be surprised if you try to start a conversation and no one responds.
+  The easiest way to join is with the official <a href="https://web.libera.chat/#lobsters">Libera web chat</a>.
+  </p>
+
+  <p>
   If you're familiar with IRC, join <a href="ircs://irc.libera.chat/lobsters"><tt>#lobsters</tt></a> on <tt>irc.libera.chat</tt>.
   </p>
 
   <p>
   The policies and ideals of the discussion channel are the same as the website; quality content and conversing, respect for other users, and no spamming.
   Slightly off-topic discussion is generally acceptable, but we're still not open to discussion of electoral politics and policies.
-  The channel isn't busy enough that there's always someone talking, so don't be surprised if you try to start a conversation and no one responds.
-  Leave it open and you'll see activity, though we're most active during US work hours.
   </p>
 
   <p>


### PR DESCRIPTION
Semi-frequently, somebody will join #lobsters, say hi, get no response in 5 minutes, and leave. Explain that IRC won't show any history, and give an idea of the activity level of the channel. The messages per day statistic comes from my Weechat logs.

I've put this before the link to the web chat, under the theory that as soon as somebody sees how to join, they'll stop reading the page.

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
