### PR TITLE
Fixes missing underline for Top page in navbar

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -101,8 +101,8 @@ module ApplicationHelper
   # limitation: this can't handle generating links based on a hash of options,
   # like { controller: ..., action: ... }
   def link_to_different_page(text, path, options = {})
-    current = request.path.sub(/\/page\/\d+$/, "")
-    path.sub!(/\/page\/\d+$/, "")
+    current = request.path.sub(/\/page\/\d+$/, "").sub(/\/\d+[dwmy]$/, "")
+    path = path.sub(/\/page\/\d+$/, "").sub(/\/\d+[dwmy]$/, "")
     options[:class] = class_names(options[:class], current_page: current == path)
     if current == path
       options[:aria] ||= {}

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -53,6 +53,30 @@ describe ApplicationHelper do
     end
   end
 
+  describe "link_to_different_page" do
+    def stub_current_path(path)
+      allow(helper).to receive(:request).and_return(double(path: path))
+    end
+
+    it "marks link as current when time suffix" do
+      stub_current_path("/top/1w")
+      result = helper.link_to_different_page("Top", "/top")
+      expect(result).to have_css("a[aria-current='page']")
+    end
+
+    it "marks link as current when page suffix" do
+      stub_current_path("/active/page/2")
+      result = helper.link_to_different_page("Active", "/active")
+      expect(result).to have_css("a[aria-current='page']")
+    end
+
+    it "marks link as current when both page and time suffix" do
+      stub_current_path("/top/2m/page/23")
+      result = helper.link_to_different_page("Top", "/top")
+      expect(result).to have_css("a[aria-current='page']")
+    end
+  end
+
   describe "#page_numbers_for_pagination" do
     it "returns the right number of pages" do
       expect(helper.page_numbers_for_pagination(10, 1))


### PR DESCRIPTION
<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->

Fixes #2049. 

The link_to_different_page function compares the navigation link with the current path and optionally adds the red-underline style. On the Top page the current path defaults to /top/1w, while the nav link is /top/. Fixed by adjusting the regex to optionally account for the time suffix.
