### PR TITLE
Fixes #1942 can't edit own comment in "Newest comments".

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -323,18 +323,26 @@ export class _LobstersFunction {
           if (replyForm) {
             // user submitted from a temporary reply form, so this is a reply to an existing comment
             replace(replyForm, text)
-          } else {
-            // Iterating up the comments tree to the nearest parent. If there isn't one, we are creating
-            // a top-level comment, so find the top of the comments tree.
-            const comments = form.closest('.comments') || qS('.comments')
-            parentSelector(form, '.comment_form_container').remove()
+            return;
+          }
 
-            // if comments is .comments1, it is top-level comment: insert it deeper
-            if (comments.classList.contains('comments1')) {
-              comments.querySelector('#story_comments .comments').insertAdjacentHTML("afterbegin", text)
-            } else {
-              comments.insertAdjacentHTML("afterbegin", text)
-            }
+          const commentContainer = form.closest('.comment');
+          if (commentContainer) {
+            // User is editing comment.
+            replace(commentContainer, text);
+            return;
+          }
+
+          // Iterating up the comments tree to the nearest parent. If there isn't one, we are creating
+          // a top-level comment, so find the top of the comments tree.
+          const comments = form.closest('.comments') || qS('.comments')
+          parentSelector(form, '.comment_form_container').remove()
+
+          // if comments is .comments1, it is top-level comment: insert it deeper
+          if (comments.classList.contains('comments1')) {
+            comments.querySelector('#story_comments .comments').insertAdjacentHTML("afterbegin", text)
+          } else {
+            comments.insertAdjacentHTML("afterbegin", text)
           }
 
         })
@@ -932,12 +940,14 @@ document.addEventListener("DOMContentLoaded", () => {
 
   on('click', 'a.comment_editor', (event) => {
     event.preventDefault();
-    let comment = parentSelector(event.target, '.comment');
+    const comment = parentSelector(event.target, '.comment');
+    const commentText = qS(comment, '.comment_text');
     const commentId = comment.getAttribute('data-shortid')
+
     fetchWithCSRF('/comments/' + commentId + '/edit')
       .then(response => {
         response.text().then(text => {
-          replace(comment, text);
+          replace(commentText, text);
           autosize(qSA('textarea'));
         });
       });

--- a/app/views/comments/_commentbox.html.erb
+++ b/app/views/comments/_commentbox.html.erb
@@ -7,7 +7,7 @@
   </ol>
 <% end %>
 
-<div class="comment comment_form_container" data-shortid="<%= comment.short_id if comment.persisted? %>">
+<div class="comment_form_container" data-shortid="<%= comment.short_id if comment.persisted? %>">
 <%= form_with url: comment do |f| %>
   <% if comment.errors.any? %>
     <%= errors_for comment %>


### PR DESCRIPTION
Fixes #1942. Fixes #1709 too. editing a reply orphaned it from its parent comment (in the UI)

In "Newest comments", When editing a comment, don't replace the whole comment container but only the container of the text comment.

When submitting a comment, check if the form is inside a comment; this indicates that user was editing a comment.

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
