### PR TITLE
Remove bold styling from "caches" link

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1650,7 +1650,8 @@ input[type="submit"].link_post.pushover_button {
 		margin: 0.5rem;
 	}
 
-	label:not(:has(> input[type="radio"])) {
+	form label:not(:has(> input[type="radio"])),
+	.profile label {
 		font-weight: bold;
 	}
 


### PR DESCRIPTION
<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->

## Summary

Resolves #1751 

Removes bold styling on mobile from all "caches" links, by applying bold on mobile only to labels that are (a) within a form, or (b) on the Profile page.

The bold on the "caches" link was accidentally introduced (by me) in [`24da9ec` (#1737)](https://github.com/lobsters/lobsters/pull/1737/commits/24da9ec66f8408a2a42dbec20920dcf2f8b0a567).

## Screenshots

Two of the affected views, and one that I made sure is not affected:

|  | home | story | profile (unchanged) |
|---|---|---|---|
| before | <img width="164" height="228" alt="image" src="https://github.com/user-attachments/assets/cebea510-53bd-418e-bc2c-efcc2449a3e2" /> | <img width="191" height="115" alt="image" src="https://github.com/user-attachments/assets/f5d69afe-5601-4174-ba83-550472b289f9" /> | <img width="164" height="296" alt="image" src="https://github.com/user-attachments/assets/c6dcddde-2098-40a3-9489-b6d27a63dfe0" /> |
| after | <img width="164" height="283" alt="image" src="https://github.com/user-attachments/assets/017070af-af03-49d3-bfec-92a3aabd4f1a" /> | <img width="190" height="115" alt="image" src="https://github.com/user-attachments/assets/6fa8b325-58d7-4c9f-8a07-4c278516b092" /> | <img width="166" height="304" alt="image" src="https://github.com/user-attachments/assets/26199648-4b49-4daa-a6ea-7eccec1443d5" /> |

## ~~"caches" links == labels with a `for` attribute starting with `"archive_"`~~

<details>
<summary>(referring to the previous implementation, no longer relevant)</summary>

```sh
lobsters git:(main) $ git grep '<label for="archive'
app/views/home/index.html.erb:            <label for="archive_<%= story.short_id %>" tabindex="0">caches</label>
app/views/search/index.html.erb:            <label for="archive_<%= story.short_id %>" tabindex="0">caches</label>
app/views/stories/_listdetail.html.erb:            <label for="archive_<%= story.short_id %>" tabindex="0">caches</label>
app/views/stories/_singledetail.html.erb:              <label for="archive_<%= ms.short_id %>" tabindex="0">caches</label>
app/views/stories/show.html.erb:                  <label for="archive_<%= ms.short_id %>" tabindex="0">caches</label>
```

shows the same lines as:

```sh
lobsters git:(main) $ git grep '>caches<'
app/views/home/index.html.erb:            <label for="archive_<%= story.short_id %>" tabindex="0">caches</label>
app/views/search/index.html.erb:            <label for="archive_<%= story.short_id %>" tabindex="0">caches</label>
app/views/stories/_listdetail.html.erb:            <label for="archive_<%= story.short_id %>" tabindex="0">caches</label>
app/views/stories/_singledetail.html.erb:              <label for="archive_<%= ms.short_id %>" tabindex="0">caches</label>
app/views/stories/show.html.erb:                  <label for="archive_<%= ms.short_id %>" tabindex="0">caches</label>
```
</details>