### PR TITLE
UI improvements for "hide" action

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -301,8 +301,9 @@ summary {
 input.btn-link:hover,
 input.btn-link {
 	border: 0;
+	margin: 0;
 	padding: 0;
-	background-color: var(--color-bg);
+	background-color: inherit;
 	color: var(--color-fg-contrast-4-5);
 	line-height: 1;
 }
@@ -769,6 +770,24 @@ li .byline form {
 li.story.saved .saver .btn-link {
 	color: var(--color-fg-affirmative);
 }
+
+li.story .hidden-by-you {
+	display: none;
+}
+
+li.story.hidden .hidden-by-you {
+	display: inline;
+}
+
+#hide-alert .hider {
+	display: inline-block;
+}
+
+#hide-alert .hider .btn-link {
+	color: var(--color-fg-link);
+	text-decoration: underline;
+}
+
 
 li.story.deleted {
 	opacity: var(--opacity-deleted);

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -102,9 +102,9 @@ function hasProperties(obj, props) {
   return isObject(obj) && props.every((p) => p in obj);
 }
 
-/** @param {unknown} obj @returns obj is object */
+/** @param {unknown} obj */
 function isObject(obj) {
-	return typeof obj === "object" && !!obj;
+	return !!obj && typeof obj === "object"
 }
 
 /** @param {string} msg */
@@ -118,16 +118,7 @@ function notify(msg) {
 /** @param {SubmitEvent} ev */
 export async function asyncFormSubmit(ev) {
   ev.preventDefault();
-
-  const submitter = /** @type {HTMLInputElement} */ (ev.submitter);
   const form = /** @type {HTMLFormElement} */ (ev.target);
-
-  // Prevent double submissions
-  if (submitter.disabled) {
-    return;
-  }
-
-  submitter.disabled = true;
 
   try {
     const response = await fetch(form.action, {
@@ -157,8 +148,6 @@ export async function asyncFormSubmit(ev) {
     const error = err instanceof Error ? err : new Error(JSON.stringify(err));
     notify(error.message);
     throw error;
-  } finally {
-    submitter.disabled = false;
   }
 }
 
@@ -378,76 +367,88 @@ export class _LobstersFunction {
 
   /** @param {SubmitEvent} ev */
   async hideStory(ev) {
-    await Lobster._handleStoryAction(ev, {
-      selector: ".hider",
-      stateProp: "hidden",
-      classToggle: "hidden",
-      activeText: "unhide",
-      inactiveText: "hide",
-    });
+    const submitBtn = /** @type HTMLInputElement */ ( ev.submitter );
+    const story = submitBtn.closest('.story');
+
+    // If no .story, action was triggered by #hide-alert.
+    const submitBtns = ( story ?
+      [...qSA(story, '.hider [type="submit"]'), qS('#hide-alert .hider [type="submit"]')] :
+      [...qSA('.hider [type="submit"]')] ).filter(btn => btn instanceof HTMLInputElement)
+
+    const data = await Lobster._handleStoryAction(ev, submitBtns);
+
+    if (!(data && "hidden" in data)) { return }
+
+    const isHidden = !!data.hidden;
+    const cta = isHidden ? "unhide" : "hide"
+
+    if (!isHidden) {
+      qS("hide-alert")?.setAttribute("hidden", "hidden");
+    } else {
+      qS("hide-alert")?.removeAttribute("hidden");
+    }
+
+
+    for (const submitBtn of submitBtns) {
+      if (!submitBtn.closest("#hide-alert")) {
+        submitBtn.value = cta;
+      }
+    }
+
+    ( story ?? qS('.story') )?.classList.toggle("hidden", isHidden);
   }
 
   /** @param {SubmitEvent} ev */
   async saveStory(ev) {
-    await Lobster._handleStoryAction(ev, {
-      selector: ".saver",
-      stateProp: "saved",
-      classToggle: "saved",
-      activeText: "unsave",
-      inactiveText: "save",
-    });
+    const submitBtn = /** @type HTMLInputElement */ ( ev.submitter );
+    const submitBtns = /** @type NodeListOf<HTMLInputElement> */ ( qSA(parentSelector(submitBtn, ".story"), ".saver [type='submit']") );
+
+    const data = await Lobster._handleStoryAction(ev, submitBtns);
+
+    if (!(data && "saved" in data)) { return }
+
+    const isSaved = !!data.saved;
+    const cta = isSaved ? "unsave" : "save"
+
+    for (const submitBtn of submitBtns) {
+      submitBtn.value = cta;
+    }
+
+    parentSelector(submitBtn, '.story')?.classList.toggle("saved", isSaved)
   }
 
   /**
    * @param {SubmitEvent} ev
-   * @param {{selector: string, stateProp: string, classToggle: string, activeText: string, inactiveText: string}} config
+   * @param {HTMLInputElement[] | NodeListOf<HTMLInputElement>} submitBtns
    */
-  async _handleStoryAction(ev, config) {
-    const submitter = /** @type {HTMLInputElement} */ (ev.submitter);
-    const story = parentSelector(submitter, ".story");
-    const btns = Array.from(
-      qSA(story, `${config.selector} input[type=submit]`),
-    ).filter((el) => el instanceof HTMLInputElement);
-
-    const setButtonsDisabled = (/** @type boolean */ state) => {
-      for (const btn of btns) {
-        if (btn !== submitter) btn.disabled = state;
-      }
-    };
-
-    setButtonsDisabled(true);
+  async _handleStoryAction(ev, submitBtns) {
+    for (const btn of submitBtns) {
+      btn.disabled = true;
+    }
 
     try {
       const data = await asyncFormSubmit(ev);
 
-      const { stateProp } = config;
+      const nextAction = "nextAction" in data && typeof data.nextAction === "string" ? data.nextAction : null;
 
-      if (!hasProperties(data, [stateProp, "nextAction"])) {
-        return;
-      }
+      if (!nextAction) { throw new Error("Bad response") }
 
-      const isTrue = data[stateProp];
-      const nextAction = data["nextAction"];
-
-      if (typeof isTrue !== "boolean" || typeof nextAction !== "string") {
-        throw new Error(`Bad response for ${config.selector}`);
-      }
-
-      qSA(story, config.selector).forEach((el) => {
-        if (el instanceof HTMLFormElement) {
-          el.action = nextAction;
+      for (const btn of submitBtns) {
+        const form = btn.closest("form");
+        if (form) {
+          form.action = nextAction;
         }
-      });
+      }
 
-      story.classList.toggle(config.classToggle, isTrue);
+      return data
 
-      btns.forEach((b) => {
-        b.value = isTrue ? config.activeText : config.inactiveText;
-      });
     } catch (err) {
       console.error(`${err}`);
+      return;
     } finally {
-      setButtonsDisabled(false);
+      for (const btn of submitBtns) {
+        btn.disabled = false;
+      }
     }
   }
 
@@ -760,7 +761,7 @@ document.addEventListener("DOMContentLoaded", () => {
     Lobster.modalFlaggingDropDown("story", event.target, reasons);
   });
 
-  on('submit', 'li.story .hider', Lobster.hideStory);
+  on('submit', 'li.story .hider, #hide-alert .hider', Lobster.hideStory);
 
   on('submit', 'li.story .saver', Lobster.saveStory)
 

--- a/app/views/stories/_singledetail.html.erb
+++ b/app/views/stories/_singledetail.html.erb
@@ -87,15 +87,17 @@ classes = [
           <% end %>
 
           <%= divider_tag %>
-          <%= form_with :class => "hider", url: ms.is_hidden_by_cur_user ? story_unhide_path(ms.short_id) : story_hide_path(ms.short_id) do |form| %>
-            <%= form.submit ms.is_hidden_by_cur_user ? "unhide" : "hide", :class => "btn-link" %>
+          <%= form_with :class => "hider", url: merged_stories.first.is_hidden_by_cur_user ? story_unhide_path(merged_stories.first.short_id) : story_hide_path(merged_stories.first.short_id) do |form| %>
+            <%= form.submit merged_stories.first.is_hidden_by_cur_user ? "unhide" : "hide", :class => "btn-link" %>
           <% end %>
 
           <% if ms.hider_count > 0 %>
             <span>
-              <% if ms.is_hidden_by_cur_user %>
-                (hidden by you and <%= pluralize(ms.hider_count - 1, "other user") %>)
-              <% else %>
+              <% if ms.is_hidden_by_cur_user && ( ms.hider_count - 1 ) > 0 %>
+                (hidden by <span class="hidden-by-you">you and</span>
+                <%= pluralize(ms.hider_count - 1, "other user") %>)
+              <% end %>
+              <% if !ms.is_hidden_by_cur_user %>
                 (hidden by <%= pluralize(ms.hider_count, "user") %>)
               <% end %>
             </span>
@@ -107,7 +109,7 @@ classes = [
           <% end %>
 
           <%= divider_tag %>
-          <%= form_with :class => "saver", url: merged_stories.first.is_saved_by_cur_user ? story_unsave_path(ms.short_id) : story_save_path(ms.short_id) do |form| %>
+          <%= form_with :class => "saver", url: merged_stories.first.is_saved_by_cur_user ? story_unsave_path(merged_stories.first.short_id) : story_save_path(merged_stories.first.short_id) do |form| %>
             <%= form.submit merged_stories.first.is_saved_by_cur_user ? "unsave" : "save", :class => "btn-link" %>
           <% end %>
 


### PR DESCRIPTION
Use the main story endpoint for saving and hiding in merged stories. Fixes #1959.

Don't show hidden users count if others users count is 0.

In single story page, if the user has hidden the story and we are showing the "hidden by you and others", toggle the "by you" part is user unhides the story.

In the same page, toggle the visibility of the "you have hidden this story" paragraph after toggling the story hidden status.

Allow the "hide" cta in the "you have hidden this story" message to do async requests too.

Fix styling for "hide" button in the "you have hidden this story" so it looks like a link in the paragraph.

Fix background for save and hide buttons when an story is target link.

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
