### PR TITLE
Disable Story Byline Buttons when Previewing

### DIFF
--- a/app/views/stories/_singledetail.html.erb
+++ b/app/views/stories/_singledetail.html.erb
@@ -66,7 +66,7 @@ classes = [
           <a href="<%= edit_story_path(ms.short_id) %>">edit</a>
         <% end %>
 
-        <% if @user&.is_moderator? %>
+        <% if @user&.is_moderator? && !ms.previewing %>
           <%= divider_tag %>
           <% css = ms.has_suggestions? ? "story_has_suggestions" : "" %>
           <% if ms.previewing %>

--- a/app/views/stories/_singledetail.html.erb
+++ b/app/views/stories/_singledetail.html.erb
@@ -68,12 +68,7 @@ classes = [
 
         <% if @user&.is_moderator? && !ms.previewing %>
           <%= divider_tag %>
-          <% css = ms.has_suggestions? ? "story_has_suggestions" : "" %>
-          <% if ms.previewing %>
-            <span class="<%= css %>">mod edit</span>
-          <% else %>
-            <%= link_to "mod edit", edit_mod_story_path(ms.short_id), class: css %>
-          <% end %>
+          <a href="<%= edit_mod_story_path(ms.short_id) %>" class="<%= ms.has_suggestions? ? "story_has_suggestions" : "" %>">mod edit</a>
         <% end %>
 
         <% if ms.can_have_suggestions_from_user?(@user) %>

--- a/app/views/stories/_singledetail.html.erb
+++ b/app/views/stories/_singledetail.html.erb
@@ -68,7 +68,12 @@ classes = [
 
         <% if @user&.is_moderator? %>
           <%= divider_tag %>
-          <a href="<%= edit_mod_story_path(ms.short_id) %>" class="<%= ms.has_suggestions? ? "story_has_suggestions" : "" %>">mod edit</a>
+          <% css = ms.has_suggestions? ? "story_has_suggestions" : "" %>
+          <% if ms.previewing %>
+            <span class="<%= css %>">mod edit</span>
+          <% else %>
+            <%= link_to "mod edit", edit_mod_story_path(ms.short_id), class: css %>
+          <% end %>
         <% end %>
 
         <% if ms.can_have_suggestions_from_user?(@user) %>
@@ -88,7 +93,7 @@ classes = [
 
           <%= divider_tag %>
           <%= form_with :class => "hider", url: merged_stories.first.is_hidden_by_cur_user ? story_unhide_path(merged_stories.first.short_id) : story_hide_path(merged_stories.first.short_id) do |form| %>
-            <%= form.submit merged_stories.first.is_hidden_by_cur_user ? "unhide" : "hide", :class => "btn-link" %>
+            <%= form.submit merged_stories.first.is_hidden_by_cur_user ? "unhide" : "hide", :class => "btn-link", disabled: ms.previewing %>
           <% end %>
 
           <% if ms.hider_count > 0 %>
@@ -110,7 +115,7 @@ classes = [
 
           <%= divider_tag %>
           <%= form_with :class => "saver", url: merged_stories.first.is_saved_by_cur_user ? story_unsave_path(merged_stories.first.short_id) : story_save_path(merged_stories.first.short_id) do |form| %>
-            <%= form.submit merged_stories.first.is_saved_by_cur_user ? "unsave" : "save", :class => "btn-link" %>
+            <%= form.submit merged_stories.first.is_saved_by_cur_user ? "unsave" : "save", :class => "btn-link", disabled: ms.previewing %>
           <% end %>
 
         <% end %>
@@ -131,10 +136,12 @@ classes = [
 
           <span class="comments_label">
             <%= divider_tag %>
-            <a role="heading" aria-level="2" href="<%= merged_stories.count > 1 ? Routes.title_path(merged_stories.first, anchor: ms.comments_anchor) : "#comments-#{merged_stories.first.short_id}" %>">
-              <%= ms.comments_count.zero? ? "no" : ms.comments_count %>
-              <%= 'comment'.pluralize(ms.comments_count) %>
-            </a>
+            <% label = ms.comments_count.zero? ? "no comment" : "#{ms.comments_count} #{'comment'.pluralize(ms.comments_count)}" %>
+            <% if ms.previewing %>
+              <span role="heading" aria-level="2"><%= label %></span>
+            <% else %>
+              <%= link_to label, (merged_stories.count > 1 ? Routes.title_path(merged_stories.first, anchor: ms.comments_anchor) : "#comments-#{merged_stories.first.short_id}"), role: "heading", "aria-level": 2 %>
+            <% end %>
           </span>
 
           <% if ((@user&.is_moderator? && ms.flags > 0) || (ms.flags >= 3 || ms.score <= 0)) %>


### PR DESCRIPTION
<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->

Fixes: #2109. 

Pretty straight forward, just disables the two forms or removes the link/href from the byline buttons when previewing.