### PR TITLE
Extend CSS validation to include property values

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -529,7 +529,7 @@ li.story {
 ol.stories li.story div.story_liner {
 	padding-top: 0.25em;
 	padding-bottom: 0.25em;
-	word-break: break-word;
+	overflow-wrap: break-word;
 }
 .comment {
 	clear: both;
@@ -1387,7 +1387,7 @@ label:has(+ *[type="hidden"] + *:required)::after {
 .labelled_grid {
 	display: grid;
 	grid-template-columns: minmax(10rem, min-content) 1fr;
-	word-break: break-word;
+	overflow-wrap: break-word;
 	column-gap: 1rem;
 	row-gap: 12px;
 }

--- a/spec/css_widely_available_spec.rb
+++ b/spec/css_widely_available_spec.rb
@@ -14,7 +14,8 @@ ALLOWED_AT_RULES = Set.new(%w[])
 # writing comments, that is the beating heart of the site.
 ALLOWED_PROPERTIES = Set.new(%w[user-select])
 
-ALLOWED_PROPERTY_VALUES = Set.new([])
+# See https://github.com/lobsters/lobsters/pull/2079#issuecomment-4730563102 for reasoning.
+ALLOWED_PROPERTY_VALUES = Set.new([["cursor", "pointer"], ["cursor", "default"], ["user-select", "none"]])
 
 # :has() https://caniuse.com/css-has
 # Unprincipled exception because it solves so many big problems.
@@ -227,7 +228,7 @@ RSpec.describe "CSS" do
 
   WANTED_PROPERTY_VALUES.each do |prop_val|
     it "wanted property_value '#{prop_val[0]}: #{prop_val[1]}' is not yet Baseline widely available" do
-      expect(restricted_values).to include(BaselinePropertyValue.new(property: prop_val[0], value: prop_val[1])),
+      expect(restricted_values).to include(BaselinePropertyValue.new(name: prop_val[0], value: prop_val[1])),
         "Property Value '#{prop_val[0]}: #{prop_val[1]}' is now Baseline widely available! " \
           "See comment in this spec for where we wanted to use it."
     end

--- a/spec/css_widely_available_spec.rb
+++ b/spec/css_widely_available_spec.rb
@@ -14,6 +14,8 @@ ALLOWED_AT_RULES = Set.new(%w[])
 # writing comments, that is the beating heart of the site.
 ALLOWED_PROPERTIES = Set.new(%w[user-select])
 
+ALLOWED_PROPERTY_VALUES = Set.new(%w[])
+
 # :has() https://caniuse.com/css-has
 # Unprincipled exception because it solves so many big problems.
 ALLOWED_SELECTORS = Set.new(%w[has])
@@ -24,6 +26,8 @@ WANTED_PROPERTIES = Set.new(%w[field-sizing resize])
 BaselineAtRule = Data.define(:name)
 BaselineProperty = Data.define(:name)
 BaselineSelector = Data.define(:name)
+
+BaselinePropertyValue = Data.define(:property, :value)
 
 Violation = Data.define(:line, :kind, :name) do
   def to_s
@@ -38,14 +42,14 @@ def fetch_feature_data
 
   cache_file = Rails.root.join("tmp/web_feature_availibility.json")
   data = if cache_file.exist? && cache_file.mtime.after?(1.week.ago)
-    cache_file.read
-  else
-    response = Sponge.fetch(DATA_URL)
-    raise "Failed to download availability data" unless response
-    # puts response.inspect
-    File.binwrite(cache_file, response.body)
-    response.body
-  end
+           cache_file.read
+         else
+           response = Sponge.fetch(DATA_URL)
+           raise "Failed to download availability data" unless response
+           # puts response.inspect
+           File.binwrite(cache_file, response.body)
+           response.body
+         end
 
   JSON.parse(data)
 ensure
@@ -68,42 +72,53 @@ end
 #   }
 # }
 def extract_widely_available(data:)
-  data["features"].each_value.flat_map { |feature|
-    (feature.dig("status", "by_compat_key") || {}).filter_map { |key, status|
-      next unless status["baseline"] == "high"
+  baseline = []
+  restricted_values = []
 
+  data["features"].each_value { |feature|
+    (feature.dig("status", "by_compat_key") || {}).each { |key, status|
       parts = key.split(".")
+
       next unless parts[0] == "css" && parts.length >= 3
 
       case parts[1]
-      when "at-rules" then BaselineAtRule.new(name: parts[2])
-      when "properties" then BaselineProperty.new(name: parts[2])
-      when "selectors" then BaselineSelector.new(name: parts[2])
+      when "at-rules" then
+        baseline << BaselineAtRule.new(name: parts[2]) if status["baseline"] == "high"
+      when "properties" then
+        if parts.length == 3
+          baseline << BaselineProperty.new(name: parts[2]) if status["baseline"] == "high"
+        elsif parts.length == 4
+          restricted_values << BaselinePropertyValue.new(property: parts[2], value: parts[3]) if status["baseline"] != "high"
+        end
+      when "selectors" then
+        baseline << BaselineSelector.new(name: parts[2]) if status["baseline"] == "high"
       end
     }
   }
+
+  [baseline.to_set, restricted_values.to_set]
 end
 
-def find_violations(baseline:, css_file:)
+def find_violations(baseline:, restricted_values:, css_file:)
   css = File.read(css_file)
   tree = Crass.parse(css)
-  check_nodes(baseline:, nodes: tree, css:)
+  check_nodes(baseline:, restricted_values:, nodes: tree, css:)
 end
 
-def check_nodes(baseline:, nodes:, css:)
+def check_nodes(baseline:, restricted_values:, nodes:, css:)
   return [] unless nodes
 
   nodes.flat_map { |node|
     violation = case node[:node]
-    when :property then check_property(baseline:, node:, css:)
-    when :style_rule then check_selector(baseline:, node:, css:)
-    when :at_rule then check_at_rule(baseline:, node:, css:)
-    end
+                when :property then check_property(baseline:, node:, css:) || check_property_value(restricted_values:, node:, css:)
+                when :style_rule then check_selector(baseline:, node:, css:)
+                when :at_rule then check_at_rule(baseline:, node:, css:)
+                end
 
     [
       *violation,
-      *check_nodes(baseline:, nodes: node[:children], css:),
-      *check_nodes(baseline:, nodes: node[:block], css:)
+      *check_nodes(baseline:, restricted_values:, nodes: node[:children], css:),
+      *check_nodes(baseline:, restricted_values:, nodes: node[:block], css:)
     ]
   }
 end
@@ -137,6 +152,17 @@ def check_property(baseline:, node:, css:)
   Violation.new(kind: :property, line:, name:)
 end
 
+def check_property_value(restricted_values:, node:, css:)
+  value = node[:value].to_s.strip
+  name = node[:name]
+
+  return if ALLOWED_PROPERTY_VALUES.include?(name)
+  return unless restricted_values.include?(BaselinePropertyValue.new(property: name, value:))
+
+  line = token_line(tokens: node[:tokens], css:)
+  Violation.new(kind: :property_value, line:, name: "#{name}: #{value}")
+end
+
 def check_selector(baseline:, node:, css:)
   node.dig(:selector, :value).scan(/::?([\w-]+)/).filter_map { |match|
     name = match[0]
@@ -153,38 +179,38 @@ end
 
 RSpec.describe "CSS" do
   css_files = Dir.glob("app/assets/stylesheets/**/*.css").sort
-  baseline = extract_widely_available(data: fetch_feature_data)
+  baseline, restricted_values = extract_widely_available(data: fetch_feature_data)
 
   css_files.each do |css_file|
     it "#{css_file} uses only Baseline widely available features" do
-      violations = find_violations(baseline:, css_file:)
+      violations = find_violations(baseline:, restricted_values:, css_file:)
       expect(violations).to be_empty,
-        "CSS features not Baseline widely available:\n  #{violations.join("\n  ")}\n" \
-        "See: https://web-platform-dx.github.io/web-features/"
+                            "CSS features not Baseline widely available:\n  #{violations.join("\n  ")}\n" \
+                              "See: https://web-platform-dx.github.io/web-features/"
     end
   end
 
   ALLOWED_AT_RULES.each do |at_rule|
     it "exception '#{at_rule}' is still not Baseline widely available" do
       expect(baseline).not_to include(BaselineAtRule.new(name: at_rule)),
-        "At rule '#{at_rule}' is now Baseline widely available! " \
-        "Remove it from ALLOWED_AT_RULES in #{__FILE__} and rejoice."
+                              "At rule '#{at_rule}' is now Baseline widely available! " \
+                                "Remove it from ALLOWED_AT_RULES in #{__FILE__} and rejoice."
     end
   end
 
   ALLOWED_PROPERTIES.each do |prop|
     it "exception '#{prop}' is still not Baseline widely available" do
       expect(baseline).not_to include(BaselineProperty.new(name: prop)),
-        "Property '#{prop}' is now Baseline widely available! " \
-        "Remove it from ALLOWED_PROPERTIES in #{__FILE__} and rejoice."
+                              "Property '#{prop}' is now Baseline widely available! " \
+                                "Remove it from ALLOWED_PROPERTIES in #{__FILE__} and rejoice."
     end
   end
 
   ALLOWED_SELECTORS.each do |sel|
     it "exception ':#{sel}' is still not Baseline widely available" do
       expect(baseline).not_to include(BaselineSelector.new(name: sel)),
-        "Selector ':#{sel}' is now Baseline widely available! " \
-        "Remove it from ALLOWED_SELECTORS in #{__FILE__} and rejoice."
+                              "Selector ':#{sel}' is now Baseline widely available! " \
+                                "Remove it from ALLOWED_SELECTORS in #{__FILE__} and rejoice."
     end
   end
 
@@ -193,8 +219,8 @@ RSpec.describe "CSS" do
   WANTED_PROPERTIES.each do |prop|
     it "wanted property '#{prop}' is not yet Baseline widely available" do
       expect(baseline).not_to include(BaselineProperty.new(name: prop)),
-        "Property '#{prop}' is now Baseline widely available! " \
-        "See comment in this spec for where we wanted to use it."
+                              "Property '#{prop}' is now Baseline widely available! " \
+                                "See comment in this spec for where we wanted to use it."
     end
   end
 end

--- a/spec/css_widely_available_spec.rb
+++ b/spec/css_widely_available_spec.rb
@@ -14,7 +14,7 @@ ALLOWED_AT_RULES = Set.new(%w[])
 # writing comments, that is the beating heart of the site.
 ALLOWED_PROPERTIES = Set.new(%w[user-select])
 
-ALLOWED_PROPERTY_VALUES = Set.new(%w[])
+ALLOWED_PROPERTY_VALUES = Set.new([])
 
 # :has() https://caniuse.com/css-has
 # Unprincipled exception because it solves so many big problems.
@@ -23,11 +23,12 @@ ALLOWED_SELECTORS = Set.new(%w[has])
 # textarea { field-sizing: content; resize: vertical; } would let us delete autosize.js
 WANTED_PROPERTIES = Set.new(%w[field-sizing resize])
 
+WANTED_PROPERTY_VALUES = Set.new([["appearance", "base-select"]])
+
 BaselineAtRule = Data.define(:name)
 BaselineProperty = Data.define(:name)
+BaselinePropertyValue = Data.define(:name, :value)
 BaselineSelector = Data.define(:name)
-
-BaselinePropertyValue = Data.define(:property, :value)
 
 Violation = Data.define(:line, :kind, :name) do
   def to_s
@@ -42,14 +43,14 @@ def fetch_feature_data
 
   cache_file = Rails.root.join("tmp/web_feature_availibility.json")
   data = if cache_file.exist? && cache_file.mtime.after?(1.week.ago)
-           cache_file.read
-         else
-           response = Sponge.fetch(DATA_URL)
-           raise "Failed to download availability data" unless response
-           # puts response.inspect
-           File.binwrite(cache_file, response.body)
-           response.body
-         end
+    cache_file.read
+  else
+    response = Sponge.fetch(DATA_URL)
+    raise "Failed to download availability data" unless response
+    # puts response.inspect
+    File.binwrite(cache_file, response.body)
+    response.body
+  end
 
   JSON.parse(data)
 ensure
@@ -82,15 +83,15 @@ def extract_widely_available(data:)
       next unless parts[0] == "css" && parts.length >= 3
 
       case parts[1]
-      when "at-rules" then
+      when "at-rules"
         baseline << BaselineAtRule.new(name: parts[2]) if status["baseline"] == "high"
-      when "properties" then
+      when "properties"
         if parts.length == 3
           baseline << BaselineProperty.new(name: parts[2]) if status["baseline"] == "high"
         elsif parts.length == 4
-          restricted_values << BaselinePropertyValue.new(property: parts[2], value: parts[3]) if status["baseline"] != "high"
+          restricted_values << BaselinePropertyValue.new(name: parts[2], value: parts[3]) if status["baseline"] != "high"
         end
-      when "selectors" then
+      when "selectors"
         baseline << BaselineSelector.new(name: parts[2]) if status["baseline"] == "high"
       end
     }
@@ -110,10 +111,10 @@ def check_nodes(baseline:, restricted_values:, nodes:, css:)
 
   nodes.flat_map { |node|
     violation = case node[:node]
-                when :property then check_property(baseline:, node:, css:) || check_property_value(restricted_values:, node:, css:)
-                when :style_rule then check_selector(baseline:, node:, css:)
-                when :at_rule then check_at_rule(baseline:, node:, css:)
-                end
+    when :property then check_property(baseline:, node:, css:) || check_property_value(restricted_values:, node:, css:)
+    when :style_rule then check_selector(baseline:, node:, css:)
+    when :at_rule then check_at_rule(baseline:, node:, css:)
+    end
 
     [
       *violation,
@@ -156,8 +157,8 @@ def check_property_value(restricted_values:, node:, css:)
   value = node[:value].to_s.strip
   name = node[:name]
 
-  return if ALLOWED_PROPERTY_VALUES.include?(name)
-  return unless restricted_values.include?(BaselinePropertyValue.new(property: name, value:))
+  return if ALLOWED_PROPERTY_VALUES.include?([name, value])
+  return unless restricted_values.include?(BaselinePropertyValue.new(name: name, value:))
 
   line = token_line(tokens: node[:tokens], css:)
   Violation.new(kind: :property_value, line:, name: "#{name}: #{value}")
@@ -185,32 +186,32 @@ RSpec.describe "CSS" do
     it "#{css_file} uses only Baseline widely available features" do
       violations = find_violations(baseline:, restricted_values:, css_file:)
       expect(violations).to be_empty,
-                            "CSS features not Baseline widely available:\n  #{violations.join("\n  ")}\n" \
-                              "See: https://web-platform-dx.github.io/web-features/"
+        "CSS features not Baseline widely available:\n  #{violations.join("\n  ")}\n" \
+          "See: https://web-platform-dx.github.io/web-features/"
     end
   end
 
   ALLOWED_AT_RULES.each do |at_rule|
     it "exception '#{at_rule}' is still not Baseline widely available" do
       expect(baseline).not_to include(BaselineAtRule.new(name: at_rule)),
-                              "At rule '#{at_rule}' is now Baseline widely available! " \
-                                "Remove it from ALLOWED_AT_RULES in #{__FILE__} and rejoice."
+        "At rule '#{at_rule}' is now Baseline widely available! " \
+          "Remove it from ALLOWED_AT_RULES in #{__FILE__} and rejoice."
     end
   end
 
   ALLOWED_PROPERTIES.each do |prop|
     it "exception '#{prop}' is still not Baseline widely available" do
       expect(baseline).not_to include(BaselineProperty.new(name: prop)),
-                              "Property '#{prop}' is now Baseline widely available! " \
-                                "Remove it from ALLOWED_PROPERTIES in #{__FILE__} and rejoice."
+        "Property '#{prop}' is now Baseline widely available! " \
+          "Remove it from ALLOWED_PROPERTIES in #{__FILE__} and rejoice."
     end
   end
 
   ALLOWED_SELECTORS.each do |sel|
     it "exception ':#{sel}' is still not Baseline widely available" do
       expect(baseline).not_to include(BaselineSelector.new(name: sel)),
-                              "Selector ':#{sel}' is now Baseline widely available! " \
-                                "Remove it from ALLOWED_SELECTORS in #{__FILE__} and rejoice."
+        "Selector ':#{sel}' is now Baseline widely available! " \
+          "Remove it from ALLOWED_SELECTORS in #{__FILE__} and rejoice."
     end
   end
 
@@ -219,8 +220,16 @@ RSpec.describe "CSS" do
   WANTED_PROPERTIES.each do |prop|
     it "wanted property '#{prop}' is not yet Baseline widely available" do
       expect(baseline).not_to include(BaselineProperty.new(name: prop)),
-                              "Property '#{prop}' is now Baseline widely available! " \
-                                "See comment in this spec for where we wanted to use it."
+        "Property '#{prop}' is now Baseline widely available! " \
+          "See comment in this spec for where we wanted to use it."
+    end
+  end
+
+  WANTED_PROPERTY_VALUES.each do |prop_val|
+    it "wanted property_value '#{prop_val[0]}: #{prop_val[1]}' is not yet Baseline widely available" do
+      expect(restricted_values).to include(BaselinePropertyValue.new(property: prop_val[0], value: prop_val[1])),
+        "Property Value '#{prop_val[0]}: #{prop_val[1]}' is now Baseline widely available! " \
+          "See comment in this spec for where we wanted to use it."
     end
   end
 end


### PR DESCRIPTION
Addresses #2068. 

To-Do

- [X] The validator should catch  that `select { appearance: base-select; }` is not yet widely available.
- [x] Add this specific CSS to a WANTED list so we know when it's available.
- [x] Rewrite Existing Non-Conforming CSS to OR add to ALLOWED.

> It will almost certainly turn up that we have accepted CSS that doesn't meet the widely available standard. Ideally we'll be able to rewrite to meet the standard, but maybe we'll decide to add more to the ALLOWED lists.

As expected there is CSS that doesn't meet the baseline. which is why the test currently fails.
- [cursor: pointer](https://caniuse.com/mdn-css_properties_cursor_pointer)
- [word-break: break-word](https://caniuse.com/wf-word-break-break-word)
- [user-select: none](https://caniuse.com/user-select-none)