### PR TITLE
Use HTML list for tags

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -664,6 +664,13 @@ li.story a.tag {
 
 li .tags {
 	margin-right: 0.25em;
+	display: inline-block;
+	vertical-align: middle;
+	padding: 0;
+}
+
+li .tags li {
+	display: inline-block;
 }
 
 li .domain {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -182,6 +182,7 @@ module ApplicationHelper
     link_to tag.tag,
       tag_path(tag),
       options.reverse_merge({
+        aria: {label: "Tag #{tag.tag}"},
         class: [tag.css_class, filtered_tags.include?(tag) ? "filtered" : nil],
         title: tag.description
       })

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -58,11 +58,11 @@ class="story <%= story.current_upvoted? ? "upvoted" : "" %>
         href="<%= Routes.title_path story %>">&#x2636;</a>
     <% end %>
     <% if story.can_be_seen_by_user?(@user) %>
-      <span class="tags">
+      <ul class="tags" aria-label="Tags">
         <% story.tags.each do |tag| %>
-          <%= tag_link(tag) %>
+          <li><%= tag_link tag %></li>
         <% end %>
-      </span>
+      </ul>
       <% if story.origin.present? %>
         <%= link_to story.origin.identifier, origin_path(story.origin), class: 'domain' %>
       <% elsif story.domain.present? %>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -182,11 +182,11 @@ class="story <%= story.current_upvoted? ? "upvoted" : "" %>
         href="<%= Routes.title_path story %>">&#x2636;</a>
     <% end %>
     <% if story.can_be_seen_by_user?(@user) %>
-      <span class="tags">
+      <ul class="tags" aria-label="Tags">
         <% story.tags.each do |tag| %>
-          <%= tag_link(tag) %>
+          <li><%= tag_link tag %></li>
         <% end %>
-      </span>
+      </ul>
       <% if story.origin.present? %>
         <%= link_to story.origin.identifier, origin_path(story.origin), class: 'domain' %>
       <% elsif story.domain.present? %>

--- a/app/views/stories/_listdetail.html.erb
+++ b/app/views/stories/_listdetail.html.erb
@@ -43,11 +43,11 @@ class="story <%= story.current_upvoted? ? "upvoted" : "" %>
         href="<%= Routes.title_path story %>">&#x2636;</a>
     <% end %>
     <% if story.can_be_seen_by_user?(@user) %>
-      <span class="tags">
+      <ul class="tags" aria-label="Tags">
         <% story.tags.each do |tag| %>
-          <%= tag_link(tag) %>
+          <li><%= tag_link tag %></li>
         <% end %>
-      </span>
+      </ul>
       <% if story.origin.present? %>
         <%= link_to story.origin.identifier, origin_path(story.origin), class: 'domain' %>
       <% elsif story.domain.present? %>

--- a/app/views/stories/_singledetail.html.erb
+++ b/app/views/stories/_singledetail.html.erb
@@ -39,11 +39,11 @@ classes = [
         <a class="description_present" title="<%= truncate(ms.description, :length => 500) %>" href="<%= Routes.title_path ms %>">&#x2636;</a>
       <% end %>
 
-      <span class="tags">
+      <ul class="tags" aria-label="Tags">
         <% ms.tags.each do |tag| %>
-          <%= tag_link tag %>
+          <li><%= tag_link tag %></li>
         <% end %>
-      </span>
+      </ul>
       <% if ms.origin.present? %>
         <%= link_to ms.origin.identifier, origin_path(ms.origin), class: 'domain' %>
       <% elsif ms.domain.present? %>


### PR DESCRIPTION
Tag links should be grouped to give them context. This is from my
understandind of "WCAG 2.1 SC 2.4.4 Link Purpose (In Context) (Level A)"

> The purpose of each link can be determined from the link text alone or
from the link text together with its programmatically determined link
context.

And then for "context", it reads

> [...] text that is in the same paragraph, list item, or table cell as
the link or in a table header cell [...]

So, I guess we can say there's context because once a screen reader
lands on the first items, it reads "Tags, list with n items, tag name,
link".

When listing links, the list context is lost, so an aria-label is added to prefix each link with "Tag"

https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-in-context
https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-in-context#dfn-programmatically-determined-link-context

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
