### PR TITLE
Fix .ruby-version is needed inside container for running with Docker

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -17,7 +17,7 @@ WORKDIR /lobsters
 RUN gem install bundler
 
 # Copy Gemfile and Gemfile.lock
-COPY Gemfile Gemfile.lock ./
+COPY Gemfile Gemfile.lock .ruby-version ./
 
 # Install gems
 RUN bundle install


### PR DESCRIPTION
Add `.ruby-version` to the files copied into the container when running the project with Docker. `bundler` requires it since it's referenced in the `Gemfile`.