### PR TITLE
Allow the server to start without credentials set in development

### DIFF
--- a/config/initializers/00_zeitwerk.rb
+++ b/config/initializers/00_zeitwerk.rb
@@ -19,6 +19,6 @@ if ENV["SECRET_KEY_BASE_DUMMY"].blank? && Rails.application.credentials.secret_k
   if Rails.env.production?
     raise config + migrate
   else
-    raise config
+    puts config
   end
 end


### PR DESCRIPTION
# Description

We don't actually _need_ to set the credentials to start the Rails server. All the places we call the credentials in initialization can handle an empty value. We need the credentials to test certain features, but not to start the server. However, this raise in Zeitwork was preventing the Rails server from starting in development unless they were set.

Now the error is still put in the log, production still requires crednetials, and credentials are still included in the documentation, but the server can actually start without them.
