### PR TITLE
Don't float "tags" label in "submit" form.

### DIFF
--- a/app/views/stories/_form.html.erb
+++ b/app/views/stories/_form.html.erb
@@ -42,9 +42,9 @@
     </div>
   <% end %>
 
-  <div class="boxline" style="margin-bottom: 2px;">
+  <div class="boxline" style="margin-bottom: 2px; display: flex;">
   <%= f.label :tags, "Tags",
-    :style => "line-height: 2.3em;" %>
+    :style => "line-height: 2.3em; float: none" %>
   <%= f.select "tags", options_for_select(
     Tag.all_with_filtered_counts_for(@user).map{|t|
       html = "<strong>#{h(t.tag)}</strong> - #{h(t.description.to_s)}"


### PR DESCRIPTION
Fixes #1880

The "Tags" label wasn't clickable, because the div that the TomSelect library creates extends over top of the label (because it was floated to the left and hence didn't take up space). This removes the float and uses flexbox to get the correct layout.

As mentioned in the issue, it might be desirable to replace uses of `float` with flex (or something), but that is not completely mechanical (e.g. simply changing the styles in `.boxline` (adding `display: flex`) & `.box label` (removing `float: left`) *almost* works, but the "text" textarea is squished), and so probably better left for its own issue.