### PR TITLE
fix comment counters on inline replies (#1977)

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -344,7 +344,41 @@ export class _LobstersFunction {
           } else {
             comments.insertAdjacentHTML("afterbegin", text)
           }
+          // Update comment counters
+          const newCommentEl = qS(comments, '[data-story-short-id]')
 
+          if (newCommentEl) {
+            const storyShortId = newCommentEl.getAttribute('data-story-short-id')
+            const newCount = newCommentEl.getAttribute('data-new-comment-count')
+            const countLabel = parseInt(newCount) === 1 ? 'comment' : 'comments'
+            
+            // Update byline counter
+            const commentsLabels = qSA('.comments_label')
+            for (const label of commentsLabels) {
+              if (parseInt(newCount) === 0) {
+                label.textContent = 'no comments'
+              } else {
+                label.textContent = newCount + ' ' + countLabel
+              }
+            }
+            
+            // Update thread summary counter
+            const threadSummaries = qSA('.thread_summary')
+            for (const summary of threadSummaries) {
+              const text = summary.textContent
+              if (text.includes('comment')) {
+                if (parseInt(newCount) === 0) {
+                  summary.textContent = 'no comments,' + text.substring(text.indexOf(','))
+                } else {
+                  summary.textContent = newCount + ' ' + countLabel + ',' + text.substring(text.indexOf(','))
+                }
+              }
+            }
+            
+            // Remove the data attributes after processing
+            newCommentEl.removeAttribute('data-story-short-id')
+            newCommentEl.removeAttribute('data-new-comment-count')
+          }
         })
       })
   }

--- a/app/views/comments/_postedreply.html.erb
+++ b/app/views/comments/_postedreply.html.erb
@@ -1,5 +1,6 @@
-<%# locals: (comment:, show_tree_lines: true) -%>
-<li class="comments_subtree">
+<%# locals: (comment:, story: nil, show_tree_lines: true) -%>
+<% story ||= comment.story %>
+<li class="comments_subtree" data-story-short-id="<%= story.short_id %>" data-new-comment-count="<%= story.comments_count %>">
   <%= render "comments/comment", :comment => comment, :show_tree_lines => show_tree_lines %>
   <ol class="comments"></ol>
 </li>


### PR DESCRIPTION
When posting a comment the comment counters were not updated until the page was refreshed. Added changes to postedreply.html.erb partial to pass the short-id and comment count, and updated application.js to use these attributes to update the comment counters.

