### PR TITLE
Fix comment flagging (#1967)

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -889,10 +889,10 @@ document.addEventListener("DOMContentLoaded", () => {
     Lobster.modalFlaggingDropDown("comment", event.target, reasons);
   });
 
-  on('click', '.comment #flag_dropdown a', (event) => {
+  on('click', '.comment #flag_dropdown a', (/** @type MouseEvent */ event) => {
     event.preventDefault();
-    if (event.target.getAttribute('data') != '') {
-      Lobster.voteComment(parentSelector(event.target, '.comment'), -1,  event.target.getAttribute('data'));
+    if  (event.target instanceof HTMLElement && event.target.dataset["key"] !== '') {
+      Lobster.voteComment(parentSelector(event.target, '.comment'), -1,  event.target.dataset["key"]);
     }
     Lobster.removeFlagModal()
   });


### PR DESCRIPTION
In #1944 the structure for the data about flag reasons was changed, but only the code for the story flag menu was adjusted. Adjust comment flag menu to match.

I've only tested this in browser devtools, not on a deployment of the site, so please double-check it's applied correctly.
