### PR TITLE
Remove :has from allowed css selectors

### DIFF
--- a/spec/css_widely_available_spec.rb
+++ b/spec/css_widely_available_spec.rb
@@ -17,9 +17,7 @@ ALLOWED_PROPERTIES = Set.new(%w[user-select])
 # See https://github.com/lobsters/lobsters/pull/2079#issuecomment-4730563102 for reasoning.
 ALLOWED_PROPERTY_VALUES = Set.new([["cursor", "pointer"], ["cursor", "default"], ["user-select", "none"]])
 
-# :has() https://caniuse.com/css-has
-# Unprincipled exception because it solves so many big problems.
-ALLOWED_SELECTORS = Set.new(%w[has])
+ALLOWED_SELECTORS = Set.new(%w[])
 
 # textarea { field-sizing: content; resize: vertical; } would let us delete autosize.js
 WANTED_PROPERTIES = Set.new(%w[field-sizing resize])


### PR DESCRIPTION
<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->

`:has` is now [baseline](https://caniuse.com/css-has)! 🎉 This removes it from ALLOWED_SELECTORS to fix the failing test.

As an aside the test based alert worked very well.