### PR TITLE
Native validation for category and tags edit/create forms

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -14,9 +14,12 @@ class Category < ApplicationRecord
 
   attr_accessor :edit_user_id
 
-  validates :category, length: {maximum: 25}, presence: true,
+  CATEGORY_FORMAT = /\A[A-Za-z0-9_-]+\z/
+  NAME_MAXLENGTH = 25
+
+  validates :category, length: {maximum: NAME_MAXLENGTH}, presence: true,
     uniqueness: {case_sensitive: false},
-    format: {with: /\A[A-Za-z0-9_-]+\z/}
+    format: {with: CATEGORY_FORMAT}
 
   def to_param
     category

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -20,10 +20,14 @@ class Tag < ApplicationRecord
   attr_accessor :edit_user_id, :stories_count
   attr_writer :filtered_count
 
-  validates :tag, length: {maximum: 25}, presence: true,
+  TAG_FORMAT = /\A[A-Za-z0-9_-]+\z/
+  NAME_MAXLENGTH = 25
+  DESCRIPTION_MAXLENGTH = 100
+
+  validates :tag, length: {maximum: NAME_MAXLENGTH}, presence: true,
     uniqueness: {case_sensitive: true},
-    format: {with: /\A[A-Za-z0-9_\-+]+\z/}
-  validates :description, length: {maximum: 100}
+    format: {with: TAG_FORMAT}
+  validates :description, length: {maximum: DESCRIPTION_MAXLENGTH}
   validates :hotness_mod, inclusion: {in: -10..10}
   validates :permit_by_new_users, :privileged, :active, :is_media,
     inclusion: {in: [true, false]}

--- a/app/views/categories/_form.html.erb
+++ b/app/views/categories/_form.html.erb
@@ -2,7 +2,7 @@
 <%= form_with model: category, url: category.persisted? ? update_category_path : categories_path, method: :post do |f| %>
   <div class="labelled_grid">
     <%= f.label :category, 'Name' %>
-    <%= f.text_field :category, required: true, autocapitalize: :off %>
+    <%= f.text_field :category, required: true, autocapitalize: :off, pattern: Category::CATEGORY_FORMAT.source.gsub(/\\A|\\z/, "").sub("-]", "\\-]"), maxlength: Category::NAME_MAXLENGTH %>
   </div>
 
   <%= f.submit category.persisted? ? 'Update Category' : 'Create Category' %>

--- a/app/views/mod/tags/_form.html.erb
+++ b/app/views/mod/tags/_form.html.erb
@@ -2,13 +2,14 @@
 <%= form_with model: [:mod, tag] do |f| %>
   <div class="labelled_grid">
     <%= f.label :tag, 'Name' %>
-    <%= f.text_field :tag, required: true, autocapitalize: :off %>
+    <%= f.text_field :tag, required: true, autocapitalize: :off, pattern: Tag::TAG_FORMAT.source.gsub(/\\A|\\z/,
+ "").sub("-]", "\\-]"), maxlength: Tag::NAME_MAXLENGTH  %>
 
     <%= f.label :category_name, 'Category' %>
     <%= f.select :category_name, options_for_select(Category.pluck(:category), tag.category_name) %>
 
     <%= f.label :description, 'Description' %>
-    <%= f.text_field :description %>
+    <%= f.text_field :description, maxlength: Tag::DESCRIPTION_MAXLENGTH %>
 
     <%= f.label :permit_by_new_users, 'Permit by new users', :class => "for_checkbox" %>
     <%= f.check_box :permit_by_new_users %>


### PR DESCRIPTION
For the name and description fields in the tag and category edition page, add a browser validation via the same pattern used in the backend.

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
