### PR TITLE
Repeat textarea placeholder as plain text for alternative browsers

### DIFF
--- a/app/views/stories/_form.html.erb
+++ b/app/views/stories/_form.html.erb
@@ -1,4 +1,9 @@
 <%# locals: (story:, f:, suggesting: false) -%>
+<% guidelines = "Use this textarea for stories without a URL, to link additional context, or to paste abstracts from PDF papers.
+
+Please don't use this to promote the story, summarize the post, or explain why you posted it.
+See the guidelines below for more."
+%>
 <%= render :partial => "stories/form_errors", :locals => { :f => f, :story => f.object, suggesting: suggesting } %>
 
 <div class="box">
@@ -72,12 +77,17 @@
   <% end %>
 
   <% unless suggesting %>
+    <p hidden>
+    <%
+      # Common browsers will ignore this paragraph due to [hidden], and show only the placeholder.
+      # Text browsers don't render placeholders but will show this instead.
+      # See https://github.com/lobsters/lobsters/pull/2110
+    %>
+    <%= guidelines %>
+    </p>
     <div class="boxline">
       <%= f.label :description, "Text" %>
-      <%= f.text_area :description, rows: 8, placeholder: "Use this for stories without a URL, to link additional context, or to paste abstracts from PDF papers.
-
-Please don't use this to promote the story, summarize the post, or explain why you posted it.
-See the guidelines below for more." %>
+      <%= f.text_area :description, rows: 8, placeholder: guidelines %>
     <%= render :partial => "global/markdownhelp", :locals => { allow_images: @story.can_have_images? } %>
     </div>
 


### PR DESCRIPTION
Most (if not all) text browsers do not support the placeholder attribute. Even Netsuft, being a graphical support, does not support it.

By repeating it in the submit story page, we can show the same hint to those.

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
