### PR TITLE
Add .gitattributes to enforce LF line endings for bin scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+bin/** text eol=lf


### PR DESCRIPTION
Running `docker compose up --build` on Windows fails with:
```
#14 [8/8] RUN bin/setup
#14 0.217 env: ‘ruby\r’: No such file or directory
#14 0.217 env: use -[v]S to pass options in shebang lines
#14 ERROR: process "/bin/sh -c bin/setup" did not complete successfully: exit code: 127
------
 > [8/8] RUN bin/setup:
0.217 env: ‘ruby\r’: No such file or directory
0.217 env: use -[v]S to pass options in shebang lines
------
```

Git on Windows checks out bin/* with CRLF line endings by default (core.autocrlf=true). Linux containers then can't execute the scripts because the shebang becomes '#!/usr/bin/env ruby\r'.

[GitHub Docs](https://docs.github.com/en/get-started/git-basics/configuring-git-to-handle-line-endings#per-repository-settings)
Adding `.gitattributes` with `bin/** text eol=lf` fixes checkout on Windows, it overrides core.autocrlf and matches the `end_of_line = lf` already set in .editorconfig.

Tested on Windows 11: `docker compose up --build` completes after a fresh clone of the changed remote branch.

This is ready to merge.