### PR TITLE
Automatic release tag for GitHub or Codeberg releases

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -773,6 +773,7 @@ document.addEventListener("DOMContentLoaded", () => {
       "\.pdf($|\\?|#)": "pdf",
       "[\/\.](asciinema\.org|(youtube|vimeo)\.com|youtu\.be|twitch\.tv|media\.ccc\.de)\/": "video",
       "\.(mp4|avi|mkv|webm)($|\\?|#)": "video",
+      "(https:\/\/(github\.com|codeberg\.org)\/[^\/]+\/[^\/]+\/releases)": "release",
       "[\/\.](slideshare\.net|speakerdeck\.com)\/": "slides",
       "[\/\.](soundcloud\.com)\/": "audio",
       "\.(mp3|wav|ogg|flac)($|\\?|#)": "audio",


### PR DESCRIPTION
I've recently been seeing more and more github.com/<...>/<...>/releases links not getting tagged with the release tag.

I'm proposing this change to bring attention to users to use the release tag.