### PR TITLE
Add badge next to comment author is user is submitter/author

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -542,6 +542,12 @@ ol.stories li.story div.story_liner {
 	color: var(--color-fg-contrast-7-5);
 }
 
+.comment .user_is_submitter::after {
+	content: " [OP]"/"";
+	font-size: var(--font-size-tags);
+	vertical-align: top;
+}
+
 ol.stories li:first-child div.story_liner {
 	padding-top: 0.5em;
 }

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -36,7 +36,7 @@ module UsersHelper
     end
   end
 
-  def styled_user_link user, content = nil, html_options = {}
+  def styled_user_link user, content = nil, parent = nil, html_options = {}
     html_options[:class] ||= []
     if content.is_a?(Story) && content.user_is_author?
       html_options[:class].push "user_is_author"
@@ -44,6 +44,11 @@ module UsersHelper
     if content.is_a?(Comment) && content.story&.user_is_author? && content.story.user_id == user.id
       html_options[:class].push "user_is_author"
       html_options[:aria] = {label: "#{user.username} - Author"}
+    end
+
+    if content.is_a?(Comment) && content.story&.user_id == user.id
+      html_options[:class].push "user_is_submitter"
+      html_options[:aria] = {label: "#{user.username} - Submitter"}
     end
 
     if !user.is_active?


### PR DESCRIPTION
Add a small "[OP]" next to user name in those comment where the user is the one who submitted the original story.

Fixes #1997

<img width="1826" height="285" alt="image" src="https://github.com/user-attachments/assets/a5d60624-a36e-49e3-878e-69d1bf7bd736" />

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
