### PR TITLE
Prevent vote counts from wrapping

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -518,7 +518,9 @@ div.voters {
 	flex-direction: column;
 	align-items: center;
 	justify-self: center;
+	min-width: 3ch;
 	text-decoration: none;
+	white-space: nowrap;
 }
 .upvoter:focus { outline: none; } /* don't outline after upvote click */
 .upvoter:focus-visible { outline: 2px solid var(--color-fg-link); } /* do outline when tabbing */


### PR DESCRIPTION
## Summary
- Prevent vote counts from wrapping inside the upvote control by giving the score area a three-digit minimum width and disabling whitespace wrapping.

Fixes #1989

## Testing
- `ruby -e 'css=File.read("app/assets/stylesheets/application.css"); abort "missing nowrap" unless css.include?("white-space: nowrap;"); abort "missing min-width" unless css.include?("min-width: 3ch;"); puts "CSS vote count rules present"'`
