### PR TITLE
Add Speculation Rules prefetching for visitors

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -46,7 +46,7 @@
       href="<%= @comments_rss_link[:href] %>">
   <% end %>
   <meta name="robots" content="noai, noimageai">
-
+<% # only for logged-out users so we don't speculatively advance ReadRibbons %>
   <% if !@user %>
     <script type="speculationrules" nonce="<%= content_security_policy_nonce %>">
       {


### PR DESCRIPTION
<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->

## Summary

Resolves #1687

### Logged out

Prefetches are visible in the Chrome dev tools Application tab → Speculative loads → Rules.

https://github.com/user-attachments/assets/34c0a4f9-5c77-4eef-b661-3bf0de435baa

In the video above, prefetch failures start to appear after the second successful prefetch because Chrome allows only two prefetches at a time, and the "failures" come from the oldest prefetches being discarded as new ones are successfully loaded. You can see this in Speculative loads → Speculations:

<img width="651" height="289" alt="image" src="https://github.com/user-attachments/assets/8a23b6b1-2c54-4b13-bc47-c9b107d65005" />

### Logged in

No speculation rules are defined, because the script is absent from the page.

<img width="1173" height="772" alt="speculationrules-logged-in" src="https://github.com/user-attachments/assets/e83d2691-6076-4c2a-ada8-82c922167726" /> |

