### PR TITLE
Fix HTML markup errors found by Herb

### DIFF
--- a/app/views/about/about.html.erb
+++ b/app/views/about/about.html.erb
@@ -260,7 +260,7 @@
   client.  These e-mails are then converted and submitted to the website as
   comments, just as if the comment was posted through a web browser.
   <%- raise "Don't just delete that error message. You didn't set up mailing list mode, right? This really isn't your about page, write one from scratch." if Rails.env.production? and Rails.application.name != 'Lobsters' -%>
-  </p>
+  </p></li>
 
   <li><p>
   <strong>Private messaging</strong> enables users to communicate privately

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -147,10 +147,11 @@ class="story <%= story.current_upvoted? ? "upvoted" : "" %>
             <span> | </span>
             <a role="heading" aria-level="2" href="<%= Routes.title_path story %>">
             <% if story.comments_count == 0 %>
-              no comments</a>
+              no comments
             <% else %>
-              <%= story.comments_count %> <%= 'comment'.pluralize(story.comments_count) %></a>
+              <%= story.comments_count %> <%= 'comment'.pluralize(story.comments_count) %>
             <% end %>
+            </a>
           </span>
         <% end %>
       <% end %>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -276,10 +276,11 @@ class="story <%= story.current_upvoted? ? "upvoted" : "" %>
             <span> | </span>
             <a role="heading" aria-level="2" href="<%= Routes.title_path story %>">
             <% if story.comments_count == 0 %>
-              no comments</a>
+              no comments
             <% else %>
-              <%= story.comments_count %> <%= 'comment'.pluralize(story.comments_count) %></a>
+              <%= story.comments_count %> <%= 'comment'.pluralize(story.comments_count) %>
             <% end %>
+            </a>
           </span>
         <% end %>
       <% end %>

--- a/app/views/stories/_listdetail.html.erb
+++ b/app/views/stories/_listdetail.html.erb
@@ -132,10 +132,11 @@ class="story <%= story.current_upvoted? ? "upvoted" : "" %>
             <span> | </span>
             <a role="heading" aria-level="2" href="<%= Routes.title_path story %>">
             <% if story.comments_count == 0 %>
-              no comments</a>
+              no comments
             <% else %>
-              <%= story.comments_count %> <%= 'comment'.pluralize(story.comments_count) %></a>
+              <%= story.comments_count %> <%= 'comment'.pluralize(story.comments_count) %>
             <% end %>
+            </a>
           </span>
         <% end %>
       <% end %>

--- a/app/views/stories/_singledetail.html.erb
+++ b/app/views/stories/_singledetail.html.erb
@@ -31,7 +31,7 @@ classes = [
 
   <% merged_stories.filter {it.can_be_seen_by_user?(@user)}.each do |ms| %>
     <div class="details" id="<%= ms.header_anchor %>">
-      <span role="heading" class="link" aria-level="1" class="link h-cite u-repost-of">
+      <span role="heading" aria-level="1" class="link h-cite u-repost-of">
         <a href="<%= Routes.url_or_comments_path(ms) %>" rel="ugc <%= ms.send_referrer? ? '' : 'noreferrer' %>" class="u-url"><%= ms.title %></a>
       </span>
 
@@ -152,7 +152,7 @@ classes = [
         <span class="comments_label">
           |
           <% cc = merged_stories.map(&:comments_count).sum %>
-          <%= (cc == 0) ? "no" : "total: #{cc}" %> <%= 'comment'.pluralize(cc) %></a>
+          <%= (cc == 0) ? "no" : "total: #{cc}" %> <%= 'comment'.pluralize(cc) %>
         </span>
       <% end %>
     </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -228,7 +228,6 @@
             <td><a href="/~<%= v.story.user.try(:username) %>"><%= v.story.user.try(:username) %></a></td>
             <td><a href="<%= Routes.title_path v.story %>"><%= v.story.title %></a></td>
           <% end %>
-          </p>
         </tr><% end %>
       </table>
 


### PR DESCRIPTION
Follow up on #1633 

This pull request fixes some of the parse errors Herb discovered using the [`herb analyze`](https://github.com/marcoroth/herb?tab=readme-ov-file#command-line-usage) command.

I also noticed that the fixed content in these files are identical and might benefit from being extracted to a partial:
- `app/views/home/index.html.erb`
- `app/views/search/index.html.erb`
- `app/views/stories/_listdetail.html.erb`

I intentionally didn't address any of the Herb Linter offenses yet, but I'm happy to go over those too if you want! 🙌🏼 