### PR TITLE
Revoke GitHub token when disconnecting account

### DIFF
--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -267,6 +267,9 @@ class SettingsController < ApplicationController
   end
 
   def github_disconnect
+    unless Github.revoke_token(@user.github_oauth_token)
+      flash[:notice] = "We asked GitHub to revoke our auth token and got an API error, if it still exists you should delete it: https://github.com/settings/applications"
+    end
     @user.github_oauth_token = nil
     @user.github_username = nil
     @user.save!

--- a/extras/github.rb
+++ b/extras/github.rb
@@ -45,4 +45,25 @@ class Github
     "https://github.com/login/oauth/authorize?client_id=#{Rails.application.credentials.github.client_id}&" \
       "state=#{state}"
   end
+
+  def self.revoke_token(token)
+    return if token.blank?
+
+    s = Sponge.new
+    headers = {
+      "Accept" => "application/vnd.github+json",
+      "Content-Type" => "application/json",
+      "X-GitHub-Api-Version" => "2022-11-28"
+    }
+    uri = URI::HTTPS.build(
+      userinfo: [
+        Rails.application.credentials.github.client_id,
+        Rails.application.credentials.github.client_secret
+      ].join(":"),
+      host: "api.github.com",
+      path: "/applications/#{Rails.application.credentials.github.client_id}/grant"
+    )
+    res = s.fetch(uri, :delete, {}, JSON.generate({access_token: token}), headers)
+    res.is_a? Net::HTTPSuccess
+  end
 end


### PR DESCRIPTION
So I went looking for [documentation on token revocation](https://docs.github.com/en/rest/apps/oauth-applications?apiVersion=2022-11-28#delete-an-app-authorization) to put in the issue, at which point I figured I'd done most of the work for a fix.

That turned out to be wrong, as I had to patch `extras/sponge.rb` to support JSON-encoded (well, non-form-encoded) bodies, and to send DELETE requests with a body at all ([`Net::HTTP#delete`](https://docs.ruby-lang.org/en/4.0/Net/HTTP.html#method-i-delete) does not seem to support it). This is the part that I'm most worried about; I tried to make it compatible with the two existing usages:

- This first one should work as before, as it sends an empty body. However, I don't have a Mastodon account to test with. https://github.com/lobsters/lobsters/blob/9acc2b5b3fd4958a6e577f3cdef55a3ad6c6ca13/extras/mastodon.rb#L37-L48

- This one will start sending the body that it previously wasn't sending, which is a change in behavior, but the existing code is probably erroneous to start with. Note that it will be sending that body form-encoded, not JSON-encoded. It's only used by [app/jobs/mastodon_sync_list.rb](https://github.com/lobsters/lobsters/blob/9acc2b5b3fd4958a6e577f3cdef55a3ad6c6ca13/app/jobs/mastodon_sync_list_job.rb), which claims that it isn't actually running in production at the moment.
https://github.com/lobsters/lobsters/blob/9acc2b5b3fd4958a6e577f3cdef55a3ad6c6ca13/extras/mastodon.rb#L124-L134

I created a Github oauth app to test this manually, but I haven't provided automated tests as I didn't see anything similarly testing external APIs in the existing suite. I'd be willing to change that if needed, though.