### PR TITLE
Fix username timeout validation

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -625,7 +625,7 @@ class User < ApplicationRecord
   def validate_username_timeouts
     return unless username_changed?
 
-    at = usernames.where("created_at <= ?", 1.year.ago).order(created_at: :desc).first&.created_at
+    at = usernames.where("created_at >= ?", 1.year.ago).order(created_at: :desc).first&.created_at
     errors.add(:username, "has already been changed in the last year (#{at.strftime("%Y-%m-%d")})") if at
 
     recently_used = Username.where(username: username).where("renamed_away_at >= ?", 5.years.ago).order(renamed_away_at: :desc).first&.renamed_away_at

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -30,15 +30,31 @@ describe User do
     expect { create(:user, username: "case-insensITive") }.to raise_error
   end
 
-  it "doesn't allow changing username in < 1.year" do
-    user = create(:user, username: "alice", created_at: 2.years.ago)
-    Username.rename! user: user, from: "alice", to: "cool_alice", by: user, at: 6.months.ago
-    user.update_attribute :username, "cool_alice"
-    expect(User.find_by(username: "alice")).to be(nil)
-
-    user.username = "really_cool_alice"
+  it "doesn't allow new users to change in < 1 year" do
+    user = create(:user, username: "alice", created_at: 6.months.ago)
+    user.username = "betty"
     user.valid?
     expect(user.errors[:username].select { |e| e =~ /changed in the last year/ }).to_not be_empty
+  end
+
+  it "doesn't allow changing usernames in < 1 year of last change" do
+    user = create(:user, username: "alice", created_at: 3.years.ago)
+    Username.rename! user: user, from: "alice", to: "betty", by: user, at: 6.months.ago
+    user.update_attribute :username, "betty"
+
+    user.username = "eve"
+    user.valid?
+    expect(user.errors[:username].select { |e| e =~ /changed in the last year/ }).to_not be_empty
+  end
+
+  it "allows changing username with no creation/changing in < 1 year" do
+    user = create(:user, username: "alice", created_at: 3.years.ago)
+    Username.rename! user: user, from: "betty", to: "cool_betty", by: user, at: 2.years.ago
+    user.update_attribute :username, "betty"
+
+    user.username = "eve"
+    user.valid?
+    expect(user.errors[:username].select { |e| e =~ /changed in the last year/ }).to be_empty
   end
 
   it "doesn't allow changing to a username someone else stopped using in the last 5 years" do


### PR DESCRIPTION
Seems like the timeout validation for username change is inverted. The existing test is actually wrong.

Here's the error I got on lobste.rs: 

<img width="578" height="150" alt="image" src="https://github.com/user-attachments/assets/313aa70c-8d82-4b87-9d44-e7f8df6abfe5" />
