### PR TITLE
minor typo fixes in updated flag definitions

### DIFF
--- a/app/views/about/about.html.erb
+++ b/app/views/about/about.html.erb
@@ -187,7 +187,7 @@
           For stories, these are:
   
           <ul>
-              <li><b>Off-topic</b> which should be used when stores which do meet the site's definition of <a href="#topicality">topicality</a>.</li>
+              <li><b>Off-topic</b> which should be used when stories do not meet the site's definition of <a href="#topicality">topicality</a>.</li>
               <li><b>Already Posted</b> which should be used when there is a duplicate submission on the same topic or submissions which elaborate on another submission that is less than a week old (see <a href="#merging">merging</a>).</li>
               <li><b>Broken Link</b> which should be used for links that present a <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status">client or server error response</a> or present a "paywall" which requires registration or payment to pass.</li>
               <li><b>Spam</b> which should be used for content that either is designed to promote a commercial service or for content that is created without meaningful human authorship.</li>

--- a/app/views/about/about.html.erb
+++ b/app/views/about/about.html.erb
@@ -178,14 +178,14 @@
           Users can flag stories and comments when there is a problem that needs moderator attention.
           If a story or comment is flagged at least twice, it is added to the moderation review queue.
           Note that, at any time users can always <a href="/moderators">contact a moderator</a> about issues they perceive surrounding content on the site.
-  
+
           To guide usage and head off distracting meta-conversations ("Why was this flagged!?", etc), flagging requires selecting from a preset list of reasons.
           Users must reach <%= User::MIN_KARMA_TO_FLAG %> karma to flag.
       </p>
-  
+
       <p>
           For stories, these are:
-  
+
           <ul>
               <li><b>Off-topic</b> which should be used when stories do not meet the site's definition of <a href="#topicality">topicality</a>.</li>
               <li><b>Already Posted</b> which should be used when there is a duplicate submission on the same topic or submissions which elaborate on another submission that is less than a week old (see <a href="#merging">merging</a>).</li>
@@ -193,10 +193,10 @@
               <li><b>Spam</b> which should be used for content that either is designed to promote a commercial service or for content that is created without meaningful human authorship.</li>
           </ul>
       </p>
-  
+
       <p>
           For comments, these are:
-  
+
           <ul>
               <li><b>Off-topic</b> which should be used when a comment is drifting into meta or topics that aren't related to the story.</li>
               <li><b>Me-too</b> which should be used when a comment doesn't add new information, typically a single sentence of appreciation, agreement, or humor.</li>


### PR DESCRIPTION
I noticed a couple typos in the updated flag definitions from #2020, so here's a patch. second commit is just removing some whitespace that my editor was complaining about while making the typo fixes. 

very much appreciate the work y'all continue to put in behind the scenes :)
