### PR TITLE
Fix Markdown dropdown on Mobile for Submit Story

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -995,9 +995,6 @@ label.caches {
 .controls details {
 	margin-left: auto;
 }
-#story_box .markdown_help summary {
-	width: calc(7em + 610px);
-}
 .markdown_help summary {
 	color: var(--color-fg-contrast-4-5);
 	text-align: right;
@@ -1694,6 +1691,10 @@ input[type="submit"].link_post.pushover_button {
 	#story_holder .ts-control {
 		display: inline-block;
 		width: 611px;
+	}
+
+	#story_box .markdown_help summary {
+		width: calc(7em + 610px);
 	}
 }
 


### PR DESCRIPTION
Closes #1955

Desktop view:
<img width="2402" height="1334" alt="image" src="https://github.com/user-attachments/assets/5e5f0476-f425-4f66-bc3e-82f6031598e0" />

Mobile view:
<img width="2402" height="1334" alt="Screenshot From 2026-03-12 11-57-54" src="https://github.com/user-attachments/assets/b2ec1b34-415d-423d-92af-a5b25ecf37e4" />
