### PR TITLE
Add rel="ugc" to all links in Markdown

### DIFF
--- a/extras/markdowner.rb
+++ b/extras/markdowner.rb
@@ -46,11 +46,7 @@ class Markdowner
 
     # make links have rel=ugc
     ng.css("a").each do |h|
-      h[:rel] = "ugc" unless begin
-        URI.parse(h[:href]).host.nil?
-      rescue
-        false
-      end
+      h[:rel] = "ugc"
     end
 
     if ng.at_css("body")

--- a/spec/extras/markdowner_spec.rb
+++ b/spec/extras/markdowner_spec.rb
@@ -49,17 +49,30 @@ describe Markdowner do
         "test</a></p>\n")
   end
 
-  it "correctly adds ugc" do
-    expect(Markdowner.to_html("[ex](http://example.com)"))
-      .to eq("<p><a href=\"http://example.com\" rel=\"ugc\">" \
-            "ex</a></p>\n")
+  it "adds ugc" do
+    expect(Markdowner.to_html("[full URL](http://example.com)"))
+      .to eq("<p><a href=\"http://example.com\" rel=\"ugc\">full URL</a></p>\n")
 
-    expect(Markdowner.to_html("[ex](//example.com)"))
-      .to eq("<p><a href=\"//example.com\" rel=\"ugc\">" \
-            "ex</a></p>\n")
+    expect(Markdowner.to_html("[protocol-relative URL](//example.com)"))
+      .to eq("<p><a href=\"//example.com\" rel=\"ugc\">protocol-relative URL</a></p>\n")
 
-    expect(Markdowner.to_html("[ex](/~abc)"))
-      .to eq("<p><a href=\"/~abc\">ex</a></p>\n")
+    # invalid URLs that are still parsed as links (not an exhaustive list)
+    expect(Markdowner.to_html("[missing protocol](example.com)"))
+      .to eq("<p><a href=\"example.com\" rel=\"ugc\">missing protocol</a></p>\n")
+
+    expect(Markdowner.to_html("[wrong number of slashes after protocol](http:/example.com)"))
+      .to eq("<p><a href=\"http:/example.com\" rel=\"ugc\">wrong number of slashes after protocol</a></p>\n")
+
+    # relative links
+    expect(Markdowner.to_html("[relative link](/example)"))
+      .to eq("<p><a href=\"/example\" rel=\"ugc\">relative link</a></p>\n")
+
+    expect(Markdowner.to_html("[relative link to user profile](/~abc)"))
+      .to eq("<p><a href=\"/~abc\" rel=\"ugc\">relative link to user profile</a></p>\n")
+
+    # autolink
+    expect(Markdowner.to_html("www.example.com"))
+      .to eq("<p><a href=\"http://www.example.com\" rel=\"ugc\">www.example.com</a></p>\n")
   end
 
   it "escapes raw HTML" do


### PR DESCRIPTION
<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->

## Summary

Resolves #1728 

Adjusts `Markdowner::to_html` to add `rel="ugc"` to all links.

Previously, it was added only to links with a non-nil `URI::HTTP#host`, so links were not getting `rel="ugc"` when the URL lacked a host, or the host could not be parsed. This was the case in the two examples in the Issue (relative links, and URLs missing one protocol slash).

## Note: why should _all_ links get `rel="ugc"`?

The UGC attribute [should be present in all links that appear in user-generated content](https://ahrefs.com/seo/glossary/ugc-link-attribute). That's why I changed `Markdowner` to add `rel="ugc"` to _all_ links, rather than trying to account for just the two cases that the Issue mentioned.