### PR TITLE
Fix tags list on Tags page

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1573,6 +1573,17 @@ input[type="submit"].link_post.pushover_button {
 	margin-right: 1rem;
 }
 
+/* Tags page */
+.tag-title {
+	display: flex;
+	gap: 0.5rem;
+	align-items: baseline;
+}
+
+.tag-title:first-of-type {
+	margin-top: -0.75rem;
+}
+
 @media only screen and (max-width: 480px) {
 	.radio-group-container legend {
 		float: none;

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -172,11 +172,13 @@ module ApplicationHelper
     super
   end
 
-  def tag_link(tag)
+  def tag_link(tag, options = {})
     link_to tag.tag,
       tag_path(tag),
-      class: [tag.css_class, filtered_tags.include?(tag) ? "filtered" : nil],
-      title: tag.description
+      options.merge({
+        class: [tag.css_class, filtered_tags.include?(tag) ? "filtered" : nil],
+        title: tag.description
+      })
   end
 
   def how_long_ago_label(time)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -175,7 +175,7 @@ module ApplicationHelper
   def tag_link(tag, options = {})
     link_to tag.tag,
       tag_path(tag),
-      options.merge({
+      options.reverse_merge({
         class: [tag.css_class, filtered_tags.include?(tag) ? "filtered" : nil],
         title: tag.description
       })

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -5,33 +5,35 @@
 </p>
 
 <% @categories.each do |category| %>
-  <h2 id="<%= category.category %>">
-    <%= link_to category.category, category_path(category) %>
+  <div class="tag-title">
+    <h2 id="<%= category.category %>">
+      <%= link_to category.category, category_path(category) %>
+    </h2>
     <% if is_admin %>
-      <span class="byline">| <%= link_to 'edit', edit_category_path(category.category) %></span>
-    <% end %>
-  </h2>
+      <p class="byline"><%= divider_tag %> <%= link_to 'edit', edit_category_path(category.category), id: "editlink-#{category.category}", aria: {labelledby: "editlink-#{category.category} #{category.category}"} %></p>
+      <% end %>
+  </div>
 
-  <% category.tags.each do |tag| %>
-    <ol class="category_tags">
-      <li id="<%= tag.tag %>">
-      <% filtered = @filtered_tags.include?(tag.id) %>
-      <%= tag_link tag %>
-      <span class="<%= filtered || !tag.active ? 'inactive_tag' : '' %>"><%= tag.description %></span>
-      <span class="byline">
-      <% if !tag.active %>
-        | <em>inactive</em>
-      <% end %>
-      <% if filtered %>
-        | <%= link_to "filtered", filters_path(anchor: tag.tag) %>
-      <% end %>
-      <% if is_admin %>
-        | <%= link_to 'edit', edit_tag_path(tag.tag) %>
-      <% end %>
-      </span>
+  <ol class="category_tags" aria-labelledby="<%= category.category %>">
+    <% category.tags.each do |tag| %>
+      <li>
+        <% filtered = @filtered_tags.include?(tag.id) %>
+        <%= tag_link tag, {id: tag.tag} %>
+        <span class="<%= filtered || !tag.active ? 'inactive_tag' : '' %>"><%= tag.description %></span>
+        <span class="byline">
+          <% if !tag.active %>
+            <%= divider_tag %> <em>inactive</em>
+          <% end %>
+          <% if filtered %>
+            <%= divider_tag %> <%= link_to "filtered", filters_path(anchor: tag.tag) %>
+          <% end %>
+          <% if is_admin %>
+            <%= divider_tag %> <%= link_to 'edit', edit_tag_path(tag.tag), id: "editlink-#{tag.tag}", aria: {labelledby: "editlink-#{tag.tag} tag-#{tag.tag}"} %>
+          <% end %>
+        </span>
       </li>
-    </ol>
-  <% end %>
+    <% end %>
+  </ol>
 <% end %>
 
 <% if is_admin %>


### PR DESCRIPTION
Related links should use one list element to group them all.

"|" characters hidden from screen readers.

Add aria-label to "edit" links so they read what exactly they would edit.

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
