### PR TITLE
Fixes #1891 Reset textarea after comment

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -330,6 +330,7 @@ export class _LobstersFunction {
     qS('#modal_backdrop').remove();
   }
 
+  /** @param { HTMLFormElement } form */
   postComment(form) {
     const formData = new FormData(form);
     const action = form.getAttribute('action');
@@ -357,6 +358,8 @@ export class _LobstersFunction {
             // Iterating up the comments tree to the nearest parent. If there isn't one, we are creating
             // a top-level comment, so find the top of the comments tree.
             const comments = form.closest('.comments') || qS('.comments')
+            const textArea = form.querySelector('textarea');
+            if (textArea) { textArea.value = "" }
             parentSelector(form, '.comment_form_container').remove()
 
             // if comments is .comments1, it is top-level comment: insert it deeper

--- a/app/views/comments/_commentbox.html.erb
+++ b/app/views/comments/_commentbox.html.erb
@@ -34,6 +34,7 @@
 
   <div style="width: 100%;">
     <%= f.text_area "comment", :value => comment.comment, :rows => 5,
+      :required => true,
       :disabled => !@user,
       :placeholder => (@user ? "" : "You must be logged in to leave a comment.")
     %>


### PR DESCRIPTION
When doing an async request to post a comment, clear the textarea before removing the whole form container. Prevents the textarea from being populated on page reload.

Make the textarea required to submit a comment.

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
