### PR TITLE
Set a default --color-fg-accent

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -16,6 +16,7 @@ But I make an unprincipled exception for :has because it solves so many big prob
 	--color-bg-50: rgb(var(--base-bg) / 50%);
 
 	--color-fg: rgb(var(--base-fg) / var(--opacity-fg)); /* primary text */
+	--color-fg-accent: currentColor;
 	--color-fg-contrast-13: rgb(var(--base-fg) / var(--opacity-fg-contrast-13));
 	--color-fg-contrast-10: rgb(var(--base-fg) / var(--opacity-fg-contrast-10));
 	--color-fg-contrast-7-5: rgb(var(--base-fg) / var(--opacity-fg-contrast-7-5));


### PR DESCRIPTION
Border for current page needs a color value to create a valid css rule. Currently it's parsed as `2px solid`, not a valid css rule. Defaulting to whatever the default foreground color the browser reports prevent layout shuffling when colors are finally loaded.

Fixes #2089 

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
