### PR TITLE
Fix opacity of comments link for hidden stories in mobile

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -735,7 +735,8 @@ li .byline a.story_has_suggestions {
 	.dropdown_parent > label, /* Caches button */
 	.byline > :not(.dropdown_parent),
 	.details > :not(.byline),
-	.voters
+	.voters,
+	.mobile_comments
 ) {
 	opacity: 0.25;
 }


### PR DESCRIPTION
When hiding a story, the comments link should turn semi transparent instead of remaining opaque.

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
