### PR TITLE
Set DATABASE_HOST in database.yml, defaults to local

### DIFF
--- a/config/database.yml.sample
+++ b/config/database.yml.sample
@@ -2,7 +2,7 @@
 trilogy: &trilogy
   adapter: trilogy
   encoding: utf8mb4
-  host: 127.0.0.1
+  host: <%= ENV.fetch('DATABASE_HOST') { "127.0.0.1" } %>
   port: 3306
   pool: 5
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,6 +8,8 @@ services:
       dockerfile: Dockerfile.dev
       args:
         RUBY_VERSION: ${RUBY_VERSION}
+    environment:
+      DATABASE_HOST: db
     volumes:
       - .:/lobsters
     ports:

--- a/docs/setup_with_docker.md
+++ b/docs/setup_with_docker.md
@@ -15,9 +15,6 @@
     * You should get a similar image like this:
    ![successful vim](./vim_result.jpg)
 
-* Update `database.yml`
-  * Change line 5 to `host: db`
-
 * Switch back to the tab running the mariadb image and restart the server by:
   * Holding down `control` and `c`
   * Run `make docker-serve`


### PR DESCRIPTION
# Description

Right now, we have to manually set the host for the database in database.yml if we're using docker. In local development, we use localhost, but Docker needs to reference the db image.

This change sets an environment variable `DATABASE_HOST` in docker and the database.yml. No manual editing needed, and localhost continues to use localhost.
