### PR TITLE
Account for clock drift in TOTP authentication

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -237,7 +237,7 @@ class User < ApplicationRecord
 
   def authenticate_totp(code)
     totp = ROTP::TOTP.new(totp_secret)
-    totp.verify(code)
+    totp.verify(code, drift_behind: totp.interval, drift_ahead: totp.interval)
   end
 
   def avatar_path(size = 100)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -153,6 +153,21 @@ describe User do
     expect(u.authenticate("hunteR2")).to be false
   end
 
+  it "allows totp codes from the surrounding time steps" do
+    u = create(:user)
+    u.totp_secret = ROTP::Base32.random
+
+    totp = ROTP::TOTP.new(u.totp_secret)
+
+    travel_to Time.current do
+      past_code = totp.at(Time.current - totp.interval)
+      expect(u.authenticate_totp(past_code)).to be_truthy
+
+      future_code = totp.at(Time.current + totp.interval)
+      expect(u.authenticate_totp(future_code)).to be_truthy
+    end
+  end
+
   it "gets an error message after registering banned name" do
     expect { create(:user, username: "admin") }
       .to raise_error("Validation failed: Username is not permitted")

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -67,6 +67,7 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.raise_errors_for_deprecations!
 
+  config.include ActiveSupport::Testing::TimeHelpers
   config.include AuthenticationHelper::ControllerHelper, type: :controller
   config.include AuthenticationHelper::FeatureHelper, type: :feature
   config.include AuthenticationHelper::RequestHelper, type: :request


### PR DESCRIPTION
When I logged into lobsters my autofilled TOTP code from bitwarden was invalid. I've never had that happen before and I thought the [spec](https://www.rfc-editor.org/rfc/rfc6238#section-6) had something to say about clock skew:

>  Because of possible clock drifts between a client and a validation
   server, we RECOMMEND that the validator be set with a specific limit
   to the number of time steps a prover can be "out of synch" before
   being rejected.
>
> This limit can be set both forward and backward from the calculated
   time step on receipt of the OTP value.  If the time step is
   30 seconds as recommended, and the validator is set to only accept
   two time steps backward, then the maximum elapsed time drift would be
   around 89 seconds, i.e., 29 seconds in the calculated time step and
   60 seconds for two backward time steps.
>
>   This would mean the validator could perform a validation against the
   current time and then two further validations for each backward step
   (for a total of 3 validations).  Upon successful validation, the
   validation server can record the detected clock drift for the token
   in terms of the number of time steps.  When a new OTP is received
   after this step, the validator can validate the OTP with the current
   timestamp adjusted with the recorded number of time-step clock drifts
   for the token.

ROTP supports checking for drift in [`ROTP::TOTP.verify`](https://www.rubydoc.info/github/mdp/rotp/main/ROTP/TOTP#verify-instance_method).

P.S. Thanks for the devcontainer configuration. It made getting a dev environment almost instant.
