### PR TITLE
ui: replace caches dropdown with inline reveal

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -944,21 +944,21 @@ div.comment_text code {
 	background-color: var(--color-box-bg-shaded);
 }
 
-.archive-dropdown {
+.caches-dropdown {
 	width: fit-content;
 	margin: 0 auto;
 }
 
-.archive-dropdown a {
+.caches-dropdown a {
 	color: var(--color-fg-contrast-4-5);
 	text-decoration: none;
 }
 
-.archive-dropdown a:hover {
+.caches-dropdown a:hover {
 	text-decoration: underline;
 }
 
-.details:has(> .archive_button:checked) label[for^="archive_"]::before {
+.details:has(> .caches_button:checked) label.caches::before {
 	content: "▾ ";
 }
 
@@ -977,19 +977,16 @@ div.comment_text code {
 	z-index: 1;
 }
 
-/* archive caches */
-.archive_button {
+.caches_button {
 	display: none;
 }
-.archive_button:not(:checked) ~ .archive-dropdown {
+.caches_button:not(:checked) ~ .caches-dropdown {
 	display: none;
 }
-label[for^="archive_"] {
+label.caches {
 	cursor: pointer;
 	white-space: nowrap;
 }
-
-
 
 .controls details {
 	margin-left: auto;

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -134,7 +134,7 @@ class="story <%= story.current_upvoted? ? "upvoted" : "" %>
         <% end %>
         <% if story.url.present? && (!story.is_gone? || @user.try(:is_moderator?))  %>
           <%= divider_tag %>
-          <label for="archive_<%= story.short_id %>" tabindex="0">caches</label>
+          <label for="caches_<%= story.short_id %>" class="caches" tabindex="0">caches</label>
         <% end %>
         <% if !story.is_gone? || @user.try(:is_moderator?) %>
           <span class="comments_label">
@@ -151,8 +151,8 @@ class="story <%= story.current_upvoted? ? "upvoted" : "" %>
       <% end %>
     </div>
     <% if story.url.present? && (!story.is_gone? || @user.try(:is_moderator?)) %>
-      <input id="archive_<%= story.short_id %>" class="archive_button" type="checkbox">
-      <div class="archive-dropdown">
+      <input id="caches_<%= story.short_id %>" class="caches_button" type="checkbox">
+      <div class="caches-dropdown">
         <a href="<%= story.archiveorg_url %>">Archive.org</a>
         <%= divider_tag %>
         <a href="<%= story.ghost_url %>">Ghostarchive</a>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -256,7 +256,7 @@ class="story <%= story.current_upvoted? ? "upvoted" : "" %>
         <% end %>
         <% if story.url.present? && (!story.is_gone? || @user.try(:is_moderator?))  %>
           <%= divider_tag %>
-          <label for="archive_<%= story.short_id %>" tabindex="0">caches</label>
+          <label for="caches_<%= story.short_id %>" class="caches" tabindex="0">caches</label>
         <% end %>
         <% if !story.is_gone? || @user.try(:is_moderator?) %>
           <span class="comments_label">
@@ -273,8 +273,8 @@ class="story <%= story.current_upvoted? ? "upvoted" : "" %>
       <% end %>
     </div>
     <% if story.url.present? && (!story.is_gone? || @user.try(:is_moderator?)) %>
-      <input id="archive_<%= story.short_id %>" class="archive_button" type="checkbox">
-      <div class="archive-dropdown">
+      <input id="caches_<%= story.short_id %>" class="caches_button" type="checkbox">
+      <div class="caches-dropdown">
         <a href="<%= story.archiveorg_url %>">Archive.org</a>
         <%= divider_tag %>
         <a href="<%= story.ghost_url %>">Ghostarchive</a>

--- a/app/views/stories/_listdetail.html.erb
+++ b/app/views/stories/_listdetail.html.erb
@@ -119,7 +119,7 @@ class="story <%= story.current_upvoted? ? "upvoted" : "" %>
         <% end %>
         <% if story.url.present? && (!story.is_gone? || @user.try(:is_moderator?))  %>
           <%= divider_tag %>
-          <label for="archive_<%= story.short_id %>" tabindex="0">caches</label>
+          <label for="caches_<%= story.short_id %>" class="caches" tabindex="0">caches</label>
         <% end %>
         <% if !story.is_gone? || @user.try(:is_moderator?) %>
           <span class="comments_label">
@@ -136,8 +136,8 @@ class="story <%= story.current_upvoted? ? "upvoted" : "" %>
       <% end %>
     </div>
     <% if story.url.present? && (!story.is_gone? || @user.try(:is_moderator?)) %>
-      <input id="archive_<%= story.short_id %>" class="archive_button" type="checkbox">
-      <div class="archive-dropdown">
+      <input id="caches_<%= story.short_id %>" class="caches_button" type="checkbox">
+      <div class="caches-dropdown">
         <a href="<%= story.archiveorg_url %>">Archive.org</a>
         <%= divider_tag %>
         <a href="<%= story.ghost_url %>">Ghostarchive</a>

--- a/app/views/stories/_singledetail.html.erb
+++ b/app/views/stories/_singledetail.html.erb
@@ -119,7 +119,7 @@ classes = [
         <% else %>
           <% if ms.url.present? && (!ms.is_gone? || @user.try(:is_moderator?))  %>
             <%= divider_tag %>
-            <label for="archive_<%= ms.short_id %>" tabindex="0">caches</label>
+            <label for="caches_<%= ms.short_id %>" class="caches" tabindex="0">caches</label>
           <% end %>
 
           <span class="comments_label">
@@ -136,8 +136,8 @@ classes = [
         <% end %>
       </div>
       <% if ms.url.present? && (!ms.is_gone? || @user.try(:is_moderator?)) %>
-        <input id="archive_<%= ms.short_id %>" class="archive_button" type="checkbox">
-        <div class="archive-dropdown">
+        <input id="caches_<%= ms.short_id %>" class="caches_button" type="checkbox">
+        <div class="caches-dropdown">
           <a href="<%= ms.archiveorg_url %>">Archive.org</a>
           <%= divider_tag %>
           <a href="<%= ms.ghost_url %>">Ghostarchive</a>

--- a/app/views/stories/show.html.erb
+++ b/app/views/stories/show.html.erb
@@ -96,7 +96,7 @@
 
                 <% if ms.url.present? && (!ms.is_gone? || @user.try(:is_moderator?)) %>
                   <%= divider_tag %>
-                  <label for="archive_<%= ms.short_id %>" tabindex="0">caches</label>
+                  <label for="caches_<%= ms.short_id %>" class="caches" tabindex="0">caches</label>
                 <% end %>
 
                 <%= divider_tag %>
@@ -109,8 +109,8 @@
                 </span>
               </span>
               <% if ms.url.present? && (!ms.is_gone? || @user.try(:is_moderator?)) %>
-                <input id="archive_<%= ms.short_id %>" class="archive_button" type="checkbox">
-                <div class="archive-dropdown">
+                <input id="caches_<%= ms.short_id %>" class="caches_button" type="checkbox">
+                <div class="caches-dropdown">
                   <a href="<%= ms.archiveorg_url %>">Archive.org</a>
                   <%= divider_tag %>
                   <a href="<%= ms.ghost_url %>">Ghostarchive</a>


### PR DESCRIPTION
Addressing the discussion in #1916, this PR replaces the caches dropdown with an inline reveal (keeping the checkbox logic). It does use the `:has` selector (Baseline 2023), but I see there is an exception for this. Please let me know if anything else should be changed.

Closes #1915 and closes #1913.

Thanks!