### PR TITLE
Hide URL search results for non-logged in users.

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -8,7 +8,8 @@ class SearchController < ApplicationController
     @title = "Search"
 
     @search = Search.new(search_params, @user)
-    if !@user && params[:q].to_s.starts_with?("https://")
+
+    if !@user && @search.parse_tree.any? { |node| node.key?(:url) }
       flash[:error] = "Sorry, you have to log in to search for a URL. We're getting hammered by a spambot with many thousands of IPs. More info at https://github.com/lobsters/lobsters/issues/1814"
       @search.invalid("You have to log in to search for a URL.")
     end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -8,14 +8,12 @@ class SearchController < ApplicationController
     @title = "Search"
 
     @search = Search.new(search_params, @user)
-
     if !@user && params[:q].to_s.starts_with?("https://")
       flash[:error] = "Sorry, you have to log in to search for a URL. We're getting hammered by a spambot with many thousands of IPs. More info at https://github.com/lobsters/lobsters/issues/1814"
-      @results = []
-    else
-      @results = @search.results
+      @search.invalid("You have to log in to search for a URL.")
     end
 
+    @results = @search.results
     if @user && @search.results
       if params[:what] == "stories"
         votes = Vote.story_votes_by_user_for_story_ids_hash(@user.id, @search.results.map(&:id))


### PR DESCRIPTION
<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->

Fixes #2071. 

Two changes:
- Swapped out manual results override with the `invalid` method of `Search`.
- Uses the URL check logic implemented in Search rather than the naive check for "https".