### PR TITLE
Fix title shortword search handling

### DIFF
--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -91,9 +91,15 @@ class Search
   def flatten_title tree
     if tree.keys.first == :term
       ActiveRecord::Base.connection.quote_string(tree.values.first.to_s)
+    elsif tree.keys.first == :shortword
+      ActiveRecord::Base.connection.quote_string(tree.values.first.to_s)
     elsif tree.keys.first == :quoted
       '"' + tree.values.first.map(&:values).flatten.join(" ").gsub("'", "\\\\'") + '"'
     end
+  end
+
+  def title_shortword? tree
+    tree.keys.first == :shortword
   end
 
   # security: must prevent sql injection
@@ -148,6 +154,7 @@ class Search
         tags.or!(Tag.where(tag: value.to_s))
       # TODO unknown tag
       when :title
+        next if title_shortword? value
         title = true
         value = flatten_title value
         query.where!(
@@ -257,6 +264,7 @@ class Search
         tags.or!(Tag.where(tag: value.to_s))
       # TODO unknown tag
       when :title
+        next if title_shortword? value
         title = true
         value = flatten_title value
         query.joins!(:story_text).where!(

--- a/app/models/search_parser.rb
+++ b/app/models/search_parser.rb
@@ -33,7 +33,7 @@ class SearchParser < Parslet::Parser
   rule(:submitter) { str("submitter:") >> match("[@~]").repeat(0, 1) >> match("[A-Za-z0-9_\\-]").repeat(1, 24).as(:submitter) >> space? }
   # reproduce the 'validates :tag, format:' regexp from Tag
   rule(:tag) { str("tag:") >> match("[A-Za-z0-9\\-_+]").repeat(1).as(:tag) >> space? }
-  rule(:title) { str("title:") >> (term | quoted).as(:title) >> space? }
+  rule(:title) { str("title:") >> (term | shortword | quoted).as(:title) >> space? }
   rule(:url) {
     (
       str("http") >> str("s").repeat(0, 1) >> str("://") >>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -59,7 +59,14 @@
           <dd>Tag: <%= link_to value, tag_path(value) %></dd>
         <% when :title %>
           <dt><span class="searchq">title:<%= @search.flatten_title(value) %></span></dt>
-          <dd>Title: <%= @search.flatten_title(value) %></dd>
+          <% if @search.title_shortword?(value) %>
+            <dd>
+              Title shortword: <span class="searchq"><%= @search.flatten_title(value) %></span>
+              <br>Title terms must be at least 3 characters long.
+            </dd>
+          <% else %>
+            <dd>Title: <%= @search.flatten_title(value) %></dd>
+          <% end %>
         <% when :url %>
           <dt><span class="searchq">url:<%= value %></span></dt>
           <dd>URL: <%= value %></dd>

--- a/spec/models/search_parser_spec.rb
+++ b/spec/models/search_parser_spec.rb
@@ -139,6 +139,7 @@ describe SearchParser do
 
   describe "title rule" do
     it("parses single") { expect(sp.title).to parse("title:seven") }
+    it("parses shortwords") { expect(sp.title).to parse("title:xz") }
     it("does parse single word quote") { expect(sp.title).to parse('title:"tips"') }
     it("does parse multi word quote") { expect(sp.title).to parse('title:"for fast tests"') }
     it("doesn't parse multi word") { expect(sp.title).to_not parse("title:in 2023") }
@@ -206,6 +207,10 @@ describe SearchParser do
     it "parses a search that uses a few stopwords" do
       assert SearchParser.new.parse "Notes on structured concurrency, or: Go statement considered harmful"
       assert SearchParser.new.parse "a  Simple Serialization System"
+    end
+
+    it "associates title: with a shortword search" do
+      expect("title:xz").to parse_to [{title: {shortword: "xz"}}]
     end
   end
 end

--- a/spec/models/search_spec.rb
+++ b/spec/models/search_spec.rb
@@ -205,6 +205,13 @@ describe Search do
     expect(search.results.first.title).to eq("unique")
   end
 
+  it "does not issue a title search for short words" do
+    search = Search.new({q: "title:t2", what: "stories"}, @alice)
+
+    expect(search.results).to be_empty
+    expect(search.invalid_because).to eq("No search terms recognized")
+  end
+
   it "can search for stories by title with multiple words" do
     search = Search.new({q: 'title:"term1 t2"', what: "stories"}, @alice)
 


### PR DESCRIPTION
Fixes #1933.

This keeps `title:` queries with short words associated with the title operator instead of falling through into the confusing `:shortword` parse case. When a bare title term is too short for full-text search, the search now treats it as an unrecognized title search instead of issuing a title full-text query, and the parse explanation calls out the minimum title length.

Changes:
- parse `title:xz` as a title shortword
- avoid issuing title full-text searches for bare title shortwords
- show a clearer parse explanation for title shortwords
- add parser and search coverage for the short title case

Validation:
- `git diff --check`
- `docker compose run --rm --no-deps app bundle exec standardrb app/models/search.rb app/models/search_parser.rb spec/models/search_parser_spec.rb spec/models/search_spec.rb`
- `docker compose run --rm app bundle exec rspec spec/models/search_parser_spec.rb spec/models/search_spec.rb` (`109 examples, 0 failures`)