### PR TITLE
fix: replace dependent: :destroy with restrict_with_exception in Stor…

### DIFF
--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -17,7 +17,7 @@ class Story < ApplicationRecord
     dependent: :nullify
   has_many :taggings,
     autosave: true,
-    dependent: :destroy # tests fail if :restrict_with_exception
+    dependent: :restrict_with_exception
   has_many :suggested_taggings, dependent: :restrict_with_exception
   has_many :suggested_tags, source: :story, through: :suggested_taggings, dependent: :restrict_with_exception
   has_many :suggested_titles, dependent: :restrict_with_exception
@@ -35,7 +35,7 @@ class Story < ApplicationRecord
   has_many :tags, -> { order("tags.is_media desc, tags.tag") }, through: :taggings
   has_many :votes, -> { where(comment_id: nil) },
     inverse_of: :story,
-    dependent: :destroy # tests fail if :restrict_with_exception
+    dependent: :restrict_with_exception
   has_many :voters, -> { where("votes.comment_id" => nil) },
     through: :votes,
     source: :user
@@ -44,7 +44,7 @@ class Story < ApplicationRecord
   has_one :story_text, foreign_key: :id, dependent: :restrict_with_exception, inverse_of: :story
   has_many :links,
     inverse_of: :from_story,
-    dependent: :destroy # tests fail if :restrict_with_exception
+    dependent: :restrict_with_exception
   has_many :incoming_links,
     class_name: "Link",
     inverse_of: :to_story,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,7 +43,7 @@ class User < ApplicationRecord
   has_one :moderation,
     inverse_of: :user,
     dependent: :restrict_with_exception
-  has_many :usernames, dependent: :destroy # tests fail if :restrict_with_exception
+  has_many :usernames, dependent: :restrict_with_exception
   has_many :votes, dependent: :restrict_with_exception
   has_many :voted_stories, -> { where("votes.comment_id" => nil) },
     through: :votes,

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -58,8 +58,20 @@ describe Search do
 
   after(:all) do
     @comments.each(&:destroy!)
-    @stories.flat_map(&:votes).each(&:destroy!)
+    @stories.each { |s|
+      s.taggings.destroy_all
+      s.votes.destroy_all
+      s.links.destroy_all
+      s.suggested_taggings.destroy_all
+      s.suggested_titles.destroy_all
+      s.hidings.destroy_all
+      s.savings.destroy_all
+      s.read_ribbons.destroy_all
+      s.saved_stories.destroy_all
+    }
     @stories.each(&:destroy!)
+    @alice&.usernames&.destroy_all
+    @bob&.usernames&.destroy_all
     @alice&.destroy!
     @bob&.destroy!
   end


### PR DESCRIPTION
## Summary
Follow-up to #1914. Fixes #1929.

## Problem
Four `dependent: :destroy` associations remained after the previous
cleanup:
- `Story`: taggings, votes, links
- `User`: usernames

These silent cascade deletions are a data integrity risk — destroying
a parent record would silently wipe related data without any warning.

## Fix
Changed all four to `dependent: :restrict_with_exception`:

```ruby
# Story model (3 occurrences)
# Before
dependent: :destroy # tests fail if :restrict_with_exception
# After
dependent: :restrict_with_exception

# User model (1 occurrence)
# Before
has_many :usernames, dependent: :destroy # tests fail if :restrict_with_exception
# After
has_many :usernames, dependent: :restrict_with_exception
```

## Test Fixes
The `after(:all)` hook in `spec/models/search_spec.rb` was calling
`story.destroy!` without first cleaning up restricted associations.
Fixed by explicitly destroying all dependent records before destroying
the story, and clearing usernames before destroying users.

## Results
148 examples, 0 failures across all affected spec files.

## Notes
The original comments said "tests fail if :restrict_with_exception" —
those failures were in the test cleanup hooks, not in the actual
application logic. The fix required updating the test teardown to
properly clean up associations before destroying parent records.