### PR TITLE
Fix filtering the modlog to all moderator actions

### DIFF
--- a/app/controllers/moderations_controller.rb
+++ b/app/controllers/moderations_controller.rb
@@ -35,7 +35,7 @@ class ModerationsController < ApplicationController
     when "(All)"
       @moderations
     when "(Moderators)"
-      @moderations.joins(:moderator).where(moderator_user_id: @moderators)
+      @moderations.where.not(moderator_user_id: nil)
     when "(Users)"
       @moderations.where(is_from_suggestions: true)
     else

--- a/spec/requests/moderations_spec.rb
+++ b/spec/requests/moderations_spec.rb
@@ -32,6 +32,60 @@ RSpec.describe "moderations", type: :request do
       end
     end
 
+    context "when filtering entries by moderator" do
+      let!(:story) { create(:story) }
+      let!(:moderator1) { create(:user, :moderator, username: "alice") }
+      let!(:moderator2) { create(:user, :moderator, username: "bob") }
+      let!(:moderation1) { Moderation.create!(story: story, action: "Alice Moderation", moderator: moderator1) }
+      let!(:moderation2) { Moderation.create!(story: story, action: "Bob Moderation", moderator: moderator2) }
+      let!(:moderation3) { Moderation.create!(story: story, action: "Changed tags", is_from_suggestions: true) }
+
+      it "shows all by default" do
+        get "/moderations"
+
+        expect(response).to be_successful
+        expect(response.body).to include("Alice Moderation")
+        expect(response.body).to include("Bob Moderation")
+        expect(response.body).to include("Changed tags")
+      end
+
+      it "shows all when selected" do
+        get "/moderations", params: {moderator: "(All)"}
+
+        expect(response).to be_successful
+        expect(response.body).to include("Alice Moderation")
+        expect(response.body).to include("Bob Moderation")
+        expect(response.body).to include("Changed tags")
+      end
+
+      it "shows all moderator actions when selected" do
+        get "/moderations", params: {moderator: "(Moderators)"}
+
+        expect(response).to be_successful
+        expect(response.body).to include("Alice Moderation")
+        expect(response.body).to include("Bob Moderation")
+        expect(response.body).to_not include("Changed tags")
+      end
+
+      it "shows moderator actions when selected" do
+        get "/moderations", params: {moderator: "alice"}
+
+        expect(response).to be_successful
+        expect(response.body).to include("Alice Moderation")
+        expect(response.body).to_not include("Bob Moderation")
+        expect(response.body).to_not include("Changed tags")
+      end
+
+      it "shows user actions when selected" do
+        get "/moderations", params: {moderator: "(Users)"}
+
+        expect(response).to be_successful
+        expect(response.body).to_not include("Alice Moderation")
+        expect(response.body).to_not include("Bob Moderation")
+        expect(response.body).to include("Changed tags")
+      end
+    end
+
     context "when filtering entries by type" do
       let(:story) { create :story, title: "How to 10x your pipeline with this one weird trick" }
 


### PR DESCRIPTION
Previously we were comparing moderator user IDs with usernames. Instead, we can match moderations with a non-null moderator.

This commit also adds tests for filtering the modlog by moderator.

Closes #1906

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
