### PR TITLE
Fix some dead links in chat page

### DIFF
--- a/app/views/about/chat.html.erb
+++ b/app/views/about/chat.html.erb
@@ -51,7 +51,7 @@
 
   <p>
   The channel has a bot named
-  <a href="https://github.com/lobsters/lobstersbot">mockturtle</a>.
+  <a href="https://github.com/lobsters/mockturtle">mockturtle</a>.
   It announces new stories submitted to the site and provides other useful features like showing the page title of URLs mentioned in the channel.
   </p>
 
@@ -69,7 +69,7 @@
 
   <p>
   If you are interested in working on the Lobsters codebase or using it to run your own site, as of February 2025 we have a <a href="https://lobsters.zulipchat.com/">Zulip-based chat room</a>.
-  If you run a <a href="https://github.com/lobsters/lobsters/wiki">sister site</a> please ask to be added to the `#security-notifications` stream for any vulnerability announcements.
+  If you run a <a href="https://github.com/lobsters/lobsters/blob/main/sister_sites.md">sister site</a> please ask to be added to the `#security-notifications` stream for any vulnerability announcements.
   This is also an experiment to evaluate whether we should move the primary Lobsters chat room over to Zulip.
   </p>
 


### PR DESCRIPTION
When going on the https://lobste.rs/chat page, I noticed some dead / outdated links on there 