### PR TITLE
Fix expiring avatars error

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -378,11 +378,11 @@ class User < ApplicationRecord
   def expire_avatar!
     expired = 0
 
-    Dir.entries(CACHE_DIR).select { |f|
-      f.match(/\A#{@user.username}-(\d+)\.png\z/)
+    Dir.entries(AvatarsController::CACHE_DIR).select { |f|
+      f.match(/\A#{username}-(\d+)\.png\z/)
     }.each do |f|
       # Rails.logger.debug { "Expiring #{f}" }
-      File.unlink("#{CACHE_DIR}/#{f}")
+      File.unlink("#{AvatarsController::CACHE_DIR}/#{f}")
       expired += 1
     end
     expired


### PR DESCRIPTION
Recent merge of PR #1952 moves the logic of expiring the avatars from `avatars_controller.rb` to `user.rb`.

I wanted to try it in prod, however it causes errors due to some variables not being accessible outside of `avatars_controller`. Here's my proposed fix.

I have tested it in my dev environment.

(mentionning @pushcx as expiring your cache or setting your avatar source currently returns 500)