### PR TITLE
Set textarea font-size to base font size

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -42,7 +42,6 @@ But I make an unprincipled exception for :has because it solves so many big prob
 /* generics */
 
 html {
-	font-size: var(--font-size-default);
 	/* force a vertical scrollbar to avoid page-shifting */
 	overflow-y: scroll;
 
@@ -54,6 +53,7 @@ html {
 
 body, textarea, input, button {
 	font-family: "helvetica neue", arial, sans-serif;
+	font-size: var(--font-size-default);
 	color: var(--color-fg);
 	line-height: 1.45em;
 }


### PR DESCRIPTION
Font size is too small in Safari. Affects both textarea and text fields. See https://github.com/lobsters/lobsters/issues/1872#issuecomment-3791880878

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
