### PR TITLE
Fix comment sibling indicator centering

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -676,7 +676,7 @@ li.comments_subtree {
 	content: "";
 	position: absolute;
 	top: 3.6lh;
-	left: calc(1em - 1px);
+	left: calc(0.9em - 1px);
 	bottom: 0;
 	border-left: 2px dotted var(--color-fg-shape);
 }


### PR DESCRIPTION
<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->

Created as #1926 doesn't center (relative to upvote button) the thickened vertical lines properly.