### PR TITLE
Add `span` element to fix visual bug on the users page.

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -15,6 +15,7 @@
 
   <div class="labelled_grid">
   <label>Status</label>
+  <span>
     <% if @showing_user.is_banned? %>
       Banned by a moderator
     <% elsif !@showing_user.is_active? %>
@@ -31,6 +32,7 @@
         disabled
       <% end %>
     <% end %>
+  </span>
 
     <label>Joined</label>
     <span>


### PR DESCRIPTION
Adding an `span` element around the status of the user, so that it is correctly displayed on both rows, and not just in the first row on devices with a width under 480px.

Currently it looks like this:
<img width="266" height="96" alt="image" src="https://github.com/user-attachments/assets/61f728e3-76cd-4626-8cd9-c347c6e4e5d4" />

With the fix it will look like this:
<img width="254" height="53" alt="image" src="https://github.com/user-attachments/assets/16ca7190-4708-4c77-b6ed-7b1100cbcb68" />
