### PR TITLE
Remove avatar links from tabbing order

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -90,7 +90,7 @@ module ApplicationHelper
 
   def inline_avatar_for(viewer, user)
     if !viewer || viewer.show_avatars?
-      link_to avatar_img(user, 16), user_path(user)
+      link_to avatar_img(user, 16), user_path(user), {tabindex: "-1", aria: {hidden: true}}
     end
   end
 


### PR DESCRIPTION
Prevent avatars from focusing when tabbing through the page.

Hide the avatar link from screen readers.

Its functionality is duplicated by the link with the author name.

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
