### PR TITLE
Dont let link be hidden by caches dropdown; remove line throght of user on active

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -774,11 +774,14 @@ span.new_user, a.new_user,
 li .byline a.new_user {
 	color: var(--color-fg-affirmative);
 }
-span.inactive_user, a.inactive_user,
-li .byline a.inactive_user,
+a.inactive_user,
 .inactive_tag {
 	color: var(--color-fg-contrast-5);
 	text-decoration: line-through;
+}
+a.inactive_user:focus-visible,
+a.inactive_user:hover {
+	text-decoration: none;
 }
 span.user_is_author, a.user_is_author,
 li .byline a.user_is_author {

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -755,6 +755,19 @@ li.story .byline {
 	color: var(--color-fg-contrast-4-5);
 	text-decoration: none;
 }
+
+.details input:hover,
+.details input:focus-visible,
+.details summary:hover,
+.details summary:focus-visible,
+.details a:hover:not(details *),
+.details a:focus-visible:not(details *) {
+	position: relative;
+	z-index: 10;
+	background: var(--color-bg);
+	box-shadow: 0 0 0 0.25rem var(--color-bg);
+}
+
 .comment.replied .flagger,
 .comment.flagged .comment_replier {
 	color: var(--color-fg);


### PR DESCRIPTION
There are two commits here.

* [Remove line through for inactive user on focus and hover.](https://github.com/lobsters/lobsters/commit/ea4f50cb2c053b44352c6ec6f12754ed27e619bf): like it says, the line through is removed for inactive users when the link is hovered of focused using a keyboard.

<img width="390" height="199" alt="image" src="https://github.com/user-attachments/assets/46481066-3ded-4585-8f35-b40f3a76d889" />

* [Don't let links be hidden by caches dropdown](https://github.com/lobsters/lobsters/commit/3ae6295bfccef09327e182afef89006bb9479666): Since the 'caches' dropdown does not close automatically, it may obscure other links near it. This change raises them when focused or hovered.

<img width="249" height="179" alt="image" src="https://github.com/user-attachments/assets/a480f072-5262-437f-9cd6-fe9eb34a09bc" />


<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
