### PR TITLE
Disable autocapitalization on the search field

### DIFF
--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -2,7 +2,7 @@
 <div class="box">
   <%= form_with url: '/search', method: :get do |f| %>
     <div class="boxline">
-        <%= f.text_field "q", { :value => @search.q, :size => 40 }.
+        <%= f.text_field "q", { :value => @search.q, :size => 40, :autocapitalize => "none" }.
         merge(@search.q.present? ? {} : { :autofocus => "autofocus" }) %>
       <input type="submit" value="Search">
     </div>


### PR DESCRIPTION
Fixes #1185

This felt like the right way to fix this bug:
1. It's super easy
2. I don't think a search field should be autocapitalized anyway.

For the record, the search field on google.com has `autocapitalize="off"` .