### PR TITLE
Serve JPG avatars with the right mime type

### DIFF
--- a/app/controllers/avatars_controller.rb
+++ b/app/controllers/avatars_controller.rb
@@ -24,6 +24,10 @@ class AvatarsController < ApplicationController
     redirect_to "/settings"
   end
 
+  def content_type_for(data)
+    data.start_with?("\xFF\xD8\xFF".b) ? "image/jpeg" : "image/png"
+  end
+
   def show
     username, size = params[:username_size].to_s.scan(/\A(.+)-(\d+)\z/).first
     size = size.to_i
@@ -55,6 +59,6 @@ class AvatarsController < ApplicationController
     File.rename("#{CACHE_DIR}/.#{u.username}-#{size}.png", "#{CACHE_DIR}/#{u.username}-#{size}.png")
 
     response.headers["Expires"] = 1.hour.from_now.httpdate
-    send_data av, type: "image/png", disposition: "inline"
+    send_data av, type: content_type_for(av), disposition: "inline"
   end
 end


### PR DESCRIPTION
Even though all avatars are saved with the `.png` extension, check its magic bytes to see if it's actually a JPG image. If so, serve with the right mime type.

Fixes #2009

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
