### PR TITLE
Move markdown help below controls on mobile

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -930,8 +930,7 @@ div.comment_text {
 }
 .controls {
 	display: flex;
-	flex-flow: row;
-	flex-wrap: wrap;
+	flex-flow: row wrap;
 	gap: 0.5rem;
 	justify-content: start;
 	margin-top: 1rem;
@@ -1693,21 +1692,6 @@ input[type="submit"].link_post.pushover_button {
 	margin-top: -0.75rem;
 }
 
-@media only screen and (max-width: 480px) {
-	.radio-group-container legend {
-		float: none;
-		margin-bottom: 0.5rem;
-	}
-
-	.radio-group-container .radio-group {
-		gap: 1rem;
-	}
-
-	.radio-group-container .radio-group	label {
-		display: inline;
-	}
-}
-
 @media screen and (min-width: 481px) {
 	body {
 		max-width: 60rem;
@@ -2040,6 +2024,32 @@ input[type="submit"].link_post.pushover_button {
 	}
 	.labelled_grid input[type="checkbox"] + .hint {
 		margin-left: 0;
+	}
+
+	.radio-group-container legend {
+		float: none;
+		margin-bottom: 0.5rem;
+	}
+
+	.radio-group-container .radio-group {
+		gap: 1rem;
+	}
+
+	.radio-group-container .radio-group	label {
+		display: inline;
+	}
+
+	.controls {
+		flex-flow: column;
+	}
+
+	.controls .markdown_help[open] summary,
+	.controls details {
+		margin: 0;
+	}
+
+	.markdown_help summary {
+		text-align: left;
 	}
 }
 @media print {


### PR DESCRIPTION
Rearrange button and markdown help block in a column view so the markdown help won't overlap button when open.

Fixes #2086 
<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
