### PR TITLE
feat Add aria-current="page" in navigation

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -100,6 +100,10 @@ module ApplicationHelper
     current = request.path.sub(/\/page\/\d+$/, "")
     path.sub!(/\/page\/\d+$/, "")
     options[:class] = class_names(options[:class], current_page: current == path)
+    if current == path
+      options[:aria] ||= {}
+      options[:aria][:current] = "page"
+    end
     link_to text, path, options
   end
 


### PR DESCRIPTION
`aria-current` can be used when you have a group of related elements and there's already a visual indication for the currently selected item. The `page` value represent the current page.

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
