### PR TITLE
Fix bundle install error for development

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -8,6 +8,7 @@ RUN apt-get update -qq && apt-get install -y \
   libjemalloc2 \
   libvips \
   mariadb-client \
+  clang \
   vim
 
 # Set working directory


### PR DESCRIPTION
## Error description

When "make docker-serve" was executed
```
87.20 thread 'main' (11522) panicked at
87.20 /usr/local/bundle/gems/commonmarker-2.5.0/ext/commonmarker/.rb-sys/stable/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bindgen-0.69.5/lib.rs:622:31:
87.20 Unable to find libclang: "couldn't find any valid shared libraries matching:
87.20 ['libclang.so', 'libclang-*.so', 'libclang.so.*', 'libclang-*.so.*'], set the
87.20 `LIBCLANG_PATH` environment variable to a path where one of these files can be
87.20 found (invalid: [])"
87.20   note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
87.20 warning: build failed, waiting for other jobs to finish...
87.20 make: *** [Makefile:571: target/release/libcommonmarker.so] Error 101
```
## Possible causes

https://github.com/gjtorikian/commonmarker/issues/268

## Correction details

Added the Clang libraries installation to the Dockerfile.

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
