### PR TITLE
Add inbox_mentions setting

### DIFF
--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -275,7 +275,7 @@ class SettingsController < ApplicationController
   def user_params
     params.require(:user).permit(
       :username, :email, :password, :password_confirmation, :homepage, :about,
-      :email_replies, :email_messages, :email_mentions,
+      :email_replies, :email_messages, :email_mentions, :inbox_mentions,
       :pushover_replies, :pushover_messages, :pushover_mentions,
       :mailing_list_mode, :show_email, :show_avatars, :show_story_previews,
       :show_submitted_story_threads, :prefers_color_scheme, :prefers_contrast

--- a/app/jobs/notify_comment_job.rb
+++ b/app/jobs/notify_comment_job.rb
@@ -15,7 +15,9 @@ class NotifyCommentJob < ApplicationJob
   def deliver_mention_notifications(comment, notified)
     to_notify = comment.plaintext_comment.scan(/\B[@~]([\w\-]+)/).flatten.uniq - notified - [comment.user.username]
     User.active.where(username: to_notify).find_each do |u|
-      u.notifications.create(notifiable: comment)
+      if u.inbox_mentions?
+        u.notifications.create(notifiable: comment)
+      end
 
       if u.email_mentions?
         begin

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -78,6 +78,7 @@ class User < ApplicationRecord
     s.boolean :email_messages, default: false
     s.boolean :pushover_messages, default: false
     s.boolean :email_mentions, default: false
+    s.boolean :inbox_mentions, default: true
     s.boolean :show_avatars, default: true
     s.boolean :show_email, default: false
     s.boolean :show_story_previews, default: false

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -85,6 +85,8 @@
       <h2>Comment Mention Notification Settings</h2>
 
       <div class="labelled_grid">
+        <%= f.label :inbox_mentions, "Show in Inbox", :class => "required for_checkbox" %>
+        <span><%= f.check_box :inbox_mentions %></span>
         <%= f.label :email_mentions, "Receive E-mail", :class => "required for_checkbox" %>
         <span><%= f.check_box :email_mentions %></span>
         <%= f.label :pushover_mentions, "Receive Pushover Alert",

--- a/spec/jobs/notify_comment_job_spec.rb
+++ b/spec/jobs/notify_comment_job_spec.rb
@@ -47,6 +47,35 @@ RSpec.describe NotifyCommentJob, type: :job do
       expect(recipient.notifications.first.notifiable).to eq(c)
     end
 
+    it "creates inbox notification when inbox_mentions is true" do
+      recipient = build(:user)
+      recipient.settings["inbox_mentions"] = true
+      recipient.save!
+
+      sender = create(:user)
+      c = build(:comment, user: sender, comment: "@#{recipient.username}")
+      c.save!
+
+      NotifyCommentJob.perform_now(c)
+
+      expect(recipient.notifications.count).to eq(1)
+      expect(recipient.notifications.first.notifiable).to eq(c)
+    end
+
+    it "does not create inbox notification when inbox_mentions is false" do
+      recipient = build(:user)
+      recipient.settings["inbox_mentions"] = false
+      recipient.save!
+
+      sender = create(:user)
+      c = build(:comment, user: sender, comment: "@#{recipient.username}")
+      c.save!
+
+      NotifyCommentJob.perform_now(c)
+
+      expect(recipient.notifications.count).to eq(0)
+    end
+
     it "also sends mentions with ~username" do
       recipient = build(:user)
       recipient.settings["email_notifications"] = true


### PR DESCRIPTION
Since people keep mentioning cadey in the friendlysock thread, this
seems like a good time to add a setting.

This is a really basic subset of https://github.com/lobsters/lobsters/issues/872

I can add the other booleans as well, but thought i'd start with the most minimal needed change.
