### PR TITLE
Log modlog hats when they're added to a comment in an edit

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -35,9 +35,12 @@ class Comment < ApplicationRecord
   validates :short_id, presence: true, uniqueness: {case_sensitive: false}
 
   before_validation :assign_initial_attributes, on: :create
+
+  # We log hats before the transaction ends so we can accurately check whether the model changed
+  after_save :log_hat_use
   # Calling :record_initial_upvote from after_commit instead of after_create minimizes how many
   # queries happen inside the transaction, which seems to be the cause of bug #1238.
-  after_commit :log_hat_use, :mark_submitter, :record_initial_upvote, on: :create
+  after_commit :mark_submitter, :record_initial_upvote, on: :create
   after_commit :recreate_links, :update_associated_caches
 
   scope :deleted, -> { where(is_deleted: true) }
@@ -423,6 +426,7 @@ class Comment < ApplicationRecord
 
   def log_hat_use
     return unless hat&.modlog_use
+    return unless previously_new_record? || hat_previously_changed?
 
     m = Moderation.new
     m.created_at = created_at

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -23,6 +23,55 @@ describe Comment do
       comment.valid?
       expect(comment.errors[:hat]).to be_empty
     end
+
+    it "logs hat use on new comment" do
+      hat = create(:hat, modlog_use: true)
+      user = hat.user
+      comment = build(:comment, user: user, hat: hat)
+
+      expect { comment.save! }
+        .to change { Moderation.count }.by(1)
+
+      modlog = Moderation.last
+      expect(modlog.moderator).to eq(user)
+      expect(modlog.comment).to eq(comment)
+      expect(modlog.action).to eq("used #{hat.hat} hat")
+    end
+
+    it "logs hat use on edited comment that adds it" do
+      hat = create(:hat, modlog_use: true)
+      user = hat.user
+      comment = build(:comment, user: user)
+
+      expect { comment.save! }
+        .to_not change { Moderation.count }
+
+      comment.hat = hat
+      expect { comment.save! }
+        .to change { Moderation.count }.by(1)
+
+      modlog = Moderation.last
+      expect(modlog.moderator).to eq(user)
+      expect(modlog.comment).to eq(comment)
+      expect(modlog.action).to eq("used #{hat.hat} hat")
+    end
+
+    it "doesn't relog hat use on edit that doesn't change hat" do
+      hat = create(:hat, modlog_use: true)
+      user = hat.user
+      comment = build(:comment, user: user, hat: hat)
+      expect { comment.save! }
+        .to change { Moderation.count }.by(1)
+
+      modlog = Moderation.last
+      expect(modlog.moderator).to eq(user)
+      expect(modlog.comment).to eq(comment)
+      expect(modlog.action).to eq("used #{hat.hat} hat")
+
+      comment.comment = "edited"
+      expect { comment.save! }
+        .to_not change { Moderation.count }
+    end
   end
 
   it "validates the length of short_id" do


### PR DESCRIPTION
Moving this callback to run on `after_save` was the only way I could find to make `previously_new_record?` and `hat_previously_changed?` reliable. I believe this is because the model may get changed multiple times during the transaction, so it's unlikely the callback will run while the changes we're interested in are still the most recent ones.

This may be the cause of #1964.

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
