### PR TITLE
Consistent size for upvote arrows on hover

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -481,7 +481,7 @@ div.voters {
 	content: "\25b3";
 	color: var(--color-fg);
 	font-size: 1.2rem;
-	font-family: system-ui, monospace, sans-serif
+	font-family: system-ui, monospace, sans-serif;
 }
 .upvoter:hover:before,
 .upvoted .upvoter:before {


### PR DESCRIPTION
Currently, since the upvote arrow uses Unicode, the browser has to use whatever font has the required glyphs. Often this means that each arrow is rendered using a different font with different sizes.

Instead use whatever font the OS uses by default, cause it surely has all needed glyphs.

Also fix styling for mobile, where arrows where using an older style.

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
