### PR TITLE
Move vote link to top for long mail list messages

### DIFF
--- a/script/mail_new_activity.rb
+++ b/script/mail_new_activity.rb
@@ -113,7 +113,6 @@ if __FILE__ == $PROGRAM_NAME
         end
 
         body.push "Vote: #{Routes.story_short_id_url s}"
-        body.push "-- "
 
         if s.url.present?
           body.push ""


### PR DESCRIPTION
I value the mail list functionality of this site (thank you!) but sometimes the messages are really long (ie the recent one had an entire RFC in the email https://lobste.rs/s/wvgp5t/rfc_9180_hybrid_public_key_encryption). What this means is the link to see all the comments on lobste.rs is waaaay down the bottom.

So this PR is to move it up to the top. I shifted around the padding and line breaks too but :man_shrugging: 

PS No AI was used, I barely used my own!