### PR TITLE
Fix fake_data test

### DIFF
--- a/lib/tasks/fake_data.rake
+++ b/lib/tasks/fake_data.rake
@@ -364,7 +364,7 @@ task fake_data: :environment do
   fail "Refusing to add fake-data to a non-development environment" unless Rails.env.development?
 
   record_count = User.count + Tag.count + Story.count + Comment.count
-  if record_count > 3 # more than would be created by db:seed
+  if record_count > 4 # more than would be created by db:seed
     warn "Database has #{record_count} records, are you sure you want to add more? [y to continue]"
     fail "Cancelled" if $stdin.gets.chomp != "y"
   end

--- a/spec/slow/fake_data_spec.rb
+++ b/spec/slow/fake_data_spec.rb
@@ -5,7 +5,8 @@ require "rails_helper"
 Rails.application.load_tasks
 
 describe "fake_data" do
-  before { Rails.application.load_seed }
+  # Delete the system user created by the rails helper since the seeds contain the same user.
+  before { User.find_by(username: "System").destroy && Rails.application.load_seed }
 
   # basic smoke test, task shouldn't throw exceptions
   it "runs" do


### PR DESCRIPTION
Before:

```
tom@debian:~/work/lobsters-original$ rails db:drop db:create db:schema:load && bundle exec rspec ./spec/slow/fake_data_spec.rb

...

Failures:

  1) fake_data runs
     Failure/Error: before { Rails.application.load_seed }

     ActiveRecord::RecordInvalid:
       Validation failed: Username has already been taken, Email has already been taken
     # ./db/seeds.rb:2:in '<top (required)>'
     # ./spec/slow/fake_data_spec.rb:8:in 'block (2 levels) in <top (required)>'

Finished in 2.01 seconds (files took 2.77 seconds to load)
1 example, 1 failure

...
```

After, the tests pass.