### PR TITLE
Fix stray collapse checkbox in isolated comment preview

### DIFF
--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -8,11 +8,13 @@
   # is_unread: show (unread) in byline
   # show_folder_control: whether to display the control to hide the comment
 %>
-<input id="comment_folder_<%= comment.short_id %>"
-  class="comment_folder_button" type="checkbox"
-  <%= force_open ||
-      @user.try(:is_moderator?) ||
-      (comment.score > Comment::COLLAPSE_SCORE && !comment.current_flagged?) ? "" : "checked" %>>
+<% if show_folder_control %>
+  <input id="comment_folder_<%= comment.short_id %>"
+    class="comment_folder_button" type="checkbox"
+    <%= force_open ||
+        @user.try(:is_moderator?) ||
+        (comment.score > Comment::COLLAPSE_SCORE && !comment.current_flagged?) ? "" : "checked" %>>
+<% end %>
 
       <% can_flag = @user && @user.can_flag?(comment) %>
 <div id="c_<%= comment.short_id %>"

--- a/app/views/comments/_preview.html.erb
+++ b/app/views/comments/_preview.html.erb
@@ -4,6 +4,7 @@
     <%= render partial: "comment", locals: {
       comment: comment,
       show_tree_lines: show_tree_lines,
+      show_folder_control: false,
     } %>
   <% end %>
 </div>

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -63,6 +63,21 @@ describe "comments", type: :request do
     end
   end
 
+  describe "previewing" do
+    let(:story) { create(:story) }
+
+    before { sign_in user }
+
+    it "doesn't render the collapse checkbox" do
+      post "/comments", params: {
+        story_id: story.short_id, comment: "preview me", preview: "true",
+      }
+      expect(response.status).to eq(200)
+      expect(response.body).to include("preview")
+      expect(response.body).to_not include("comment_folder_button")
+    end
+  end
+
   describe "disowning" do
     let(:inactive_user) { create(:user, :inactive) }
 

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -70,7 +70,7 @@ describe "comments", type: :request do
 
     it "doesn't render the collapse checkbox" do
       post "/comments", params: {
-        story_id: story.short_id, comment: "preview me", preview: "true",
+        story_id: story.short_id, comment: "preview me", preview: "true"
       }
       expect(response.status).to eq(200)
       expect(response.body).to include("preview")


### PR DESCRIPTION
Fixes #2060.

The collapse checkbox `<input>` rendered unconditionally in _comment, but its label is gated by `show_folder_control`. So when a comment is previewed (or shown in the inbox/mod views that pass `show_folder_control: false`) the checkbox appeared with nothing to toggle. This moves the input inside the same guard and has the preview pass `show_folder_control: false`.