### PR TITLE
Automatic tags for common video & audio file types

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -738,8 +738,10 @@ document.addEventListener("DOMContentLoaded", () => {
     let url_tags = {
       "\.pdf($|\\?|#)": "pdf",
       "[\/\.](asciinema\.org|(youtube|vimeo)\.com|youtu\.be|twitch\.tv|media\.ccc\.de)\/": "video",
+      "\.(mp4|avi|mkv|webm)($|\\?|#)": "video",
       "[\/\.](slideshare\.net|speakerdeck\.com)\/": "slides",
       "[\/\.](soundcloud\.com)\/": "audio",
+      "\.(mp3|wav|ogg|flac)($|\\?|#)": "audio",
     };
 
     const storyUrlEl = qS('#story_url');


### PR DESCRIPTION
When trying to submit a link to a `.mp4` / `.webm` file, it wasn't automatically recognized as a video tag.

Not sure about the implementation, let me know.

`.mp4`, `.avi`, `.mkv`, `.webm` for video tag
`.mp3`, `.wav`, `.ogg`, `.flac` for audio tag