### PR TITLE
Fix #1859 - Improve text legibility

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -9,6 +9,8 @@ But I make an unprincipled exception for :has because it solves so many big prob
 
 :root {
 	/* common color scheme */
+	--font-size-default: 1rem;
+
 	--color-bg: rgb(var(--base-bg));
 	--color-bg-50: rgb(var(--base-bg) / 50%);
 
@@ -50,7 +52,7 @@ html {
 
 body, textarea, input, button {
 	font-family: "helvetica neue", arial, sans-serif;
-	font-size: 10pt;
+	font-size: var(--font-size-default);
 	color: var(--color-fg);
 	line-height: 1.45em;
 }
@@ -71,13 +73,11 @@ li.story div.details span.link a:visited {
 }
 
 h1 {
-	font-size: 12pt;
 	font-weight: bold;
 	margin: 0.5em 0 1em 0;
 	padding: 0;
 }
 h2 {
-	font-size: 11pt;
 }
 
 .clear {
@@ -89,7 +89,6 @@ a.tag {
 	border: 1px solid var(--color-tag-border);
 	border-radius: 5px;
 	color: var(--color-fg-contrast-10);
-	font-size: 8pt;
 	margin-left: 0.25em;
 	padding: 0px 0.4em 1px 0.4em;
 	text-decoration: none;
@@ -127,7 +126,6 @@ a.tag_announce, a.tag_ask, a.tag_show, a.tag_interview {
 	border: 1px solid var(--color-hat-crown-stroke);
 	border-bottom: 0;
 	border-radius: 5px 5px 0px 0px;
-	font-size: 8pt;
 	padding: 3px 5px 2px 5px;
 	text-decoration: none;
 	vertical-align: text-top;
@@ -139,7 +137,6 @@ a.tag_announce, a.tag_ask, a.tag_show, a.tag_interview {
 }
 .hat_openbsd_developer .crown {
 	font-family: comic sans ms, comic sans, comic neue, sans-serif;
-	font-size: 7pt;
 }
 .hat_sysop {
 	border-color: var(--color-lobsters-hat-sysop-brim-stroke);
@@ -338,7 +335,6 @@ header {
 		content: "L";
 		font-family: serif;
 		color: var(--color-bg);
-		font-size: 1.05rem;
 	}
 
 	@media (prefers-color-scheme: dark) {
@@ -464,10 +460,6 @@ ol.comments1 > li.comments_subtree > ol.comments {
 	padding-left: 0;
 }
 
-.message .voters {
-	font-size: 20px;
-}
-
 .notifications li {
 	margin-bottom: 1lh;
 }
@@ -486,13 +478,11 @@ div.voters {
 .upvoter:before {
 	content: "\25b3";
 	color: var(--color-fg);
-	font-size: 1.2rem;
 }
 .upvoter:hover:before,
 .upvoted .upvoter:before {
 	content: "\25b2";
 	color: var(--color-fg-accent);
-	font-size: 1.35rem;
 	-webkit-text-stroke: 1px var(--color-fg-accent);
 }
 .upvoter {
@@ -502,7 +492,6 @@ div.voters {
 	align-items: center;
 	justify-self: center;
 	text-decoration: none;
-	font-size: 9.5pt;
 }
 .upvoter:focus { outline: none; } /* don't outline after upvote click */
 .upvoter:focus-visible { outline: 2px solid var(--color-fg-link); } /* do outline when tabbing */
@@ -581,7 +570,6 @@ li .link {
 }
 
 li .link a {
-	font-size: 11.5pt;
 	text-decoration: none;
 }
 
@@ -603,7 +591,6 @@ li .tags {
 li .domain {
 	color: var(--color-fg-contrast-4-5);
 	font-style: italic;
-	font-size: 9pt;
 	text-decoration: none;
 	vertical-align: middle;
 }
@@ -620,7 +607,6 @@ li input.comment_folder_button {
 }
 li .comment_folder {
 	display: inline-block;
-	font-size: 9pt;
 	color: var(--color-fg-contrast-4-5);
 	letter-spacing: 0.1em;
 	width: 1.5em;
@@ -667,13 +653,11 @@ li.comments_subtree {
 
 .thread_summary {
 	color: var(--color-fg-contrast-4-5);
-	font-size: 9.5pt;
 	/* .comment_folder (-4px margin-left + 1.5em width) + .voters (30px width) */
 	margin-left: calc(-4px + 1.5em + 30px);
 }
 li .byline {
 	color: var(--color-fg-contrast-4-5);
-	font-size: 9.5pt;
 }
 li .byline > img.avatar {
 	margin-bottom: -5px;
@@ -841,7 +825,6 @@ a#story_text_expander {
 }
 
 div.comment_text {
-	font-size: 10.5pt;
 	max-width: 700px;
 	word-wrap: break-word;
 	overflow: hidden;
@@ -923,7 +906,6 @@ div.comment_text code {
 	border-bottom: 1px solid var(--color-box-border);
 	color: var(--color-fg-contrast-10);
 	display: block;
-	font-size: 9pt;
 	padding: 3px;
 	text-decoration: underline;
 }
@@ -932,7 +914,6 @@ div.comment_text code {
 }
 #flag_dropdown a.cancel-reason {
 	background-color: var(--color-box-bg-shaded);
-	font-size: 8pt;
 }
 
 #modal_backdrop {
@@ -967,7 +948,6 @@ div.comment_text code {
 }
 .markdown_help summary {
 	color: var(--color-fg-contrast-4-5);
-	font-size: 9pt;
 	text-align: right;
 }
 .controls .markdown_help[open] summary {
@@ -1120,7 +1100,6 @@ td.warned div, td.unwarned div {
 }
 .nominal {
 	color: var(--color-fg-accent);
-	font-size: 2em;
 	text-align: center;
 }
 .mod_activities {
@@ -1215,7 +1194,6 @@ label:has(+ *:not(label) *:required)::after,
 label:has(+ *[type="hidden"] + *:required)::after {
 	content: "*";
 	margin-left: 0.15em;
-	font-size: 150%;
 	vertical-align: middle;
 }
 /* Labels on the (read-only) Profile page get extra contrast */
@@ -1414,7 +1392,6 @@ div.flash-error h2,
 div.flash-notice h2,
 div.flash-success h2,
 div.user-stats h2 {
-	font-size: 1.25em;
 	margin: 0;
 }
 
@@ -1430,7 +1407,6 @@ div.user-stats h2 {
 	padding: 2px 0 0px 5px;
 	/* supposed to be inherited from body, but TS overwrites */
 	font-family: "helvetica neue", arial, sans-serif;
-	font-size: 13.33px;
 	color: var(--color-fg);
 	line-height: 1.5rem;
 }
@@ -1467,7 +1443,6 @@ div.user-stats h2 {
 	display: block;
 	position: absolute;
 	color: grey;
-	font-size: 10px;
 	outline: none;
 	padding-right: 3px;
 	top: 0px;
@@ -1535,7 +1510,6 @@ input[type="submit"].link_post.pushover_button {
 /* search */
 .searchresults summary .heading {
 	font-weight: bold;
-	font-size: 11pt; /* h2 */
 }
 .searchresults summary {
 	margin: 1em 0;
@@ -1676,11 +1650,7 @@ input[type="submit"].link_post.pushover_button {
 	}
 
 	header#nav .corner .inbox {
-		font-size: 18px;
 		vertical-align: bottom;
-	}
-	header#nav .corner .inbox .inbox_unread {
-		font-size: 10pt;
 	}
 	header#nav {
 		background-color: var(--color-box-bg-shaded);
@@ -1804,7 +1774,6 @@ input[type="submit"].link_post.pushover_button {
 	}
 	ol.stories.list li.story .mobile_comments {
 		display: table-cell !important;
-		font-size: 11pt;
 		min-width: 40px;
 		text-align: center;
 		text-decoration: none;
@@ -1844,7 +1813,6 @@ input[type="submit"].link_post.pushover_button {
 		border-radius: 5px;
 		color: var(--color-fg);
 		display: block;
-		font-size: 9pt;
 		margin: 0 0.5em;
 		padding: 2px;
 		position: relative;
@@ -1876,9 +1844,6 @@ input[type="submit"].link_post.pushover_button {
 	nav.morelink {
 		margin-left: 28px;
 		float: none;
-	}
-	li.story div.byline {
-		font-size: 10pt;
 	}
 
 	div.box label,


### PR DESCRIPTION
Remove all font size hardcoded values and default the body text to 1rem. The use of a relative size unit gives more control to the user since 1rem is respect whatever the value a user has configured in their browser as the root font size.

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
