### PR TITLE
Display self promo guideline when option is checked

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1008,7 +1008,8 @@ div#domain_box input[type=text] {
 }
 #story_box .url-updated,
 #story_box .title-reminder,
-#story_box .title-reminder-thanks
+#story_box .title-reminder-thanks,
+#story_box .self-promo-warning
 {
 	display: none;
 }

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -267,6 +267,14 @@ export class _LobstersFunction {
     }
   }
 
+  checkSelfPromo(input) {
+    if (input.checked) {
+      slideDownJS(qS('.self-promo-warning'));
+    } else if (qS('.self-promo-warning').classList.contains('slide-down')) {
+      qS('.self-promo-warning').classList.remove('slide-down');
+    }
+  }
+
   fetchURLTitle(button) {
     const url_field = qS('#story_url');
     const targetUrl = url_field.value;
@@ -687,7 +695,8 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Story
 
-  Lobster.checkStoryTitle()
+  Lobster.checkStoryTitle();
+  Lobster.checkSelfPromo(qS('#story_user_is_author'));
 
   Lobster.tomSelect();
 
@@ -699,6 +708,9 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   on('change', '#story_title', Lobster.checkStoryTitle);
+  on('change', '#story_user_is_author', (event) => {
+    Lobster.checkSelfPromo(event.target);
+  });
 
   on('click', '.story #flag_dropdown a', (event) => {
     event.preventDefault();

--- a/app/views/stories/_form.html.erb
+++ b/app/views/stories/_form.html.erb
@@ -141,6 +141,9 @@ See the guidelines below for more." %>
         " the author of the story at this URL (or this text)",
         :class => "normal" %>
     </div>
+    <p class="actions self-promo-warning">
+      If you're new here, please review the <a href="/about#self-promo">self-promo guideline</a>.
+    </p>
     <div class="boxline">
       <%= f.label :user_is_following, "Follow" %>
       <%= f.check_box :user_is_following %>


### PR DESCRIPTION
Show a dropdown text when the "I am the author of the story at this URL (or this text)" is checked.

Unchecked:
<img width="1284" height="166" alt="image" src="https://github.com/user-attachments/assets/b1a84131-c888-4ba3-924f-196d6c3f4251" />

Checked:
<img width="1284" height="166" alt="image" src="https://github.com/user-attachments/assets/130797d3-1878-4b31-a4f4-4e6c603b9e68" />

Shows the text same way as the `Please remove extraneous components from titles such as the name of the site, blog, section, and author.` text is shown (dropdown).

Hopefully that reduces the amount of self-promo bans on the site.

Closes #1725 
