### PR TITLE
Add https source to image policies

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -14,7 +14,7 @@ Rails.application.configure do
     policy.connect_src :self
 
     # Data URL used for Pushover logo in settings
-    policy.img_src :self, :data
+    policy.img_src :self, :data, :https
     policy.script_src :self
 
     # 18 inline styles to clean up before enabling this


### PR DESCRIPTION
This PR should close #1714.

The CSP error when loading images was happening because of the policies on images, which were `self` and `data.` That way, images could only be fetched from the same origin as the original document (e.g., lobste.rs/) or a [data URI](https://en.wikipedia.org/wiki/Data_URI_scheme).

This PR has the intent to add the `https` source as well. That way, images from `https` sources like [Imgur](https://imgur.com/) will be rendered without error.

Before:

<img width="1752" height="348" alt="image" src="https://github.com/user-attachments/assets/128d3b64-36e1-40ee-b0a5-3d208f4ed3c3" />

After:

<img width="1754" height="569" alt="image" src="https://github.com/user-attachments/assets/1e91d0ea-df8f-4005-ac3b-60e333f6750d" />

While testing, I had some issues with `page_caching`, where this bug doesn't occur on cached pages. After some investigation, I found out that this was because the Puma web server used in the development environment didn't handle CSP headers for cached pages, which led me to wonder that [Caddyfile](https://github.com/lobsters/lobsters/blob/a16def55062b9e3457b10e1fb243b2cffeb3d9ed/hatchbox/Caddyfile.pre#L65) should also include the `https` headers, but I'm not sure. Is it worth testing it locally, or will it not cover all the differences between development and production environments?