### PR TITLE
Fix #1791: cache button issue in firefox

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -678,10 +678,9 @@ li.story .byline {
 	text-decoration: none;
 	border: 0;
 	padding: 0;
+	font-weight: normal;
 	line-height: 1;
 	outline: revert;
-}
-.byline button:hover {
 	background-color: var(--color-bg);
 }
 
@@ -885,10 +884,6 @@ div.comment_text code {
 .dropdown_parent {
 	position: relative;
 	display: inline-block;
-}
-
-.archive-button {
-	font-weight: normal;
 }
 
 .comments_subtree .dropdown_parent > #flag_dropdown {


### PR DESCRIPTION
This PR should corrects issue [#1791](https://github.com/lobsters/lobsters/issues/1791?utm_source=chatgpt.com) , where the caches button appears bold in Firefox due to the browser’s default button styling.

- I do not have a Firefox environment to test this
- Verification in Firefox is recommended before merging.