### PR TITLE
Simplify title length validation reuse

### DIFF
--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -205,7 +205,10 @@ class Story < ApplicationRecord
 
   include Token
 
-  validates :title, length: {in: 3..150}, presence: true
+  TITLE_MIN_LENGTH = 3
+  TITLE_MAX_LENGTH = 150
+
+  validates :title, length: {in: TITLE_MIN_LENGTH..TITLE_MAX_LENGTH}, presence: true
   validates :description, length: {maximum: 65_535}
   validates :url, length: {maximum: 250, allow_nil: true}
   validates :short_id, presence: true, length: {maximum: 6}
@@ -1265,18 +1268,6 @@ class Story < ApplicationRecord
     rescue
       @fetched_attributes
     end
-  end
-
-  def self.title_minimum_length
-    validators_on(:title)
-      .find { |v| v.is_a? ActiveRecord::Validations::LengthValidator }
-      .options[:minimum]
-  end
-
-  def self.title_maximum_length
-    validators_on(:title)
-      .find { |v| v.is_a? ActiveRecord::Validations::LengthValidator }
-      .options[:maximum]
   end
 
   private

--- a/app/views/stories/_form.html.erb
+++ b/app/views/stories/_form.html.erb
@@ -23,7 +23,7 @@
 
   <div class="boxline">
     <%= f.label :title, "Title" %>
-    <%= f.text_field :title, required: true, minlength: Story.title_minimum_length, maxlength: Story.title_maximum_length %>
+    <%= f.text_field :title, required: true, minlength: Story::TITLE_MIN_LENGTH, maxlength: Story::TITLE_MAX_LENGTH %>
     <p class="actions title-reminder">
       Please remove extraneous components from titles such as the name of the site, blog, section, and author.
       <span class="title-reminder-thanks">

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -759,7 +759,7 @@ describe Story do
   end
 
   describe ".title_maximum_length" do
-    subject { Story.title_maximum_length }
+    subject { Story::TITLE_MAX_LENGTH }
 
     it { is_expected.to eq(150) }
   end


### PR DESCRIPTION
Store the lower and upper bounds of the length of the title in constants. Then
use those constants when defining the title length validator in the model; and
the title length validator in the HTML view.

Using a constant as the source truth means we can avoid using reflection to
extract the information from the validator we defined.

I understand that what simpler code is a matter of taste and hence subjective,
so feel free to close the pull request if you prefer the current implementation