### PR TITLE
Add note on preview card logo positioning

### DIFF
--- a/app/models/story_image.rb
+++ b/app/models/story_image.rb
@@ -102,6 +102,13 @@ class StoryImage
       lobsters_logo = lobsters_logo.resize((image.height / 5.0) / lobsters_logo.height)
     end
 
+    # If it looks like the logo is mispositioned, it is likely due to social media
+    # cropping behaviors on preview cards.
+    #
+    # References:
+    # https://docs.joinmastodon.org/entities/PreviewCard/
+    # https://docs.joinmastodon.org/entities/MediaAttachment/#image
+    # https://mastodon.online/@mastodonmigration/109440513681868009
     combined_image = image.insert(lobsters_logo, 0, image.height - lobsters_logo.height)
     combined_image.write_to_buffer(".png")
   rescue Vips::Error => e


### PR DESCRIPTION
Part of #1525 

This PR is a follow-up for https://github.com/lobsters/lobsters/issues/1525 based on the [suggestion](https://github.com/lobsters/lobsters/pull/1812#issuecomment-3826121901):
>I think at this point the only thing to do would be to document it so that someone who looks into this in the future has a running start. Could you PR a comment to where the logo is positioned explaining "If it looks like the logo is mispositioned..." with the three Mastodon links you found? Given the unreliability, I don't think future work here is warranted for us.

If the logo looks mispositioned, it is likely due to a social media cropping.
|Mastodon preview|Story preview card|
|---|---|
|<img width="901" height="990" alt="image" src="https://github.com/user-attachments/assets/89db15e7-48f9-4a89-a53b-fb7963d30278" />|<img width="512" height="349" alt="image" src="https://github.com/user-attachments/assets/e4a85451-9ba5-4ab7-8dd7-7dc71ca39eeb" />|

Refs:
- https://docs.joinmastodon.org/entities/PreviewCard/
- https://docs.joinmastodon.org/entities/MediaAttachment/#image
- https://mastodon.online/@mastodonmigration/109440513681868009