### PR TITLE
Refactor "hide" so it can work without JS

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -93,20 +93,13 @@ export const removeExtraInputs = () => {
 }
 
 /**
- * @template {string} K
+ * @template T
  * @param {unknown} obj
- * @param {K[]} keys
- * @returns {obj is {[P in K]: string}}
+ * @param {Array<keyof T>} props
+ * @returns {obj is T}
  */
-function hasProperties(obj, keys) {
-	return (
-		isObject(obj) &&
-		keys.every(
-			(key) =>
-				key in obj &&
-				typeof (/** @type {{[key]: unknown}} */ (obj)[key]) === "string",
-		)
-	);
+function hasProperties(obj, props) {
+  return isObject(obj) && props.every((p) => p in obj);
 }
 
 /** @param {unknown} obj @returns obj is object */
@@ -122,58 +115,52 @@ function notify(msg) {
 		}
 }
 
-/** @param {HTMLFormElement} form @param {HTMLInputElement} submitter */
-async function asyncFormSubmit(form, submitter) {
-	// Prevent double submissions
-	if (submitter.disabled) {
-		return;
-	}
+/** @param {SubmitEvent} ev */
+export async function asyncFormSubmit(ev) {
+  ev.preventDefault();
 
-	submitter.disabled = true;
+  const submitter = /** @type {HTMLInputElement} */ (ev.submitter);
+  const form = /** @type {HTMLFormElement} */ (ev.target);
 
-	try {
-		const response = await fetch(form.action, {
-			method: "POST",
-			body: new FormData(form),
-			headers: {
-				Accept: "application/json",
-			},
-		});
+  // Prevent double submissions
+  if (submitter.disabled) {
+    return;
+  }
 
-		let body;
+  submitter.disabled = true;
 
-		try {
-			body = await response.json();
-		} catch {
-			body = await response.text();
-		}
+  try {
+    const response = await fetch(form.action, {
+      method: form.method,
+      body: new FormData(form),
+      headers: {
+        Accept: "application/json",
+      },
+    });
 
-		if (!response.ok) {
-			throw new Error(
-				typeof body === "string"
-					? body
-					: hasProperties(body, ["error"])
-						? body.error
-						: "Bad response",
-			);
-		}
+    const textBody = await response.text();
 
-		return {
-			ok: true,
-			body,
-		};
-	} catch (err) {
-		const error = err instanceof Error ? err : new Error(JSON.stringify(err));
-		notify(error.message);
-		return {
-			ok: false,
-			error: error,
-		};
-	} finally {
-		submitter.disabled = false;
-	}
+    const body = JSON.parse(textBody);
+
+    if (response.ok && isObject(body)) {
+      return body;
+    }
+
+    // Received valid error from server?
+    if (isObject(body) && "message" in body) {
+      throw new Error(`${body.message}`);
+    }
+
+    // Let's hope server explained what happened.
+    throw new Error(textBody);
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(JSON.stringify(err));
+    notify(error.message);
+    throw error;
+  } finally {
+    submitter.disabled = false;
+  }
 }
-
 
 export class _LobstersFunction {
   constructor () {
@@ -308,23 +295,6 @@ export class _LobstersFunction {
     Lobster.checkStoryTitle();
   }
 
-  hideStory(hiderEl) {
-    if (!Lobster.curUser) return Lobster.bounceToLogin();
-
-    const li = parentSelector(hiderEl, ".story, .comment");
-    let act;
-    if (li.classList.contains("hidden")) {
-      act = "unhide";
-      li.classList.remove("hidden");
-      hiderEl.innerHTML = "hide";
-    } else {
-      act = "hide";
-      li.classList.add("hidden");
-      hiderEl.innerHTML = "unhide";
-    }
-    fetchWithCSRF("/stories/" + li.getAttribute("data-shortid") + "/" + act, {method: 'post'});
-  }
-
   removeFlagModal() {
     qS('#flag_dropdown').remove();
     qS('#modal_backdrop').remove();
@@ -407,43 +377,77 @@ export class _LobstersFunction {
   }
 
   /** @param {SubmitEvent} ev */
+  async hideStory(ev) {
+    await Lobster._handleStoryAction(ev, {
+      selector: ".hider",
+      stateProp: "hidden",
+      classToggle: "hidden",
+      activeText: "unhide",
+      inactiveText: "hide",
+    });
+  }
+
+  /** @param {SubmitEvent} ev */
   async saveStory(ev) {
-    ev.preventDefault();
+    await Lobster._handleStoryAction(ev, {
+      selector: ".saver",
+      stateProp: "saved",
+      classToggle: "saved",
+      activeText: "unsave",
+      inactiveText: "save",
+    });
+  }
 
-    const target = /** @type {HTMLFormElement} */ (ev.target);
+  /**
+   * @param {SubmitEvent} ev
+   * @param {{selector: string, stateProp: string, classToggle: string, activeText: string, inactiveText: string}} config
+   */
+  async _handleStoryAction(ev, config) {
     const submitter = /** @type {HTMLInputElement} */ (ev.submitter);
+    const story = parentSelector(submitter, ".story");
+    const btns = Array.from(
+      qSA(story, `${config.selector} input[type=submit]`),
+    ).filter((el) => el instanceof HTMLInputElement);
 
-    // Make sure to handle all "save" buttons in merged stories.
-    const story = parentSelector(target, ".story");
-    const forms = Array.from(qSA(story, ".saver")).filter(
-      (f) => f instanceof HTMLFormElement,
-    );
-    const btns = Array.from(qSA(story, ".saver input[type='submit']")).filter(
-      (b) => b instanceof HTMLInputElement,
-    );
-
-    for (const b of btns) {
-      if (b !== submitter) {
-        b.disabled = true;
+    const setButtonsDisabled = (/** @type boolean */ state) => {
+      for (const btn of btns) {
+        if (btn !== submitter) btn.disabled = state;
       }
-    }
+    };
 
-    const data = await asyncFormSubmit(target, submitter);
+    setButtonsDisabled(true);
 
-    if (data?.ok && hasProperties(data.body, ["action", "cta"])) {
-      for (const f of forms) {
-        f.action = data.body.action;
-      }
+    try {
+      const data = await asyncFormSubmit(ev);
 
-      for (const b of btns) {
-        b.value = data.body.cta;
+      const { stateProp } = config;
+
+      if (!hasProperties(data, [stateProp, "nextAction"])) {
+        return;
       }
 
-      story.classList.toggle("saved");
-    }
+      const isTrue = data[stateProp];
+      const nextAction = data["nextAction"];
 
-    for (const b of btns) {
-      b.disabled = false;
+      if (typeof isTrue !== "boolean" || typeof nextAction !== "string") {
+        throw new Error(`Bad response for ${config.selector}`);
+      }
+
+      qSA(story, config.selector).forEach((el) => {
+        if (el instanceof HTMLFormElement) {
+          el.action = nextAction;
+        }
+      });
+
+      story.classList.toggle(config.classToggle, isTrue);
+
+      btns.forEach((b) => {
+        b.value = isTrue ? config.activeText : config.inactiveText;
+      });
+    } catch (err) {
+      console.error(`${err}`);
+    } finally {
+      setButtonsDisabled(false);
     }
   }
 
@@ -743,10 +747,7 @@ document.addEventListener("DOMContentLoaded", () => {
     Lobster.modalFlaggingDropDown("story", event.target, reasons);
   });
 
-  on('click', 'li.story a.hider', (event) => {
-    event.preventDefault();
-    Lobster.hideStory(event.target);
-  });
+  on('submit', 'li.story .hider', Lobster.hideStory);
 
   on('submit', 'li.story .saver', Lobster.saveStory)
 

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -121,10 +121,9 @@ class="story <%= story.current_upvoted? ? "upvoted" : "" %>
               <a class="flagger">flag</a>
             </span>
           <% end %>
-          <% if story.is_hidden_by_cur_user %>
-            <%= divider_tag %><%= link_to "unhide", story_unhide_path(story.short_id), :class => "hider" %>
-          <% else %>
-            <%= divider_tag %><%= link_to "hide", story_hide_path(story.short_id), :class => "hider" %>
+          <%= divider_tag %>
+          <%= form_with :class => "hider", url: story.is_hidden_by_cur_user ? story_unhide_path(story.short_id) : story_hide_path(story.short_id) do |form| %>
+            <%= form.submit story.is_hidden_by_cur_user ? "unhide" : "hide", :class => "btn-link" %>
           <% end %>
           <%= divider_tag %>
           <%= form_with :class => "saver", url: story.is_saved_by_cur_user ? story_unsave_path(story.short_id) : story_save_path(story.short_id) do |form| %>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -243,10 +243,9 @@ class="story <%= story.current_upvoted? ? "upvoted" : "" %>
               <a class="flagger">flag</a>
             </span>
           <% end %>
-          <% if story.is_hidden_by_cur_user %>
-            <%= divider_tag %><%= link_to "unhide", story_unhide_path(story.short_id), :class => "hider" %>
-          <% else %>
-            <%= divider_tag %><%= link_to "hide", story_hide_path(story.short_id), :class => "hider" %>
+          <%= divider_tag %>
+          <%= form_with :class => "hider", url: story.is_hidden_by_cur_user ? story_unhide_path(story.short_id) : story_hide_path(story.short_id) do |form| %>
+            <%= form.submit story.is_hidden_by_cur_user ? "unhide" : "hide", :class => "btn-link" %>
           <% end %>
           <%= divider_tag %>
           <%= form_with :class => "saver", url: story.is_saved_by_cur_user ? story_unsave_path(story.short_id) : story_save_path(story.short_id) do |form| %>

--- a/app/views/stories/_listdetail.html.erb
+++ b/app/views/stories/_listdetail.html.erb
@@ -106,10 +106,9 @@ class="story <%= story.current_upvoted? ? "upvoted" : "" %>
               <a class="flagger">flag</a>
             </span>
           <% end %>
-          <% if story.is_hidden_by_cur_user %>
-            <%= divider_tag %><%= link_to "unhide", story_unhide_path(story.short_id), :class => "hider" %>
-          <% else %>
-            <%= divider_tag %><%= link_to "hide", story_hide_path(story.short_id), :class => "hider" %>
+          <%= divider_tag %>
+          <%= form_with :class => "hider", url: story.is_hidden_by_cur_user ? story_unhide_path(story.short_id) : story_hide_path(story.short_id) do |form| %>
+            <%= form.submit story.is_hidden_by_cur_user ? "unhide" : "hide", :class => "btn-link" %>
           <% end %>
           <%= divider_tag %>
           <%= form_with :class => "saver", url: story.is_saved_by_cur_user ? story_unsave_path(story.short_id) : story_save_path(story.short_id) do |form| %>

--- a/app/views/stories/_singledetail.html.erb
+++ b/app/views/stories/_singledetail.html.erb
@@ -86,10 +86,9 @@ classes = [
             </span>
           <% end %>
 
-          <% if ms.is_hidden_by_cur_user %>
-            <%= divider_tag %><%= link_to "unhide", story_unhide_path(ms.short_id), :class => "hider" %>
-          <% else %>
-            <%= divider_tag %><%= link_to "hide", story_hide_path(ms.short_id), :class => "hider" %>
+          <%= divider_tag %>
+          <%= form_with :class => "hider", url: ms.is_hidden_by_cur_user ? story_unhide_path(ms.short_id) : story_hide_path(ms.short_id) do |form| %>
+            <%= form.submit ms.is_hidden_by_cur_user ? "unhide" : "hide", :class => "btn-link" %>
           <% end %>
 
           <% if ms.hider_count > 0 %>

--- a/app/views/stories/show.html.erb
+++ b/app/views/stories/show.html.erb
@@ -36,9 +36,15 @@
   <% end %>
 
   <% if @story.is_hidden_by_cur_user %>
-    You have <a href="/about#story-hiding">hidden this</a> story.
-  Links to this story and its comments will not be shown elsewhere on the site for you.
-    You can <%= link_post "unhide", story_unhide_path(@story.short_id) %> it to make them visible again.
+    <div id="hide-alert">
+      You have <a href="/about#story-hiding">hidden this</a> story.
+      Links to this story and its comments will not be shown elsewhere on the site for you.
+      You can
+      <%= form_with :class => "hider", url: story_unhide_path(@story.short_id) do |form| %>
+        <%= form.submit "unhide", :class => "btn-link" %>
+      <% end %>
+      it to make them visible again.
+    </div>
   <% end %>
 
   <% if (matched_filtered_tags = @story.tags & filtered_tags).any? %>


### PR DESCRIPTION
Use native forms for the "hide" button. Use JS to do an async request.

Use flash messages only when not using JS. Also refactor "save" so flash is not used when sending a JSON response.

Modify "save" handler in JS since the logic is very similar to "hide".

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
