### PR TITLE
Fix caches dropdown in netsurf

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1022,7 +1022,7 @@ div.comment_text code {
 	list-style: none;
 }
 
-.caches ul {
+.caches[open] ul {
 	position: absolute;
 	background: var(--color-bg);
 	border: 1px solid var(--color-box-border);
@@ -1033,6 +1033,7 @@ div.comment_text code {
 }
 
 .caches li {
+	display: inline-block; /* Netsurf */
 	border-bottom: 1px solid var(--color-box-border);
 }
 


### PR DESCRIPTION
Fixes caches list overlapping other entries in Netsurf by hiding the styles using an attribute selector.

The display: inline-block is ignored by the rest of the browsers, and keeps the UI slightly more tidy in Netsurf

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
