### PR TITLE
Hide << and >> of pagination to screen readers

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -780,19 +780,27 @@ ol.stories.list details.story_content:open summary span {
 	display: none;
 }
 
-div.morelink {
+nav.morelink {
 	float: left;
 }
 
-div.morelink,
+nav.morelink,
 div.page_link_buttons {
 	margin-top: 1.5em;
 }
-div.morelink a {
+nav.morelink a {
 	color: var(--color-fg-contrast-7-5);
 	font-weight: bold;
 	text-decoration: none;
 }
+
+nav.morelink a[rel="prev"]::before {
+	content: "<< "/"";
+}
+nav.morelink a[rel="next"]::after {
+	content: " >>"/"";
+}
+
 div.page_link_buttons {
 	font-weight: bold;
 	margin-top: 2em;
@@ -1866,7 +1874,7 @@ input[type="submit"].link_post.pushover_button {
 	div.story_content {
 		margin: 0 0 0 28px;
 	}
-	div.morelink {
+	nav.morelink {
 		margin-left: 28px;
 		float: none;
 	}

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -3,8 +3,8 @@
 <% already_printed_newest_line = false %>
 <ol class="comments comments1">
   <% @comments.each do |comment| %>
-    <% if action_name == "index" && 
-       !already_printed_newest_line && 
+    <% if action_name == "index" &&
+       !already_printed_newest_line &&
        @last_read_timestamp &&
        @last_read_timestamp.after?(comment.created_at) %>
        <div class="last_read_newest">Last Read</div>
@@ -17,15 +17,15 @@
   <% end %>
 </ol>
 
-<div class="morelink">
+<nav class="morelink">
   <% if @comments.any? %>
     <% if @page && @page > 1 %>
-      <%= link_to raw("&lt;&lt; Page #{@page - 1}"), { controller: controller_name, action: action_name, page: @page - 1 }.merge(@next_page_params || {}) %>
+      <%= link_to raw("Page #{@page - 1}"), { controller: controller_name, action: action_name, page: @page - 1 }.merge(@next_page_params || {}), rel: "prev" %>
     <% end %>
 
     <% if @page && @page > 1 %>
-      |
+      <%= divider_tag %>
     <% end %>
-    <%= link_to raw("Page #{@page + 1} &gt;&gt;"), { controller: controller_name, action: action_name, page: @page + 1 }.merge(@next_page_params || {}) %>
+    <%= link_to raw("Page #{@page + 1}"), { controller: controller_name, action: action_name, page: @page + 1 }.merge(@next_page_params || {}), rel: "next" %>
   <% end %>
-</div>
+</nav>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -173,15 +173,15 @@ class="story <%= story.current_upvoted? ? "upvoted" : "" %>
 
 <%= render @below if @below %>
 
-<div class="morelink">
+<nav class="morelink">
   <% if @page && @page > 1 %>
-    <%= link_to raw("&lt;&lt; Page #{@page - 1}"), @root_path ? "/page/#{@page - 1}" : { controller: controller_name, action: action_name, page: @page - 1 }.merge(@next_page_params || {}) %>
+    <%= link_to raw("Page #{@page - 1}"), @root_path ? "/page/#{@page - 1}" : { controller: controller_name, action: action_name, page: @page - 1 }.merge(@next_page_params || {}), rel: "prev" %>
   <% end %>
 
   <% if @show_more %>
     <% if @page && @page > 1 %>
-      |
+      <%= divider_tag %>
     <% end %>
-    <%= link_to raw("Page #{@page + 1} &gt;&gt;"), @root_path ? "/page/#{@page + 1}" : { controller: controller_name, action: action_name, page: @page + 1 }.merge(@next_page_params || {}) %>
+    <%= link_to raw("Page #{@page + 1}"), @root_path ? "/page/#{@page + 1}" : { controller: controller_name, action: action_name, page: @page + 1 }.merge(@next_page_params || {}), rel: "next" %>
   <% end %>
-</div>
+</nav>

--- a/app/views/inbox/all.html.erb
+++ b/app/views/inbox/all.html.erb
@@ -29,17 +29,17 @@
 <% end %>
 
 <% if @has_more || (@page && @page > 1) %>
-  <div class="morelink">
+  <nav class="morelink">
     <% if @page && @page > 1 %>
-      <a href="/inbox/all<%= @page == 2 ? "" : "/page/#{@page - 1}" %>">&lt;&lt; Page <%= @page - 1 %></a>
+      <a rel="prev" href="/inbox/all<%= @page == 2 ? "" : "/page/#{@page - 1}" %>">Page <%= @page - 1 %></a>
     <% end %>
 
     <% if @has_more %>
       <% if @page && @page > 1 %>
-        |
+        <%= divider_tag %>
       <% end %>
 
-      <a href="/inbox/all/page/<%= @page + 1 %>">Page <%= @page + 1 %> &gt;&gt;</a>
+      <a h rel="next" ref="/inbox/all/page/<%= @page + 1 %>">Page <%= @page + 1 %></a>
     <% end %>
-  </div>
+  </nav>
 <% end %>

--- a/app/views/moderations/index.html.erb
+++ b/app/views/moderations/index.html.erb
@@ -20,14 +20,14 @@
   </p>
 <% end %>
 
-<div class="morelink">
+<nav class="morelink">
   <% if @page > 1 %>
-    <%= link_to "<< Page #{@page - 1}", @moderation_params.merge({:page => @page - 1}) %>
+    <%= link_to "Page #{@page - 1}", @moderation_params.merge({:page => @page - 1}), rel: "prev" %>
   <% end %>
   <% if @pages > 1 && @page < @pages %>
     <% if @page > 1 %>
-      |
+      <%= divider_tag %>
     <% end %>
-    <%= link_to "Page #{@page + 1} >>", @moderation_params.merge({:page => @page + 1}) %>
+    <%= link_to "Page #{@page + 1}", @moderation_params.merge({:page => @page + 1}), rel: "next"%>
   <% end %>
-</div>
+</nav>

--- a/spec/features/newest_spec.rb
+++ b/spec/features/newest_spec.rb
@@ -32,8 +32,8 @@ RSpec.feature "Reading Homepage", type: :feature do
       expect(page.body).not_to include("Last Read")
       expect(user.reload.last_read_newest_story).to be_within(1.second).of Time.zone.now
 
-      expect(page).to have_link("Page 2 >>", href: /last_read_timestamp=\d+/)
-      click_link "Page 2 >>"
+      expect(page).to have_link("Page 2", href: /last_read_timestamp=\d+/)
+      click_link "Page 2"
       expect(page.body).to include("Last Read")
       page_html = page.body
       last_read_index = page_html.index("Last Read")
@@ -71,8 +71,8 @@ RSpec.feature "Reading Homepage", type: :feature do
       expect(page.body).not_to include("Last Read")
       expect(user.reload.last_read_newest_comment).to be_within(1.second).of Time.zone.now
 
-      expect(page).to have_link("Page 2 >>", href: /last_read_timestamp=\d+/)
-      click_link "Page 2 >>"
+      expect(page).to have_link("Page 2", href: /last_read_timestamp=\d+/)
+      click_link "Page 2"
       expect(page.body).to include("Last Read")
       page_html = page.body
       last_read_index = page_html.index("Last Read")


### PR DESCRIPTION
Use CSS to show the << and >> characters in the pagination nav in a way that screen readers don't try to read them.

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
