### PR TITLE
Update uri to 1.0.4 for security patches

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -425,7 +425,7 @@ GEM
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.1.0)
-    uri (1.0.3)
+    uri (1.0.4)
     useragent (0.16.11)
     uuid7 (0.2.0)
       zeitwerk (~> 2.4)


### PR DESCRIPTION
Fixes a CVE in the uri library

    Name: uri
    Version: 1.0.3
    CVE: CVE-2025-61594
    Criticality: Unknown
    URL: https://www.ruby-lang.org/en/news/2025/10/07/uri-cve-2025-61594
    Title: CVE-2025-61594 - URI Credential Leakage Bypass over CVE-2025-27221
    Solution: update to '~> 0.12.5', '~> 0.13.3', '>= 1.0.4'
