### PR TITLE
clean up merged story view

### DIFF
--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -296,7 +296,8 @@ class Story < ApplicationRecord
   def accepting_comments?
     !is_gone? &&
       !previewing &&
-      (new_record? || created_at.after?(COMMENTABLE_DAYS.days.ago))
+      (new_record? || created_at.after?(COMMENTABLE_DAYS.days.ago)) &&
+      !merged_story_id
   end
 
   def already_posted_recently?

--- a/app/views/stories/_singledetail.html.erb
+++ b/app/views/stories/_singledetail.html.erb
@@ -129,6 +129,7 @@ classes = [
             </details>
         <% end %>
 
+        <% if ms == merged_stories.first %>
           <span class="comments_label">
             <%= divider_tag %>
             <a role="heading" aria-level="2" href="<%= Routes.title_path(merged_stories.first, anchor: ms.comments_anchor) %>">
@@ -136,6 +137,7 @@ classes = [
               <%= 'comment'.pluralize(ms.comments_count) %>
             </a>
           </span>
+        <% end %>
 
           <% if ((@user&.is_moderator? && ms.flags > 0) || (ms.flags >= 3 || ms.score <= 0)) %>
             <span> <%= divider_tag %><%= ms.vote_summary_for(@user).downcase %> </span>
@@ -148,14 +150,6 @@ classes = [
   <% if merged_stories.count > 1 %>
     <div class="details byline">
       <span class="merge"><%= merged_stories.count %> merged</span>
-
-      <% if !merged_stories.first.is_gone? || @user&.is_moderator? %>
-        <span class="comments_label">
-          <%= divider_tag %>
-          <% cc = merged_stories.map(&:comments_count).sum %>
-          <%= (cc == 0) ? "no" : "total: #{cc}" %> <%= 'comment'.pluralize(cc) %>
-        </span>
-      <% end %>
     </div>
   <% end %>
 

--- a/app/views/stories/show.html.erb
+++ b/app/views/stories/show.html.erb
@@ -79,81 +79,6 @@
 
 <% if !@story.previewing %>
   <% @merged_stories.select { it.can_be_seen_by_user?(@user) }.each do |ms| %>
-    <% if @story.stories_count > 0 %>
-      <ol class="stories">
-        <li class="story">
-          <div class="story_liner h-entry">
-            <div class="voters">
-              <span class="merge"></span>
-            </div>
-            <div class="details" id="<%= ms.comments_anchor %>">
-              <span role="heading" aria-level="2" class="link h-cite u-repost-of">
-                <% if ms.can_be_seen_by_user?(@user) %>
-                  <a class="u-url" href="<%= Routes.url_or_comments_path(ms) %>" rel="ugc <%= ms.send_referrer? ? '' : 'noreferrer' %>"><%= ms.title %></a>
-                <% end %>
-                <% if ms.is_gone? %>
-                  [Story removed by <%= ms.is_moderated? ? "moderator" : "submitter" %>]
-                <% end %>
-              </span>
-
-              <span class="byline">
-                <span>&nbsp;</span>
-                <%= inline_avatar_for @user, ms.user %>
-                <%= styled_user_link ms.user, ms, class: ['u-author', 'h-card'] %> <%= you_invited you: @user, user: ms.user %>
-
-                <% if ms.url.present? && (!ms.is_gone? || @user.try(:is_moderator?)) %>
-                  <%= divider_tag %>
-                  <details class="caches" name="caches">
-                    <summary>caches</summary>
-                    <ul>
-                      <li><a href="<%= ms.archiveorg_url %>">Archive.org</a></li>
-                      <li><a href="<%= ms.ghost_url %>">Ghostarchive</a></li>
-                    </ul>
-                  </details>
-                <% end %>
-
-                <%= divider_tag %>
-                <span class="comments_label">
-                  <% if ms.comments_count == 0 %>
-                    no comments
-                  <% else %>
-                    <%= ms.comments_count %> <%= 'comment'.pluralize(ms.comments_count) %>
-                  <% end %>
-                </span>
-              </span>
-            </div>
-          </div>
-        </li>
-      </ol>
-
-      <div class="story_content">
-        <% if ms.markeddown_description.present? %>
-          <div class="story_text">
-          <%= raw ms.markeddown_description %>
-          </div>
-        <% end %>
-
-        <% if ms.is_unavailable %>
-          <% StoryText.cached?(ms) do |text| %>
-            <details>
-              <summary>Source URL considered unavailable as of <%= how_long_ago_label(ms.unavailable_at) %>, click for cached text - also see archive links above</summary>
-
-              <p>
-              <em>All story content copyright of its respective owner.</em>
-              </p>
-
-              <div class="story_text">
-                <blockquote>
-                  <%= simple_format(text) %>
-                </blockquote>
-              </div>
-            </details>
-
-          <% end %>
-        <% end %>
-      </div>
-    <% end %>
-
     <ol class="comments comments1">
       <%# deliberately checking the top-level story, either all have comment forms or none do, less confusing %>
       <% if ms.accepting_comments? %>
@@ -161,9 +86,9 @@
       <% end %>
 
       <li class="comments_subtree" id="story_comments">
-        <% if @user && @comments.size > 0 %>
+        <% if @user && @comments.size > 0 && ms == @merged_stories.first %>
           <div class="thread_summary">
-            <%= pluralize(@comments.select { it.story_id == ms.id }.size, "comment") %>,
+            <%= pluralize(ms.comments_count, "comment") %>,
             <% unread = @ribbon.unread_count(@comments.select { it.story_id == ms.id }) %>
             <% if @ribbon.new_record? %>
               all unread

--- a/spec/features/comment_spec.rb
+++ b/spec/features/comment_spec.rb
@@ -140,8 +140,10 @@ RSpec.feature "Commenting" do
 
     it "redirects /c/shortid to merged stories with anchor" do
       parent = create(:story, title: "parent")
-      merged = create(:story, merged_into_story: parent, title: "merged")
+      merged = create(:story, title: "merged")
       comment = create(:comment, story: merged)
+      merged.merged_into_story = parent
+      merged.save!
 
       visit "/c/#{comment.short_id}"
       expect(current_url).to eq("http://www.example.com/s/#{parent.short_id}/parent#c_#{comment.short_id}")

--- a/spec/features/read_story_spec.rb
+++ b/spec/features/read_story_spec.rb
@@ -54,8 +54,13 @@ RSpec.feature "Reading Stories", type: :feature do
     end
 
     it "shows comments from merged story" do
+      merged.merged_into_story = nil
+      merged.save!
+
       merged_comment = create(:comment, story: merged)
       merged_reply = create(:comment, story: merged, parent_comment: merged_comment)
+      merged.merged_into_story = story
+      merged.save!
       visit Routes.title_path story
 
       expect(page).to have_content(merged_comment.comment)

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -430,22 +430,6 @@ describe Story do
     end
   end
 
-  describe "#update_cached_columns" do
-    context "with a merged_into_story" do
-      let(:merged_into_story) { create(:story) }
-      let(:story) { create(:story, merged_into_story: merged_into_story) }
-
-      it "should also update the merged_into_story's comment count" do
-        expect(story.comments_count).to eq 0
-        expect(merged_into_story.comments_count).to eq 0
-        create(:comment, story: story)
-        story.update_cached_columns
-        expect(story.comments_count).to eq 1
-        expect(merged_into_story.comments_count).to eq 1
-      end
-    end
-  end
-
   describe "#already_posted_recently?" do
     it "returns true when trying to submit a URL that's been submitted w/o an anchor in it" do
       create(:story, url: "https://www.example.com/article.html")


### PR DESCRIPTION
This UI is a total shit show but this at least removes the confusing multiple text boxes for input.

The first commit removes the duplicate text boxes.

The second commit is probably optional but the comment counts were wrong since merging a story adds the child story's `comments_count` to the parent, so there should probably just be one 'n comments' at the top and hide all the others.  This also removes the duplicate story headings which clutter up the UI and flattens all of the story threads.  If that confuses users as to which story the comments were made on, that's probably a good indication the stories shouldn't have been merged in the first place because they're not similar enough, but whatever.

before:

<img width="2101" height="1840" alt="before" src="https://github.com/user-attachments/assets/84faf978-d12f-465e-b863-5bf302f2abb4" />

after:

<img width="2101" height="1306" alt="after" src="https://github.com/user-attachments/assets/617aacbe-2880-406b-9dd1-cac54900050e" />

