### PR TITLE
Refactor "save story" for a11y and no JS

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -294,6 +294,19 @@ summary {
 	cursor: pointer;
 }
 
+/* Remove style from button to so it will look like a link */
+input.btn-link:hover,
+input.btn-link {
+	border: 0;
+	padding: 0;
+	background-color: var(--color-bg);
+	color: var(--color-fg-contrast-4-5);
+	line-height: 1;
+}
+input.btn-link:focus-visible {
+	outline: auto;
+}
+
 #qrsvg {
 	background-color: white;
 	display: inline-block;
@@ -306,6 +319,17 @@ summary {
 	margin: 0;
 }
 
+#toast {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border-width: 0;
+}
 
 /* header */
 
@@ -711,6 +735,10 @@ li .byline a.story_has_suggestions {
 	color: var(--color-lobsters-fg-has-suggestions);
 }
 
+li .byline form {
+	display: inline-block;
+}
+
 .last_read_newest {
 	border-bottom: 2px solid var(--color-fg-shape);
 	border-top: 0;
@@ -730,7 +758,7 @@ li .byline a.story_has_suggestions {
 	opacity: 0.25;
 }
 
-li.story.saved a.saver {
+li.story.saved .saver .btn-link {
 	color: var(--color-fg-affirmative);
 }
 

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 
 // in console: app await import("application")
@@ -25,33 +27,28 @@ export const on = (eventTypes, selector, callback) => {
   });
 }
 
-export const onPageLoad = (callback) => {
-  document.addEventListener('DOMContentLoaded', callback);
-};
-
+/** @param {HTMLElement} target @param {string} selector */
 export const parentSelector = (target, selector) => {
-  let parent = target.closest(selector);
-  if (parent === null) {
+  const parent = target.closest(selector);
+  if (parent == null) {
     throw new Error(`Did not match a parent of ${target} with the selector ${selector}`);
   }
   return parent;
 };
 
-export const qS = (context, selector) => {
-  if (selector === undefined) {
-    selector = context;
-    context = document;
-  }
-  return context.querySelector(selector);
+/** @type {(...args: ( [ string ] | [ParentNode,string] )) => Element|null} */
+export const qS = (...args) => {
+  return args.length === 1 ?
+    document.querySelector(args[0]) :
+    args[0].querySelector(args[1]);
 };
 
-export const qSA = (context, selector) => {
-  if (selector === undefined) {
-    selector = context;
-    context = document;
-  }
-  return context.querySelectorAll(selector);
-};
+/** @type {(...args: ( [ string ] | [ParentNode,string] )) => NodeListOf<Element>} */
+export const qSA = (...args) => {
+  return args.length === 1 ?
+    document.querySelectorAll(args[0]) :
+    args[0].querySelectorAll(args[1]);
+}
 
 export const replace = (oldElement, newHTMLString) => {
   const placeHolder = document.createElement('div');
@@ -95,8 +92,91 @@ export const removeExtraInputs = () => {
   }
 }
 
+/**
+ * @template {string} K
+ * @param {unknown} obj
+ * @param {K[]} keys
+ * @returns {obj is {[P in K]: string}}
+ */
+function hasProperties(obj, keys) {
+	return (
+		isObject(obj) &&
+		keys.every(
+			(key) =>
+				key in obj &&
+				typeof (/** @type {{[key]: unknown}} */ (obj)[key]) === "string",
+		)
+	);
+}
+
+/** @param {unknown} obj @returns obj is object */
+function isObject(obj) {
+	return typeof obj === "object" && !!obj;
+}
+
+/** @param {string} msg */
+function notify(msg) {
+		const toast = qS("#toast");
+		if (toast) {
+			toast.textContent = msg;
+		}
+}
+
+/** @param {HTMLFormElement} form @param {HTMLInputElement} submitter */
+async function asyncFormSubmit(form, submitter) {
+	// Prevent double submissions
+	if (submitter.disabled) {
+		return;
+	}
+
+	submitter.disabled = true;
+
+	try {
+		const response = await fetch(form.action, {
+			method: "POST",
+			body: new FormData(form),
+			headers: {
+				Accept: "application/json",
+			},
+		});
+
+		let body;
+
+		try {
+			body = await response.json();
+		} catch {
+			body = await response.text();
+		}
+
+		if (!response.ok) {
+			throw new Error(
+				typeof body === "string"
+					? body
+					: hasProperties(body, ["error"])
+						? body.error
+						: "Bad response",
+			);
+		}
+
+		return {
+			ok: true,
+			body,
+		};
+	} catch (err) {
+		const error = err instanceof Error ? err : new Error(JSON.stringify(err));
+		notify(error.message);
+		return {
+			ok: false,
+			error: error,
+		};
+	} finally {
+		submitter.disabled = false;
+	}
+}
+
+
 export class _LobstersFunction {
-  constructor (username) {
+  constructor () {
     this.curUser = null;
 
     this.storyFlagReasons = JSON.parse(qS('meta[name="story-flags"]').getAttribute('content'));
@@ -108,7 +188,7 @@ export class _LobstersFunction {
     document.location = "/login?return=" + encodeURIComponent(document.location);
   }
 
-  modalFlaggingDropDown(flaggedItemType, voterEl, reasons) {
+  modalFlaggingDropDown(_flaggedItemType, voterEl, reasons) {
     if (!Lobster.curUser) return Lobster.bounceToLogin();
 
     const li = parentSelector(voterEl, '.story, .comment');
@@ -134,7 +214,7 @@ export class _LobstersFunction {
     flaggingDropDown.setAttribute('id', 'flag_dropdown');
     voterEl.after(flaggingDropDown);
 
-    Object.keys(reasons).map(function(k, v) {
+    Object.keys(reasons).map(function(k) {
       let a = document.createElement('a')
       a.textContent = reasons[k]
       a.setAttribute('data', k)
@@ -310,25 +390,48 @@ export class _LobstersFunction {
     });
   }
 
-  saveStory(saverEl) {
-    if (!Lobster.curUser) return Lobster.bounceToLogin();
+  /** @param {SubmitEvent} ev */
+  async saveStory(ev) {
+    ev.preventDefault();
 
-    const li = parentSelector(saverEl, ".story, .comment");
-    let act;
+    const target = /** @type {HTMLFormElement} */ (ev.target);
+    const submitter = /** @type {HTMLInputElement} */ (ev.submitter);
 
-    if (li.classList.contains("saved")) {
-      act = "unsave";
-      li.classList.remove("saved");
-      saverEl.innerHTML = "save";
-    } else {
-      act = "save";
-      li.classList.add("saved");
-      saverEl.innerHTML = "unsave";
+    // Make sure to handle all "save" buttons in merged stories.
+    const story = parentSelector(target, ".story");
+    const forms = Array.from(qSA(story, ".saver")).filter(
+      (f) => f instanceof HTMLFormElement,
+    );
+    const btns = Array.from(qSA(story, ".saver input[type='submit']")).filter(
+      (b) => b instanceof HTMLInputElement,
+    );
+
+    for (const b of btns) {
+      if (b !== submitter) {
+        b.disabled = true;
+      }
     }
-    fetchWithCSRF("/stories/" + li.getAttribute("data-shortid") + "/" + act, {method: 'post'});
+
+    const data = await asyncFormSubmit(target, submitter);
+
+    if (data?.ok && hasProperties(data.body, ["action", "cta"])) {
+      for (const f of forms) {
+        f.action = data.body.action;
+      }
+
+      for (const b of btns) {
+        b.value = data.body.cta;
+      }
+
+      story.classList.toggle("saved");
+    }
+
+    for (const b of btns) {
+      b.disabled = false;
+    }
   }
 
-  tomSelect(item) {
+  tomSelect(_item) {
     if (!qS('#story_tags')) {
       return
     }
@@ -513,7 +616,7 @@ export class _LobstersFunction {
 
 const Lobster = new _LobstersFunction();
 
-onPageLoad(() => {
+document.addEventListener("DOMContentLoaded", () => {
   Lobster.curUser = document.body.getAttribute('data-username'); // hack
   autosize(qSA('textarea'));
 
@@ -548,6 +651,12 @@ onPageLoad(() => {
       t.innerText = years + " year" + (years > 1 ? "s" : "") + " ago"
     }
   }
+
+  // Append an element where xhr fetches can publish their results. Used by screen readers.
+  const toast = document.createElement("div");
+  toast.ariaLive = "polite";
+  toast.id = "toast";
+  document.body.appendChild(toast);
 
   // Global
 
@@ -619,10 +728,7 @@ onPageLoad(() => {
     Lobster.hideStory(event.target);
   });
 
-  on('click', 'li.story a.saver', (event) => {
-    event.preventDefault();
-    Lobster.saveStory(event.target);
-  });
+  on('submit', 'li.story .saver', Lobster.saveStory)
 
   on('click', 'button.story-preview', (event) => {
     Lobster.previewStory(parentSelector(event.target, 'form'));

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -126,12 +126,11 @@ class="story <%= story.current_upvoted? ? "upvoted" : "" %>
           <% else %>
             <%= divider_tag %><%= link_to "hide", story_hide_path(story.short_id), :class => "hider" %>
           <% end %>
-          <% if !story.is_saved_by_cur_user %>
-            <%= divider_tag %><%= link_to "save", story_save_path(story.short_id), :class => "saver" %>
+          <%= divider_tag %>
+          <%= form_with :class => "saver", url: story.is_saved_by_cur_user ? story_unsave_path(story.short_id) : story_save_path(story.short_id) do |form| %>
+            <%= form.submit story.is_saved_by_cur_user ? "unsave" : "save", :class => "btn-link" %>
           <% end %>
-        <% end %>
-        <% if story.is_saved_by_cur_user %>
-          <%= divider_tag %><%= link_to "unsave", story_unsave_path(story.short_id), :class => "saver" %>
+
         <% end %>
         <% if story.url.present? && (!story.is_gone? || @user.try(:is_moderator?))  %>
           <%= divider_tag %>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -248,12 +248,11 @@ class="story <%= story.current_upvoted? ? "upvoted" : "" %>
           <% else %>
             <%= divider_tag %><%= link_to "hide", story_hide_path(story.short_id), :class => "hider" %>
           <% end %>
-          <% if !story.is_saved_by_cur_user %>
-            <%= divider_tag %><%= link_to "save", story_save_path(story.short_id), :class => "saver" %>
+          <%= divider_tag %>
+          <%= form_with :class => "saver", url: story.is_saved_by_cur_user ? story_unsave_path(story.short_id) : story_save_path(story.short_id) do |form| %>
+            <%= form.submit story.is_saved_by_cur_user ? "unsave" : "save", :class => "btn-link" %>
           <% end %>
-        <% end %>
-        <% if story.is_saved_by_cur_user %>
-          <%= divider_tag %><%= link_to "unsave", story_unsave_path(story.short_id), :class => "saver" %>
+
         <% end %>
         <% if story.url.present? && (!story.is_gone? || @user.try(:is_moderator?))  %>
           <%= divider_tag %>

--- a/app/views/stories/_listdetail.html.erb
+++ b/app/views/stories/_listdetail.html.erb
@@ -111,12 +111,11 @@ class="story <%= story.current_upvoted? ? "upvoted" : "" %>
           <% else %>
             <%= divider_tag %><%= link_to "hide", story_hide_path(story.short_id), :class => "hider" %>
           <% end %>
-          <% if !story.is_saved_by_cur_user %>
-            <%= divider_tag %><%= link_to "save", story_save_path(story.short_id), :class => "saver" %>
+          <%= divider_tag %>
+          <%= form_with :class => "saver", url: story.is_saved_by_cur_user ? story_unsave_path(story.short_id) : story_save_path(story.short_id) do |form| %>
+            <%= form.submit story.is_saved_by_cur_user ? "unsave" : "save", :class => "btn-link" %>
           <% end %>
-        <% end %>
-        <% if story.is_saved_by_cur_user %>
-          <%= divider_tag %><%= link_to "unsave", story_unsave_path(story.short_id), :class => "saver" %>
+
         <% end %>
         <% if story.url.present? && (!story.is_gone? || @user.try(:is_moderator?))  %>
           <%= divider_tag %>

--- a/app/views/stories/_singledetail.html.erb
+++ b/app/views/stories/_singledetail.html.erb
@@ -105,11 +105,11 @@ classes = [
             <%= link_post "disown", story_disown_path(ms.short_id), { confirm: "Are you sure you want to disown this story?"} %>
           <% end %>
 
-          <% if !ms.is_saved_by_cur_user %>
-            <%= divider_tag %><%= link_to "save", story_save_path(ms.short_id), :class => "saver" %>
-          <% else %>
-            <%= divider_tag %><%= link_to "unsave", story_unsave_path(ms.short_id), :class => "saver" %>
+          <%= divider_tag %>
+          <%= form_with :class => "saver", url: merged_stories.first.is_saved_by_cur_user ? story_unsave_path(ms.short_id) : story_save_path(ms.short_id) do |form| %>
+            <%= form.submit merged_stories.first.is_saved_by_cur_user ? "unsave" : "save", :class => "btn-link" %>
           <% end %>
+
         <% end %>
 
         <% if ms.is_gone? %>

--- a/spec/features/read_story_spec.rb
+++ b/spec/features/read_story_spec.rb
@@ -76,15 +76,15 @@ RSpec.feature "Reading Stories", type: :feature do
     scenario "when story is deleted" do
       visit "/saved"
 
-      expect(page).not_to have_css("a.saver", text: "save", exact_text: true)
-      expect(page).to have_link("unsave")
+      expect(page).not_to have_css("form.saver input.btn-link", text: "save", exact_text: true)
+      expect(page).to have_button("unsave")
     end
 
     scenario "when story is available" do
       visit "/saved"
 
-      expect(page).not_to have_css("a.saver", text: "save", exact_text: true)
-      expect(page).to have_link("unsave")
+      expect(page).not_to have_css("form.saver input.btn-link", text: "save", exact_text: true)
+      expect(page).to have_button("unsave")
     end
   end
 


### PR DESCRIPTION
Change the "save" button in the UI so it renders as a native form instead of a link. This should allow non-JS users to submit the request, and also prevent  opening the link in a new tab.

Refactor "save story" in the BE so it returns different responses if the request used xhr. If not using xhr, BE will redirect the user back and will render success and error messages in the UI. If using xhr, BE returns a JSON with a success or error message. If the request succeded, the JSON includes the new action for the form, and the new "call to action" for the button.

For users with Javascript enabled: After clicking the "save" button, the button is marked as disabled to prevent double submissions. The success and error messages are appended to a hidden element with `role=alert` so screen readers can announce the result of the operation. In the single detail page for merged stories, change all the stories save button after success; this fixes a bug where after saving one of the merged stories, the others would still render a button with the outdated state.

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
