### PR TITLE
fix: do not require the about section on sign up.

### DIFF
--- a/app/views/signup/invited.html.erb
+++ b/app/views/signup/invited.html.erb
@@ -45,7 +45,7 @@
 
     <%= f.label :about, "About" %>
     <div>
-      <%= f.text_area :about, required: true %>
+      <%= f.text_area :about%>
 
       <%= render :partial => "global/markdownhelp" %>
     </div>


### PR DESCRIPTION
<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->

Fixes #2087.

Removes the required flag on the about field.