### PR TITLE
fix cancel comment button

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -936,7 +936,7 @@ document.addEventListener("DOMContentLoaded", () => {
           response.text().then(text => replace(comment, text));
         });
     } else {
-      comment.parentElement.remove();
+      comment.remove();
     }
   });
 


### PR DESCRIPTION
<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->

Fixes #2096.

The cancel button was removing the `<ol class="comments">` element that holds the reply form. Seems like it was introduced in dcfedfbc29fd4bdc93d1c1a054e4b8a6524c476c. 

Fixed by removing the `reply_form_temporary` element instead of the parent.