### PR TITLE
Account for focused outline in input margins

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -37,6 +37,7 @@ But I make an unprincipled exception for :has because it solves so many big prob
 
 	/* dimensions */
 	--comment-controls-height: 1.2lh;
+	--input-outline-width: 2px;
 }
 
 /* generics */
@@ -174,6 +175,15 @@ textarea {
 	color: var(--color-fg-contrast-10);
 	background-color: var(--color-box-bg);
 	padding: 3px 5px;
+	margin: var(--input-outline-width);
+}
+input:focus,
+button:focus,
+select:focus,
+textarea:focus {
+	outline: var(--input-outline-width) solid var(--color-box-border-focus);
+	border-color: transparent;
+	color: var(--color-fg);
 }
 textarea {
 	resize: vertical;
@@ -189,13 +199,6 @@ textarea {
 }
 input[type="checkbox"] {
 	margin-top: 0.5em;
-}
-select:focus,
-input:focus,
-textarea:focus {
-	outline: 2px solid var(--color-box-border-focus);
-	border-color: transparent;
-	color: var(--color-fg);
 }
 textarea::placeholder {
 	color: var(--color-fg-contrast-7-5);


### PR DESCRIPTION
The outline applied to focused elements doesn't affect layout. This is desirable so that focusing an input doesn't affect the positioning of other elements on the page. However, it may result in the outline overlapping adjacent elements. To prevent this, this commit gives the affected elements a margin of the same size of their potential outline, so that the outline can't protrude beyond the element's box.

This commit makes the outline size a variable so it can be reused, and moves the :focus selector next to the styles it's intended to override.

Closes #1867

Comparisions follow. **Note**: we're applying the margin to all four sides, meaning the submit button is indented slightly. If the outline "leaking" over the edge of the page isn't an issue, we can switch the margin to only apply to the top and bottom.

Before:
<img width="1132" height="338" alt="image" src="https://github.com/user-attachments/assets/0616066c-211a-42b4-bf7d-de6f0b000d4b" />


After:
<img width="1150" height="364" alt="image" src="https://github.com/user-attachments/assets/8c5e21da-a9b8-4f29-a470-0029240fe96d" />


<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
