### PR TITLE
Align comments link in mobile to the top

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1929,7 +1929,8 @@ input[type="submit"].link_post.pushover_button {
 		min-width: 40px;
 		text-align: center;
 		text-decoration: none;
-		vertical-align: middle;
+		vertical-align: top;
+		padding-top: 2rem;
 	}
 	ol.stories.list li.story .mobile_comments span:before {
 		border-style: solid;


### PR DESCRIPTION
Prevent the comment link to go out of the screen if story previews are enabled, and user toggles one open.

Fixes #2084 

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
