### PR TITLE
Fix mod origin edit/update routes to use identifier param

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -258,7 +258,7 @@ Rails.application.routes.draw do
       post "/domains_ban/:id" => "domains_ban#create_and_ban", :as => "create_and_ban_domain"
     end
     constraints identifier: ORIGINS_IDENTIFIER do
-      resources :origins, only: %i[edit update]
+      resources :origins, only: %i[edit update], param: :identifier
     end
     resources :mails, except: [:destroy], as: "mod_mails"
     resources :mail_messages, only: :create, as: "mod_mail_messages"


### PR DESCRIPTION
## Summary

- Added `param: :identifier` to the `resources :origins` declaration in mod routes
- Without this, Rails generates routes with `:id` param, but `Origin#to_param` returns `identifier` and `Mod::OriginsController` looks up `params[:identifier]`
- This mismatch causes 404s when trying to edit origins through the mod interface

## Details

The `resources :origins` call on line 261 was generating routes like `/mod/origins/:id/edit`, but:
- `Origin#to_param` returns `identifier` (line 66 of `origin.rb`)
- `Mod::OriginsController#find_or_initialize_origin` does `Origin.find_by! identifier: params[:identifier]`
- Links generated with `edit_mod_origin_path(@origin)` would produce URLs with the identifier value in the `:id` slot, but the controller expected `:identifier`

Adding `param: :identifier` makes the routes generate `/mod/origins/:identifier/edit` and `/mod/origins/:identifier`, matching the controller's expectations.

Fixes #1908