### PR TITLE
Filter user settings from logs etc

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -17,6 +17,7 @@ Rails.application.config.filter_parameters += [
   :passw, # preventative
   :salt, # preventative
   :secret, # preventative
+  :settings, # contains secrets for pushover, totp, github, mastodon
   :session_token, # auth cookie value
   :token, # rss token - need to transition this to a typeid
   :totp_code # LoginController


### PR DESCRIPTION
This attribute contains secrets for Pushover, TOTP, GitHub, and Mastodon. In principle it should be possible to filter just those subfields with a filter like "settings.totp_secret", but due to [how Rails implements filtering on model attributes](https://github.com/rails/rails/blob/12900149d812792f4b7fdf38f591fb6d8800db9f/activerecord/lib/active_record/attribute_methods.rb#L531-L539), the filter only sees the settings hash in its stringified form.