### PR TITLE
fix pagination on Upvoted Comments page

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -298,6 +298,8 @@ class CommentsController < ApplicationController
       .limit(COMMENTS_PER_PAGE)
       .offset((@page - 1) * COMMENTS_PER_PAGE)
 
+    @has_more = true # don't bother querying for the number of comments here
+
     @comments = CommentVoteHydrator.new(@comments, @user)
 
     @last_read_timestamp = if params[:last_read_timestamp]
@@ -345,12 +347,16 @@ class CommentsController < ApplicationController
       raise ActionController::RoutingError.new("page out of bounds")
     end
 
-    @comments = Comment.accessible_to_user(@user)
+    comment_query = Comment.accessible_to_user(@user)
       .where.not(user_id: @user.id)
       .order(id: :desc)
       .includes(:user, :hat, story: :user)
       .joins(:votes).where(votes: {user_id: @user.id, vote: 1})
       .joins(:story).where.not(stories: {is_deleted: true})
+
+    @has_more = comment_query.count > (@page * COMMENTS_PER_PAGE)
+
+    @comments = comment_query
       .limit(COMMENTS_PER_PAGE)
       .offset((@page - 1) * COMMENTS_PER_PAGE)
 

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -23,9 +23,12 @@
       <%= link_to raw("Page #{@page - 1}"), { controller: controller_name, action: action_name, page: @page - 1 }.merge(@next_page_params || {}), rel: "prev" %>
     <% end %>
 
-    <% if @page && @page > 1 %>
-      <%= divider_tag %>
+    <% if @has_more %>
+      <% if @page && @page > 1 %>
+        <%= divider_tag %>
+      <% end %>
+
+      <%= link_to raw("Page #{@page + 1}"), { controller: controller_name, action: action_name, page: @page + 1 }.merge(@next_page_params || {}), rel: "next" %>
     <% end %>
-    <%= link_to raw("Page #{@page + 1}"), { controller: controller_name, action: action_name, page: @page + 1 }.merge(@next_page_params || {}), rel: "next" %>
   <% end %>
 </nav>


### PR DESCRIPTION
This just fixes the bug reported in #1840 by adding another database query to get the number of upvoted comments, and then using that to decide whether to show the next page button.  I have not cleaned up pagination in general.

While looking into this, I noticed that the main /comments page also has the same bug.  However, seeing as I have to go past the end of all the comments to see this issue with pagination (for me on the main lobste.rs website, this was page 32387), I think it is rare for people to run into the bug on /comments. I didn't fix this case, wasn't sure if we'd want to add a query that counts all the comments.