### PR TITLE
fix #639 use <details> for story previews

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -740,13 +740,23 @@ li div.details {
 div.story_content {
 	margin-bottom: 1em;
 }
-ol.stories.list div.story_content {
+ol.stories.list details.story_content {
 	color: var(--color-fg-contrast-6);
-	max-height: 2.6em;
 	margin: 0.25em 40px 0.25em 0;
-	overflow: hidden;
-	text-overflow: clip;
 }
+
+ol.stories.list details.story_content:open {
+	color: var(--color-fg-contrast-10);
+}
+
+ol.stories.list details.story_content:open summary {
+	float: left;
+	line-height: 1;
+	margin-top: 0.2rem;
+}
+
+ol.stories.list details.story_content:open summary span {
+	display: none;
 
 div.morelink {
 	float: left;

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -68,10 +68,11 @@ class="story <%= story.current_upvoted? ? "upvoted" : "" %>
     <% end %>
 
     <% if @user&.show_story_previews? %>
-      <% if (sc = story.description_or_story_text(500)).present? %>
-        <div class="story_content">
+      <% if (sc = story.description_or_story_text()).present? %>
+        <details class="story_content">
+          <summary><span><%= story.description_or_story_text(250) %></span></summary>
           <%= sc %>
-        </div>
+        </details>
       <% end %>
     <% end %>
 

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -197,10 +197,11 @@ class="story <%= story.current_upvoted? ? "upvoted" : "" %>
     <% end %>
 
     <% if @user&.show_story_previews? %>
-      <% if (sc = story.description_or_story_text(500)).present? %>
-        <div class="story_content">
+      <% if (sc = story.description_or_story_text()).present? %>
+        <details class="story_content">
+          <summary><span><%= story.description_or_story_text(250) %></span></summary>
           <%= sc %>
-        </div>
+        </details>
       <% end %>
     <% end %>
 

--- a/app/views/stories/_listdetail.html.erb
+++ b/app/views/stories/_listdetail.html.erb
@@ -53,10 +53,11 @@ class="story <%= story.current_upvoted? ? "upvoted" : "" %>
     <% end %>
 
     <% if @user&.show_story_previews? %>
-      <% if (sc = story.description_or_story_text(500)).present? %>
-        <div class="story_content">
+      <% if (sc = story.description_or_story_text()).present? %>
+        <details class="story_content">
+          <summary><span><%= story.description_or_story_text(250) %></span></summary>
           <%= sc %>
-        </div>
+        </details>
       <% end %>
     <% end %>
 


### PR DESCRIPTION
Use the `<details>` element when showing story previews, so browsers will show matches inside when using the native search in page feature.

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
