### PR TITLE
Prefer rem over rlh in CSS

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1402,7 +1402,7 @@ label:has(+ *[type="hidden"] + *:required)::after {
 }
 .labelled_grid input[type="text"],
 .labelled_grid input[type="password"] {
-	height: 1.5rlh;
+	height: 1.8rem;
 }
 
 .labelled_grid input[type="checkbox"] {


### PR DESCRIPTION
Servo does not seem to support rhl and default to some other unit that renders input too short. Replace with the equivalent size using rems.

Fixes #2115

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
