### PR TITLE
Fix Focus ring missing for radio inputs

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -190,21 +190,15 @@ input[type="url"],
 textarea {
 	border: 1px solid var(--color-box-border);
 }
-input:focus, textarea:focus {
-	outline-style: solid;
-	outline-width: 2px;
-}
 input[type="checkbox"] {
 	margin-top: 0.5em;
 }
-select {
-	border: 1px solid var(--color-box-border);
-}
+select:focus,
 input:focus,
 textarea:focus {
-	border-color: var(--color-box-border-focus);
+	outline: 2px solid var(--color-box-border-focus);
+	border-color: transparent;
 	color: var(--color-fg);
-	outline: 0;
 }
 textarea::placeholder {
 	color: var(--color-fg-contrast-7-5);
@@ -274,13 +268,9 @@ input[type="submit"]:hover {
 }
 
 select {
+	border: 1px solid var(--color-box-border);
 	margin-top: 3px;
 	min-width: 100px;
-}
-select:focus {
-	border-color: var(--color-box-border-focus);
-	color: var(--color-fg);
-	outline: 0;
 }
 select::-moz-focus-inner {
 	border: 0;


### PR DESCRIPTION
Enable the focus ring for radio inputs when they are focused because of keyboard navigation. 

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
