### PR TITLE
Make comments number a link to comments list

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -585,6 +585,11 @@ supports it:  https://caniuse.com/?search=%3Ahas
 	border-radius: 8px;
 }
 
+.comments_subtree:target {
+	background: transparent;
+	border-radius: 0;
+}
+
 .showing-user-comment {
 	background-color: var(--color-bg-target);
 	border-radius: 8px;

--- a/app/views/comments/_threads.html.erb
+++ b/app/views/comments/_threads.html.erb
@@ -2,7 +2,7 @@
 <% previous_depth = nil %>
 <% top_comment_depth = nil %>
 <%# open list of threads %>
-<ol class="comments">
+<ol class="comments" id="story_comments">
 <% thread.each do |comment| %>
 
     <% if previous_depth %>

--- a/app/views/stories/_singledetail.html.erb
+++ b/app/views/stories/_singledetail.html.erb
@@ -131,7 +131,7 @@ classes = [
 
           <span class="comments_label">
             <%= divider_tag %>
-            <a role="heading" aria-level="2" href="<%= Routes.title_path(merged_stories.first, anchor: ms.comments_anchor) %>">
+            <a role="heading" aria-level="2" href="<%= merged_stories.count > 1 ? Routes.title_path(merged_stories.first, anchor: ms.comments_anchor) : "#comments-#{merged_stories.first.short_id}" %>">
               <%= ms.comments_count.zero? ? "no" : ms.comments_count %>
               <%= 'comment'.pluralize(ms.comments_count) %>
             </a>

--- a/app/views/stories/show.html.erb
+++ b/app/views/stories/show.html.erb
@@ -113,13 +113,13 @@
                 <% end %>
 
                 <%= divider_tag %>
-                <span class="comments_label">
+                <a href="#comments-<%= ms.short_id %>">
                   <% if ms.comments_count == 0 %>
                     no comments
                   <% else %>
                     <%= ms.comments_count %> <%= 'comment'.pluralize(ms.comments_count) %>
                   <% end %>
-                </span>
+                </a>
               </span>
             </div>
           </div>
@@ -160,7 +160,7 @@
         <li class="comments_subtree"><%= render partial: "comments/commentbox", locals: { comment: ms.comments.build, story: ms } %></li>
       <% end %>
 
-      <li class="comments_subtree" id="story_comments">
+      <li class="comments_subtree" id="<%= "comments-#{ms.short_id}" %>">
         <% if @user && @comments.size > 0 %>
           <div class="thread_summary">
             <%= pluralize(@comments.select { it.story_id == ms.id }.size, "comment") %>,


### PR DESCRIPTION
Make the "# comments" link in the "by line" point to the list of comments. For merged stories, the links at the list of entries at the start of the page still point to each individual story, and each individual story gets a link to its own comments.

Fixes #2011

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
