### PR TITLE
Omit extrapolated value from active users graph

### DIFF
--- a/app/models/stats.rb
+++ b/app/models/stats.rb
@@ -16,7 +16,8 @@ class Stats
   def self.fill_active_users_graph_cache
     cache_monthly_graph(:active_users, {
       graph_title: "Active users by month",
-      scale_y_divisions: 500
+      scale_y_divisions: 500,
+      extrapolate: false
     }) {
       stories = Story.pluck(:created_at, :user_id).map { |created_at, user_id| [created_at.strftime("%Y-%m"), user_id] }
       votes = Vote.pluck(:updated_at, :user_id).map { |updated_at, user_id| [updated_at.strftime("%Y-%m"), user_id] }
@@ -66,6 +67,7 @@ class Stats
     height: 300,
     graph_title: "Graph",
     show_graph_title: false,
+    extrapolate: true,
     no_css: false,
     key: false,
     scale_x_integers: true,
@@ -93,23 +95,11 @@ class Stats
   def self.cache_monthly_graph(name, opts)
     graph = TimeSeries.new(DEFAULTS.merge(opts))
     graph.add_data(
-      data: data_with_extrapolated_month(yield),
+      data: yield,
       template: "%Y-%m"
     )
     svg = graph.burn_svg_only
 
     Rails.cache.write(cache_key(name), svg, expires_in: 2.days)
-  end
-
-  def self.data_with_extrapolated_month(data)
-    current_month = data[-2]
-    current_month_extrapolated_value = (
-      data.last / (
-        Time.now.utc.day.to_f /
-        Time.days_in_month(Time.now.utc.month, Time.now.utc.year)
-      )
-    ).round
-
-    [*data, current_month, current_month_extrapolated_value]
   end
 end

--- a/app/views/stats/index.html.erb
+++ b/app/views/stats/index.html.erb
@@ -43,12 +43,12 @@ p svg { height: 10px; width: 10px; }
 .xAxisLabels { fill: var(--color-fg); }
 .yAxisLabels { fill: var(--color-fg); }
 .key1, .dataPoint1 { fill: var(--color-fg-accent); }
-circle:nth-last-of-type(2), circle:last-of-type, .outline circle {
+svg.extrapolate circle:nth-last-of-type(2), circle:last-of-type, .outline circle {
   fill: none;
   stroke: var(--color-fg-accent);
   stroke-width: 1;
 }
-svg:not(.outline) circle:last-of-type, .dashed circle { stroke-dasharray: 1; }
+svg.extrapolate circle:last-of-type, .dashed circle { stroke-dasharray: 1; }
 .line1 { fill: var(--color-fg-accent); }
 .guideLines { stroke: var(--color-bg); stroke-dasharray: none; }
 .dataPointPopupMask { fill: var(--color-fg); stroke: var(--color-bg); }

--- a/lib/time_series.rb
+++ b/lib/time_series.rb
@@ -3,6 +3,10 @@
 class TimeSeries < SVG::Graph::TimeSeries
   include ActionView::Helpers::NumberHelper
 
+  # Whether to add an extrapolated end-of-month data point for the current month.
+  # Provided as part of the options hash to the constructor.
+  attr_accessor :extrapolate
+
   # these two methods are a patch on the gem's lack of time zone awareness
   def format x, y, description
     [
@@ -19,5 +23,44 @@ class TimeSeries < SVG::Graph::TimeSeries
   # improves y axis labels with commas
   def get_y_labels
     get_y_values.collect { |v| number_with_delimiter(v.to_i) }
+  end
+
+  # Override to add an extrapolated value for the current month, if
+  # {extrapolate: true} has been passed into the constructor.
+  def add_data(data:, template:)
+    if extrapolate
+      data = data_with_extrapolated_month(data)
+    end
+
+    super
+  end
+
+  private
+
+  # Override to add a custom CSS class to the SVG element, if
+  # {extrapolate: true} has been passed into the constructor, so that the extra
+  # data point representing the extrapolated value can be styled differently.
+  def start_svg
+    super
+
+    if extrapolate
+      @root.attributes["class"] = (
+        (@root.attributes["class"] || "") + " extrapolate"
+      ).strip
+    end
+  end
+
+  # Adds a second data point at the current month, representing the end-of-month
+  # value, linearly extrapolated from the actual value of the current month so far.
+  def data_with_extrapolated_month(data)
+    current_month = data[-2]
+    current_month_extrapolated_value = (
+      data.last / (
+        Time.now.utc.day.to_f /
+        Time.days_in_month(Time.now.utc.month, Time.now.utc.year)
+      )
+    ).round
+
+    [*data, current_month, current_month_extrapolated_value]
   end
 end


### PR DESCRIPTION
<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->

## Summary

Follow-up to #1758

Omits the extrapolated value from the Active Users graph, because our linear extrapolation logic does not apply to that graph's data.

See [this comment](https://github.com/lobsters/lobsters/pull/1758#issuecomment-3413522508) in that previous PR.

## Screenshots

| before | after |
|---|---|
| <img width="444" height="521" alt="image" src="https://github.com/user-attachments/assets/4969d4f5-339f-4f2c-a07f-141e43fcd1b9" /> | <img width="452" height="523" alt="image" src="https://github.com/user-attachments/assets/275951c8-8812-447e-a5cb-d1ca038da423" /> |
