### PR TITLE
Full opacity on Hidden section

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -730,14 +730,16 @@ li .byline a.story_has_suggestions {
 	margin: 1em 0 1em 32px; /* matching div.detail */
 }
 
-li.story.hidden *:not(div, .dropdown_parent, .dropdown_parent > div *, .comments_label, .link, .tags, img),
-li.story.hidden .score {
+:is(ol:not(.show_hidden) li.story.hidden:not(:only-child)) :is(
+	.dropdown_parent > .flagger, /* Flag button */
+	.dropdown_parent > label, /* Caches button */
+	.byline > :not(.dropdown_parent),
+	.details > :not(.byline),
+	.voters
+) {
 	opacity: 0.25;
 }
 
-ol.show_hidden li.story.hidden {
-	opacity: 1.0 !important;
-}
 li.story.saved a.saver {
 	color: var(--color-fg-affirmative);
 }


### PR DESCRIPTION
When a story is hidden in the front page, reduce its opacity to 0.25.

When checking hidden stories in the "Hidden" section, restore its opacity so user can know what was hidden.

Show full opacity for a hidden story in its single page; if user landed there, let them see what the story was even if we show the "you have hidden this story" warning.

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
