### PR TITLE
Escape html in data-title attr of tag selector

### DIFF
--- a/app/views/stories/_form.html.erb
+++ b/app/views/stories/_form.html.erb
@@ -57,7 +57,7 @@
           (t.filtered_count == 1 ? "" : "s") << " filtering</em>"
       end
 
-      [ "#{t.tag} - #{t.description}", t.tag, { "data-title" => raw(html), "data-tag-css" => t.css_class, "data-vibe" => (t.tag == "vibecoding") ? 'ai' : '' } ]},
+      [ "#{t.tag} - #{t.description}", t.tag, { "data-title" => ERB::Util.html_escape(html), "data-tag-css" => t.css_class, "data-vibe" => (t.tag == "vibecoding") ? 'ai' : '' } ]},
     f.object.tags.map(&:tag)), {}, { multiple: true, required: true } %>
   </div>
 


### PR DESCRIPTION
For the tag selector in the submit story form, escape the html that is set in the data-title attribute. This used to break Dillo HTML parsing

Fixes #2108

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
