### PR TITLE
fix: apply tag filters and hidden stories to top feed

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -306,7 +306,7 @@ class HomeController < ApplicationController
     end
 
     @stories, @show_more = get_from_cache(top: true, length: length) {
-      paginate Story.top(@user, length)
+      paginate Story.top(@user, length, filtered_tags.map(&:id))
     }
 
     @title = if length[:dur] > 1

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -99,10 +99,11 @@ class Story < ApplicationRecord
       .order(created_at: :desc)
   }
 
-  scope :top, ->(user, length) {
+  scope :top, ->(user, length, exclude_tags = nil) {
     raise ArgumentError, "Invalid interval" unless IntervalHelper::TIME_INTERVALS.value?(length[:intv].capitalize)
 
-    top = base(user)
+    top = base(user).not_hidden_by(user)
+      .filter_tags(exclude_tags || [])
       .where("created_at >= (NOW() - INTERVAL ? #{length[:intv].upcase})", length[:dur])
     top.order(score: :desc)
   }


### PR DESCRIPTION
The `/top/` feed pages do not respect user-configured tag filters or hidden stories. The home, newest, active, and recent feeds all pass `filtered_tags.map(&:id)` through their Story scope, but the `top` scope was missing both `.not_hidden_by(user)` and `.filter_tags(exclude_tags)`.

Two changes:
- `Story.top` scope: add `exclude_tags` parameter, apply `.not_hidden_by(user).filter_tags(exclude_tags || [])` before the date range filter, matching the pattern in `hottest`, `recent`, and `active`.
- `HomeController#top`: pass `filtered_tags.map(&:id)` as the third argument.

Closes #1999