### PR TITLE
Add `media.ccc.de` to the automatic video tag

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -631,7 +631,7 @@ onPageLoad(() => {
   on('focusout', '#story_url', () => {
     let url_tags = {
       "\.pdf($|\\?|#)": "pdf",
-      "[\/\.](asciinema\.org|(youtube|vimeo)\.com|youtu\.be|twitch\.tv)\/": "video",
+      "[\/\.](asciinema\.org|(youtube|vimeo)\.com|youtu\.be|twitch\.tv|media\.ccc\.de)\/": "video",
       "[\/\.](slideshare\.net|speakerdeck\.com)\/": "slides",
       "[\/\.](soundcloud\.com)\/": "audio",
     };


### PR DESCRIPTION
Out of all (69) of the submitted stories for the `media.ccc.de` domain, only [one](https://lobste.rs/s/fesju4/media_ccc_de_arch_conf_2020) was not a video but a link to an event containing videos.

I feel like it makes sense to suggest the video tag to `media.ccc.de` as that's what's mostly posted on lobsters from the site.

Also fixed a problem with the twitch.tv regex which matched any character