### PR TITLE
RSS feed for user's comments

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -385,11 +385,21 @@ class CommentsController < ApplicationController
       @title = "Your Threads"
     end
 
+    @rss_link ||= {
+      title: "RSS 2.0 - #{@showing_user.username} Comments",
+      href: user_token_link(user_threads_url(format: :rss))
+    }
+
     @threads = Comment.recent_threads(@showing_user)
       .merge(Story.not_deleted(@user))
       .for_presentation
       .joins(:story)
     @threads = CommentVoteHydrator.new(@threads, @user)
+
+    respond_to do |format|
+      format.html { render action: "user_threads" }
+      format.rss { render action: "user_threads", layout: false }
+    end
   end
 
   private

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -384,21 +384,36 @@ class CommentsController < ApplicationController
       @showing_user = @user
       @title = "Your Threads"
     end
-
-    @rss_link ||= {
-      title: "RSS 2.0 - #{@showing_user.username} Comments",
-      href: user_token_link(user_threads_url(format: :rss))
-    }
-
     @threads = Comment.recent_threads(@showing_user)
       .merge(Story.not_deleted(@user))
       .for_presentation
       .joins(:story)
     @threads = CommentVoteHydrator.new(@threads, @user)
+  end
+
+  def user_comments
+    if params[:user]
+      @showing_user = User.find_by!(username: params[:user])
+      @title = "Comments for #{@showing_user.username}"
+    elsif !@user
+      return redirect_to active_path
+    else
+      @showing_user = @user
+      @title = "Your Comments"
+    end
+
+    @rss_link ||= {
+      title: "RSS 2.0 - #{@showing_user.username} Comments",
+      href: user_token_link(user_threads_url(format: :rss))
+    }
+    @comments = Comment.where(user: @showing_user)
+      .merge(Story.not_deleted(@user))
+      .for_presentation
+      .joins(:story)
+    @comments = CommentVoteHydrator.new(@comments, @user)
 
     respond_to do |format|
-      format.html { render action: "user_threads" }
-      format.rss { render action: "user_threads", layout: false }
+      format.rss { render action: "user_comments", layout: false }
     end
   end
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -395,16 +395,11 @@ class CommentsController < ApplicationController
     if params[:user]
       @showing_user = User.find_by!(username: params[:user])
       @title = "Comments for #{@showing_user.username}"
-    elsif !@user
-      return redirect_to active_path
-    else
-      @showing_user = @user
-      @title = "Your Comments"
     end
 
     @rss_link ||= {
       title: "RSS 2.0 - #{@showing_user.username} Comments",
-      href: user_token_link(user_threads_url(format: :rss))
+      href: user_token_link(user_comments_url(format: :rss))
     }
     @comments = Comment.where(user: @showing_user)
       .merge(Story.not_deleted(@user))

--- a/app/views/comments/user_comments.rss.builder
+++ b/app/views/comments/user_comments.rss.builder
@@ -5,11 +5,10 @@ xml.rss version: "2.0", "xmlns:atom": "http://www.w3.org/2005/Atom" do
     xml.link Rails.application.root_url
     xml.tag! "atom:link", nil, href: request.original_url, rel: :self
     xml.description @title
-    xml.pubDate @threads.first&.created_at&.rfc822 || Time.current.rfc822
+    xml.pubDate @comments.first&.created_at&.rfc822 || Time.current.rfc822
     xml.ttl 120
 
-    @threads.each do |comment|
-      next unless comment.user.username == @showing_user.username
+    @comments.each do |comment|
       xml.item do
         xml.title comment.story.title
         xml.link Routes.comment_short_id_url comment

--- a/app/views/comments/user_threads.rss.builder
+++ b/app/views/comments/user_threads.rss.builder
@@ -1,0 +1,24 @@
+xml.instruct! :xml, version: "1.0"
+xml.rss version: "2.0", "xmlns:atom": "http://www.w3.org/2005/Atom" do
+  xml.channel do
+    xml.title Rails.application.name + (@title.present? ? ": #{@title}" : "")
+    xml.link Rails.application.root_url
+    xml.tag! "atom:link", nil, href: request.original_url, rel: :self
+    xml.description @title
+    xml.pubDate @threads.first&.created_at&.rfc822 || Time.current.rfc822
+    xml.ttl 120
+
+    @threads.each do |comment|
+      next unless comment.user.username == @showing_user.username
+      xml.item do
+        xml.title comment.story.title
+        xml.link Routes.comment_short_id_url comment
+        xml.guid Routes.comment_short_id_url comment
+        xml.author "#{comment.user.username}@#{Rails.application.domain} (#{comment.user.username})"
+        xml.pubDate comment.last_edited_at.rfc822
+        xml.comments Routes.comment_short_id_url comment
+        xml.description comment.markeddown_comment
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -149,6 +149,7 @@ Rails.application.routes.draw do
   get "/~:username/standing" => "users#standing", :as => "user_standing"
   get "/~:user/stories(/page/:page)" => "home#newest_by_user", :as => "newest_by_user"
   get "/~:user/threads" => "comments#user_threads", :as => "user_threads"
+  get "/~:user/comments.rss" => "comments#user_comments", :as => "user_comments", :format => "rss"
 
   post "/~:username/ban" => "users#ban", :as => "user_ban"
   post "/~:username/unban" => "users#unban", :as => "user_unban"

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -61,6 +61,15 @@ describe "comments", type: :request do
       expect(response.body).to include(comment.comment[0..20])
       expect(response.body).to include(comment.user.username)
     end
+
+    it "/~user/threads.rss renders" do
+      comment = create(:comment)
+      get user_threads_path(comment.user, format: :rss)
+
+      expect(response).to be_successful
+      expect(response.body).to include(comment.comment[0..20])
+      expect(response.body).to include(comment.user.username)
+    end
   end
 
   describe "previewing" do

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -62,9 +62,9 @@ describe "comments", type: :request do
       expect(response.body).to include(comment.user.username)
     end
 
-    it "/~user/threads.rss renders" do
+    it "/~user/comments.rss renders" do
       comment = create(:comment)
-      get user_threads_path(comment.user, format: :rss)
+      get user_comments_path(comment.user, format: :rss)
 
       expect(response).to be_successful
       expect(response.body).to include(comment.comment[0..20])


### PR DESCRIPTION
Addresses #1242.

Adds a RSS endpoint for /~user/threads. Currently it only shows the comments by that user and not any parent/child comments.