### PR TITLE
Remove alt text for avatars

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,7 +11,8 @@ module ApplicationHelper
       srcset: "#{user.avatar_path(size)} 1x, #{user.avatar_path(size * 2)} 2x",
       class: "avatar",
       size: "#{size}x#{size}",
-      alt: "#{user.username} avatar",
+      # No need for alt since avatars are hidden by aria-hidden.
+      alt: "",
       loading: "lazy",
       decoding: "async"
     )


### PR DESCRIPTION
* Screen reader users can't read it because it's hidden by `aria-hidden`
* Graphical browsers won't show it unless user disables images. And in this case, users get a horribly long text saying "random-user avatar"
* w3m shows the alt text, but it's redundant when the link to the user profile is the next link.
* eww ignores links if they only contain an image. Does not even show alt text!

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
