### PR TITLE
markdowner: also treat explicitly nil as_of as the current time

### DIFF
--- a/extras/markdowner.rb
+++ b/extras/markdowner.rb
@@ -15,11 +15,14 @@ class Markdowner
   end
 
   # allow_images: transform ![](example.com/img.jpg) to a hotlinked image; default is to print a link to the URL
-  # as_of: what timestamp to add @mention links as of, because users rename; default Time.current
-  def self.to_html(text, allow_images: false, as_of: Time.current)
+  # as_of: what timestamp to add @mention links as of, because users rename; default is nil which is overridden
+  #        to Time.current for newly created models passing their nil created_at
+  def self.to_html(text, allow_images: false, as_of: nil)
     if text.blank?
       return ""
     end
+
+    as_of ||= Time.current
 
     commonmarker_options = {
       extension: {

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -53,6 +53,22 @@ describe Comment do
     expect(l.title).to eq("link")
   end
 
+  it "links to users during and after creation" do
+    create(:user, username: "alice", created_at: 2.weeks.ago)
+    c = Comment.new(
+      user: create(:user),
+      story: create(:story),
+      comment: "hello @alice and @bob"
+    )
+
+    expect(c.created_at).to be_nil
+    expect(c.generated_markeddown_comment).to eq("<p>hello <a href=\"https://lobste.rs/~alice\" rel=\"ugc\">@alice</a> and @bob</p>\n")
+
+    c.save!
+    expect(c.created_at).not_to be_nil
+    expect(c.generated_markeddown_comment).to eq("<p>hello <a href=\"https://lobste.rs/~alice\" rel=\"ugc\">@alice</a> and @bob</p>\n")
+  end
+
   describe ".accessible_to_user" do
     it "when user is a moderator" do
       moderator = build(:user, :moderator)


### PR DESCRIPTION
New comments, stories, etc have a created_at of nil, which was passed explicitly to Markdowner when they were rendered and broke the period-accurate username linking.

Closes #1804 

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
