### PR TITLE
Fix upvote hover state sticking on mobile touch devices

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -509,11 +509,17 @@ div.voters {
 	font-size: 1.2rem;
 	font-family: system-ui, monospace, sans-serif;
 }
-.upvoter:hover:before,
 .upvoted .upvoter:before {
 	content: "\25b2";
 	color: var(--color-fg-accent);
 	-webkit-text-stroke: 1px var(--color-fg-accent);
+}
+@media (hover: hover) {
+	.upvoter:hover:before {
+		content: "\25b2";
+		color: var(--color-fg-accent);
+		-webkit-text-stroke: 1px var(--color-fg-accent);
+	}
 }
 .upvoter {
 	color: var(--color-fg-contrast-4-5);


### PR DESCRIPTION
## Summary

On mobile, the upvote arrow would turn red when touched during scrolling and stay that way until tapping elsewhere on the page. This happened even when not logged in.

## Changes

Wrapped the `.upvoter:hover:before` rule in `@media(hover: hover)` so it only fires on devices with a true hover-capable pointer (mouse, trackpad). Touch-only devices skip the hover effect entirely.

The `.upvoted .upvoter:before` rule stays outside the media query so the arrow still turns red when you actually upvote something.

## Why `@media(hover: hover)` and not `:focus` fixes

Both #1951 and #1911 describe the same root issue. The problem is that mobile browsers fire `:hover` on tap and it persists ("sticky hover") until the user taps something else. `@media(hover: hover)` is the standard CSS solution for this, supported in all modern browsers including mobile Safari and Chrome for Android.

Fixes #1951
Fixes #1911

This contribution was developed with AI assistance (Claude Code).