### PR TITLE
Remove story_liner background color for visual consistency

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1704,7 +1704,6 @@ input[type="submit"].link_post.pushover_button {
 		display: table;
 	}
 	ol.stories.list li.story div.story_liner {
-		background-color: var(--color-mobile-story-liner-bg);
 		display: table-cell;
 		padding-top: 0.5em;
 		padding-bottom: 0.75em;

--- a/app/assets/stylesheets/dark-high.css
+++ b/app/assets/stylesheets/dark-high.css
@@ -73,7 +73,6 @@
 	--color-lobsters-hat-sysop-brim-stroke: #6f4444;
 
 	/* mobile */
-	--color-mobile-story-liner-bg: #000;
 	--color-mobile-story-comments-bubble-fill: #333;
 	--color-mobile-story-comments-bubble-fill-zero: #222;
 }

--- a/app/assets/stylesheets/dark-normal.css
+++ b/app/assets/stylesheets/dark-normal.css
@@ -73,7 +73,6 @@
 	--color-lobsters-hat-sysop-brim-stroke: #2c2222;
 
 	/* mobile */
-	--color-mobile-story-liner-bg: #0c0c0c;
 	--color-mobile-story-comments-bubble-fill: #282828;
 	--color-mobile-story-comments-bubble-fill-zero: #1c1c1c;
 }

--- a/app/assets/stylesheets/light-high.css
+++ b/app/assets/stylesheets/light-high.css
@@ -73,7 +73,6 @@
 	--color-lobsters-hat-sysop-brim-stroke: #cc8080;
 
 	/* mobile */
-	--color-mobile-story-liner-bg: #fff;
 	--color-mobile-story-comments-bubble-fill: #999;
 	--color-mobile-story-comments-bubble-fill-zero: #666;
 }

--- a/app/assets/stylesheets/light-normal.css
+++ b/app/assets/stylesheets/light-normal.css
@@ -73,7 +73,6 @@
 	--color-lobsters-hat-sysop-brim-stroke: #bbb2b2;
 
 	/* mobile */
-	--color-mobile-story-liner-bg: #fbfbfb;
 	--color-mobile-story-comments-bubble-fill: #ccc;
 	--color-mobile-story-comments-bubble-fill-zero: #d8d8d8;
 }


### PR DESCRIPTION
<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->

## Summary

Resolves https://github.com/lobsters/lobsters/issues/1723

Makes background colors more consistent by removing a slightly different background color that appears on part of some pages in the light color theme only.

## Alternative solution

Another approach would be to keep the slightly different background color, and extend it to the other color themes. Taking this approach, the slightly different background color in the "before" screenshot below would also appear in the dark and high-contrast themes.

In my opinion, a consistent background color (this PR's current approach) looks better, but happy to consider other points of view.

## Screenshots

The "before" image shows a slightly darker background color on the inner part (not including the comment bubbles and page selector).

| before | after |
|---|---|
| <img alt="image" src="https://github.com/user-attachments/assets/2eaec143-2a3f-4646-865a-6fe9e9d39565" /> | <img alt="image" src="https://github.com/user-attachments/assets/291ad43d-11ea-4952-be0f-6e6b8b352f96" /> |

For the other color themes, this background color is the same as the main background color, i.e. `--color-mobile-story-liner-bg` is the same as `--base-bg`. In the output below, only the last pair (`254 254 254` and `#fbfbfb`) are actually different colors.

```sh
lobsters git:(main) $ git grep -E "(--color-mobile-story-liner-bg|--base-bg):"
app/assets/stylesheets/dark-high.css:        --base-bg: 0 0 0;
app/assets/stylesheets/dark-high.css:        --color-mobile-story-liner-bg: #000;
app/assets/stylesheets/dark-normal.css:        --base-bg: 12 12 12;
app/assets/stylesheets/dark-normal.css:        --color-mobile-story-liner-bg: #0c0c0c;
app/assets/stylesheets/light-high.css:        --base-bg: 255 255 255;
app/assets/stylesheets/light-high.css:        --color-mobile-story-liner-bg: #fff;
app/assets/stylesheets/light-normal.css:        --base-bg: 254 254 254;
app/assets/stylesheets/light-normal.css:        --color-mobile-story-liner-bg: #fbfbfb;
```