### PR TITLE
Fixes #1972 "Caches" dropdown in merged stories

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -948,22 +948,42 @@ div.comment_text code {
 	background-color: var(--color-box-bg-shaded);
 }
 
-.caches-dropdown {
-	width: fit-content;
-	margin: 0 auto;
+.caches {
+	display: inline-block;
+	position: relative;
 }
 
-.caches-dropdown a {
-	color: var(--color-fg-contrast-4-5);
+.caches summary {
+	list-style: none;
+}
+
+.caches ul {
+	position: absolute;
+	background: var(--color-bg);
+	border: 1px solid var(--color-box-border);
+	white-space: nowrap;
+	list-style: none;
+	padding: 0;
+	z-index: 1;
+}
+
+.caches li {
+	border-bottom: 1px solid var(--color-box-border);
+}
+
+.caches li:last-child {
+	border-bottom: 0;
+}
+
+.caches a {
+	color: var(--color-fg-contrast-7-5);
 	text-decoration: none;
+	display: block;
+	padding: 3px 7px;
 }
 
-.caches-dropdown a:hover {
+.caches a:hover {
 	text-decoration: underline;
-}
-
-.details:has(> .caches_button:checked) label.caches::before {
-	content: "▾ ";
 }
 
 #flag_dropdown a.cancel-reason {
@@ -979,17 +999,6 @@ div.comment_text code {
 	bottom: 0;
 	right: 0;
 	z-index: 1;
-}
-
-.caches_button {
-	display: none;
-}
-.caches_button:not(:checked) ~ .caches-dropdown {
-	display: none;
-}
-label.caches {
-	cursor: pointer;
-	white-space: nowrap;
 }
 
 .controls details {

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -133,7 +133,13 @@ class="story <%= story.current_upvoted? ? "upvoted" : "" %>
         <% end %>
         <% if story.url.present? && (!story.is_gone? || @user.try(:is_moderator?))  %>
           <%= divider_tag %>
-          <label for="caches_<%= story.short_id %>" class="caches" tabindex="0">caches</label>
+          <details class="caches" name="caches">
+            <summary>caches</summary>
+            <ul>
+              <li><a href="<%= story.archiveorg_url %>">Archive.org</a></li>
+              <li><a href="<%= story.ghost_url %>">Ghostarchive</a></li>
+            </ul>
+          </details>
         <% end %>
         <% if !story.is_gone? || @user.try(:is_moderator?) %>
           <span class="comments_label">
@@ -149,14 +155,6 @@ class="story <%= story.current_upvoted? ? "upvoted" : "" %>
         <% end %>
       <% end %>
     </div>
-    <% if story.url.present? && (!story.is_gone? || @user.try(:is_moderator?)) %>
-      <input id="caches_<%= story.short_id %>" class="caches_button" type="checkbox">
-      <div class="caches-dropdown">
-        <a href="<%= story.archiveorg_url %>">Archive.org</a>
-        <%= divider_tag %>
-        <a href="<%= story.ghost_url %>">Ghostarchive</a>
-      </div>
-    <% end %>
   </div>
 </div>
 <a href="<%= Routes.title_path story %>" class="mobile_comments <%= story.comments_count == 0 ? "zero" : "" %>" style="display: none;">

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -255,7 +255,13 @@ class="story <%= story.current_upvoted? ? "upvoted" : "" %>
         <% end %>
         <% if story.url.present? && (!story.is_gone? || @user.try(:is_moderator?))  %>
           <%= divider_tag %>
-          <label for="caches_<%= story.short_id %>" class="caches" tabindex="0">caches</label>
+          <details class="caches" name="caches">
+            <summary>caches</summary>
+            <ul>
+              <li><a href="<%= story.archiveorg_url %>">Archive.org</a></li>
+              <li><a href="<%= story.ghost_url %>">Ghostarchive</a></li>
+            </ul>
+          </details>
         <% end %>
         <% if !story.is_gone? || @user.try(:is_moderator?) %>
           <span class="comments_label">
@@ -271,14 +277,6 @@ class="story <%= story.current_upvoted? ? "upvoted" : "" %>
         <% end %>
       <% end %>
     </div>
-    <% if story.url.present? && (!story.is_gone? || @user.try(:is_moderator?)) %>
-      <input id="caches_<%= story.short_id %>" class="caches_button" type="checkbox">
-      <div class="caches-dropdown">
-        <a href="<%= story.archiveorg_url %>">Archive.org</a>
-        <%= divider_tag %>
-        <a href="<%= story.ghost_url %>">Ghostarchive</a>
-      </div>
-    <% end %>
   </div>
 </div>
 <a href="<%= Routes.title_path story %>" class="mobile_comments <%= story.comments_count == 0 ? "zero" : "" %>" style="display: none;">

--- a/app/views/stories/_listdetail.html.erb
+++ b/app/views/stories/_listdetail.html.erb
@@ -118,7 +118,13 @@ class="story <%= story.current_upvoted? ? "upvoted" : "" %>
         <% end %>
         <% if story.url.present? && (!story.is_gone? || @user.try(:is_moderator?))  %>
           <%= divider_tag %>
-          <label for="caches_<%= story.short_id %>" class="caches" tabindex="0">caches</label>
+          <details class="caches" name="caches">
+            <summary>caches</summary>
+            <ul>
+              <li><a href="<%= story.archiveorg_url %>">Archive.org</a></li>
+              <li><a href="<%= story.ghost_url %>">Ghostarchive</a></li>
+            </ul>
+          </details>
         <% end %>
         <% if !story.is_gone? || @user.try(:is_moderator?) %>
           <span class="comments_label">
@@ -134,14 +140,6 @@ class="story <%= story.current_upvoted? ? "upvoted" : "" %>
         <% end %>
       <% end %>
     </div>
-    <% if story.url.present? && (!story.is_gone? || @user.try(:is_moderator?)) %>
-      <input id="caches_<%= story.short_id %>" class="caches_button" type="checkbox">
-      <div class="caches-dropdown">
-        <a href="<%= story.archiveorg_url %>">Archive.org</a>
-        <%= divider_tag %>
-        <a href="<%= story.ghost_url %>">Ghostarchive</a>
-      </div>
-    <% end %>
   </div>
 </div>
 <a href="<%= Routes.title_path story %>" class="mobile_comments <%= story.comments_count == 0 ? "zero" : "" %>" style="display: none;">

--- a/app/views/stories/_singledetail.html.erb
+++ b/app/views/stories/_singledetail.html.erb
@@ -118,8 +118,14 @@ classes = [
         <% else %>
           <% if ms.url.present? && (!ms.is_gone? || @user.try(:is_moderator?))  %>
             <%= divider_tag %>
-            <label for="caches_<%= ms.short_id %>" class="caches" tabindex="0">caches</label>
-          <% end %>
+            <details class="caches" name="caches">
+              <summary>caches</summary>
+                <ul>
+                  <li><a href="<%= ms.archiveorg_url %>">Archive.org</a></li>
+                  <li><a href="<%= ms.ghost_url %>">Ghostarchive</a></li>
+                </ul>
+            </details>
+        <% end %>
 
           <span class="comments_label">
             <%= divider_tag %>
@@ -132,15 +138,7 @@ classes = [
           <% if ((@user&.is_moderator? && ms.flags > 0) || (ms.flags >= 3 || ms.score <= 0)) %>
             <span> <%= divider_tag %><%= ms.vote_summary_for(@user).downcase %> </span>
           <% end %>
-        <% end %>
       </div>
-      <% if ms.url.present? && (!ms.is_gone? || @user.try(:is_moderator?)) %>
-        <input id="caches_<%= ms.short_id %>" class="caches_button" type="checkbox">
-        <div class="caches-dropdown">
-          <a href="<%= ms.archiveorg_url %>">Archive.org</a>
-          <%= divider_tag %>
-          <a href="<%= ms.ghost_url %>">Ghostarchive</a>
-        </div>
       <% end %>
     </div>
   <% end %>

--- a/app/views/stories/show.html.erb
+++ b/app/views/stories/show.html.erb
@@ -102,7 +102,13 @@
 
                 <% if ms.url.present? && (!ms.is_gone? || @user.try(:is_moderator?)) %>
                   <%= divider_tag %>
-                  <label for="caches_<%= ms.short_id %>" class="caches" tabindex="0">caches</label>
+                  <details class="caches" name="caches">
+                    <summary>caches</summary>
+                    <ul>
+                      <li><a href="<%= ms.archiveorg_url %>">Archive.org</a></li>
+                      <li><a href="<%= ms.ghost_url %>">Ghostarchive</a></li>
+                    </ul>
+                  </details>
                 <% end %>
 
                 <%= divider_tag %>
@@ -114,14 +120,6 @@
                   <% end %>
                 </span>
               </span>
-              <% if ms.url.present? && (!ms.is_gone? || @user.try(:is_moderator?)) %>
-                <input id="caches_<%= ms.short_id %>" class="caches_button" type="checkbox">
-                <div class="caches-dropdown">
-                  <a href="<%= ms.archiveorg_url %>">Archive.org</a>
-                  <%= divider_tag %>
-                  <a href="<%= ms.ghost_url %>">Ghostarchive</a>
-                </div>
-              <% end %>
             </div>
           </div>
         </li>
@@ -157,7 +155,7 @@
 
     <ol class="comments comments1">
       <%# deliberately checking the top-level story, either all have comment forms or none do, less confusing %>
-      <% if @story.accepting_comments? %>
+      <% if ms.accepting_comments? %>
         <li class="comments_subtree"><%= render partial: "comments/commentbox", locals: { comment: ms.comments.build, story: ms } %></li>
       <% end %>
 


### PR DESCRIPTION
Fixes #1972. Refactor the "caches" dropdown to use `<details>` so it can be used with a keyboard.

Use anchor positioning so it won't overflow outside of viewport.

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
