### PR TITLE
Fixes #1752 "caches" dropdown clips to the right

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -343,7 +343,7 @@ header#nav {
 }
 header#nav nav.links {
 	display: flex;
-	width: 100%
+	width: 100%;
 }
 header#nav a, header#subnav a, header#subnav input[type="submit"] {
 	color: var(--color-fg-contrast-6);
@@ -671,10 +671,20 @@ li .byline img.avatar {
 li.story .byline {
 	margin-top: 1px;
 }
+
+.byline button,
 .byline a {
 	color: var(--color-fg-contrast-4-5);
 	text-decoration: none;
+	border: 0;
+	padding: 0;
+	line-height: 1;
+	outline: revert;
 }
+.byline button:hover {
+	background-color: var(--color-bg);
+}
+
 .comment.replied .flagger,
 .comment.flagged .comment_replier {
 	color: var(--color-fg);
@@ -863,6 +873,7 @@ div.comment_text code {
 
 .dropdown_parent {
 	position: relative;
+	display: inline-block;
 }
 
 .comments_subtree .dropdown_parent > #flag_dropdown {
@@ -878,6 +889,37 @@ div.comment_text code {
 	border-bottom: 0;
 	z-index: 15;
 }
+
+@position-try --custom-left {
+	position-area: left;
+	margin-right: 0.25rem;
+}
+
+@position-try --custom-bottom {
+	top: anchor(bottom);
+	justify-self: anchor-center;
+	position-area: none;
+}
+
+.archive-dropdown {
+	/* Reset width, so max() will work. */
+	width: auto;
+	width: max(100px, max-content);
+	inset: auto;
+	padding: 0;
+	margin: 5px 0 0 0;
+	position-area: bottom span-right;
+	overflow: visible; /* Allow focus ring to be visible */
+	position-try-fallbacks: --custom-left, --custom-bottom
+}
+
+@supports (position-area: left) {
+	.archive-dropdown {
+		word-break: normal;
+	}
+}
+
+
 #flag_dropdown a, .archive-dropdown a {
 	background-color: var(--color-box-bg);
 	border-bottom: 1px solid var(--color-box-border);
@@ -905,19 +947,6 @@ div.comment_text code {
 	right: 0;
 	z-index: 1;
 }
-
-/* archive; dropdown styling is with #flag_dropdown to match it */
-.archive_button {
-	display: none;
-}
-.archive_button:not(:checked) ~ .archive-dropdown {
-	display: none;
-}
-.archive_button ~ label{
-	cursor: pointer;
-}
-
-
 
 .controls details {
 	margin-left: auto;

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -133,9 +133,8 @@ class="story <%= story.current_upvoted? ? "upvoted" : "" %>
         <% if story.url.present? && (!story.is_gone? || @user.try(:is_moderator?))  %>
           <span> | </span>
           <span class="dropdown_parent">
-            <input id="archive_<%= story.short_id %>" class="archive_button" type="checkbox">
-            <label for="archive_<%= story.short_id %>" tabindex="0">caches</label>
-            <div class="archive-dropdown">
+            <button type="button" class="archive_button" popovertarget="archive_<%= story.short_id %>">caches</button>
+            <div class="archive-dropdown" popover id="archive_<%= story.short_id %>">
               <a href="<%= story.archiveorg_url %>">Archive.org</a>
               <a href="<%= story.archivetoday_url %>">Archive.today</a>
               <a href="<%= story.ghost_url %>">Ghostarchive</a>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -262,9 +262,8 @@ class="story <%= story.current_upvoted? ? "upvoted" : "" %>
         <% if story.url.present? && (!story.is_gone? || @user.try(:is_moderator?))  %>
           <span> | </span>
           <span class="dropdown_parent">
-            <input id="archive_<%= story.short_id %>" class="archive_button" type="checkbox">
-            <label for="archive_<%= story.short_id %>" tabindex="0">caches</label>
-            <div class="archive-dropdown">
+            <button type="button" class="archive_button" popovertarget="archive_<%= story.short_id %>">caches</button>
+            <div class="archive-dropdown" popover id="archive_<%= story.short_id %>">
               <a href="<%= story.archiveorg_url %>">Archive.org</a>
               <a href="<%= story.archivetoday_url %>">Archive.today</a>
               <a href="<%= story.ghost_url %>">Ghostarchive</a>

--- a/app/views/stories/_listdetail.html.erb
+++ b/app/views/stories/_listdetail.html.erb
@@ -118,9 +118,8 @@ class="story <%= story.current_upvoted? ? "upvoted" : "" %>
         <% if story.url.present? && (!story.is_gone? || @user.try(:is_moderator?))  %>
           <span> | </span>
           <span class="dropdown_parent">
-            <input id="archive_<%= story.short_id %>" class="archive_button" type="checkbox">
-            <label for="archive_<%= story.short_id %>" tabindex="0">caches</label>
-            <div class="archive-dropdown">
+            <button type="button" class="archive_button" popovertarget="archive_<%= story.short_id %>">caches</button>
+            <div class="archive-dropdown" popover id="archive_<%= story.short_id %>">
               <a href="<%= story.archiveorg_url %>">Archive.org</a>
               <a href="<%= story.archivetoday_url %>">Archive.today</a>
               <a href="<%= story.ghost_url %>">Ghostarchive</a>

--- a/app/views/stories/_singledetail.html.erb
+++ b/app/views/stories/_singledetail.html.erb
@@ -118,9 +118,8 @@ classes = [
           <% if ms.url.present? && (!ms.is_gone? || @user.try(:is_moderator?))  %>
             <span> | </span>
             <span class="dropdown_parent">
-              <input id="archive_<%= ms.short_id %>" class="archive_button" type="checkbox">
-              <label for="archive_<%= ms.short_id %>" tabindex="0">caches</label>
-              <div class="archive-dropdown">
+              <button type="button" class="archive_button" popovertarget="archive_<%= ms.short_id %>">caches</button>
+              <div class="archive-dropdown" popover id="archive_<%= ms.short_id %>">
                 <a href="<%= ms.archiveorg_url %>">Archive.org</a>
                 <a href="<%= ms.archivetoday_url %>">Archive.today</a>
                 <a href="<%= ms.ghost_url %>">Ghostarchive</a>

--- a/app/views/stories/show.html.erb
+++ b/app/views/stories/show.html.erb
@@ -96,9 +96,8 @@
 
                 <span> | </span>
                 <span class="dropdown_parent">
-                  <input id="archive_<%= ms.short_id %>" class="archive_button" type="checkbox">
-                  <label for="archive_<%= ms.short_id %>" tabindex="0">caches</label>
-                  <div class="archive-dropdown">
+                  <button type="button" class="archive_button" popovertarget="archive_<%= ms.short_id %>_main">caches</button>
+                  <div class="archive-dropdown" popover id="archive_<%= ms.short_id %>_main">
                     <a href="<%= ms.archiveorg_url %>">Archive.org</a>
                     <a href="<%= ms.archivetoday_url %>">Archive.today</a>
                     <a href="<%= ms.ghost_url %>">Ghostarchive</a>


### PR DESCRIPTION
Migrate the "caches" dropdown to use the Popover API.

Calculate its width with CSS so if the dropdown may overflow outside of the viewport, the width will shrink and the text will wrap.

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
