### PR TITLE
Fix broken comment replies on search results

### DIFF
--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -290,8 +290,10 @@ class="story <%= story.current_upvoted? ? "upvoted" : "" %>
   <% elsif @search.what == :comments %>
     <ol class="comments comments1">
       <% @results.each do |res| %>
-        <li><%= render "comments/comment", :comment => res, :show_story => true %></li>
-      <% end %>
+        <li><%= render "comments/comment", :comment => res, :show_story => true %>
+          <ol class="comments"></ol>
+        </li>
+    <% end %>
     </ol>
   <% end %>
 

--- a/app/views/users/standing.html.erb
+++ b/app/views/users/standing.html.erb
@@ -65,6 +65,8 @@
 
 <ol class="comments comments1">
   <% @flagged_comments.each do |comment| %>
-    <li><%= render "comments/comment", :comment => comment, :show_story => true, force_open: true %></li>
+    <li><%= render "comments/comment", :comment => comment, :show_story => true, force_open: true %>
+      <ol class="comments"></ol>
+    </li>
   <% end %>
 </ol>


### PR DESCRIPTION
Fixes #2027.

The search page was missing the comment container that holds the temporary reply form.