### PR TITLE
Hide reply form when collapsing a comment

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -719,8 +719,10 @@ li .comment_folder_button:checked ~ div.comment:not(:target) div.voters .upvoter
 	visibility: hidden;
 	margin-bottom: -15px;
 }
+
 li .comment_folder_button:checked ~ ol.comments ol,
 li .comment_folder_button:checked ~ ol.comments div.comment,
+li .comment_folder_button:checked ~ ol.comments div.reply_form_temporary,
 li .comment_folder_button:checked ~ ol.comments li {
 	display: none;
 }

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -654,6 +654,26 @@ export class _LobstersFunction {
       method: 'post',
       body: formData });
   }
+
+  /** @param {string} storyId */
+  getCollapsedComments(storyId) {
+    return JSON.parse(localStorage.getItem("collapse_" + storyId) || '{}');
+  }
+
+  /**
+   * @param {string} storyId
+   * @param {string} commentId
+   * @param {boolean} collapsed
+   */
+  setCommentCollapsed(storyId, commentId, collapsed) {
+    const collapse = this.getCollapsedComments(storyId);
+    if (collapsed) {
+      collapse[commentId] = 1; // value unused, just truthy and short to serialize
+    } else {
+      delete collapse[commentId];
+    }
+    localStorage.setItem("collapse_" + storyId, JSON.stringify(collapse));
+  }
 }
 
 const Lobster = new _LobstersFunction();
@@ -841,7 +861,7 @@ document.addEventListener("DOMContentLoaded", () => {
   (function() {
     const storyId  = qS('.story')?.getAttribute('data-shortid');
     if (!storyId) return; // only remember or read these on story pages
-    const collapse = JSON.parse(localStorage.getItem("collapse_" + storyId) || '{}');
+    const collapse = Lobster.getCollapsedComments(storyId)
 
     for (var k in collapse) {
       var folder = qS('input#comment_folder_' + k);
@@ -863,13 +883,8 @@ document.addEventListener("DOMContentLoaded", () => {
     var folder = qS("input#comment_folder_" + commentShortId)
     if (folder && folder.checked) {
       folder.checked = false;
-
       const storyId = qS('.story')?.getAttribute('data-shortid');
-      if (storyId) {
-        var collapse = JSON.parse(localStorage.getItem("collapse_" + storyId) || '{}');
-        delete collapse[commentId];
-        localStorage.setItem("collapse_" + storyId, JSON.stringify(collapse));
-      }
+      if (storyId) Lobster.setCommentCollapsed(storyId, commentId, false);
     }
 
     // guard: don't create multiple reply boxes to one comment

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -857,6 +857,20 @@ document.addEventListener("DOMContentLoaded", () => {
 
     const comment = parentSelector(event.target, '.comment');
     const commentId = comment.getAttribute('id');
+    const commentShortId = comment.getAttribute('data-shortid')
+
+    // uncollapse comment
+    var folder = qS("input#comment_folder_" + commentShortId)
+    if (folder && folder.checked) {
+      folder.checked = false;
+
+      const storyId = qS('.story')?.getAttribute('data-shortid');
+      if (storyId) {
+        var collapse = JSON.parse(localStorage.getItem("collapse_" + storyId) || '{}');
+        delete collapse[commentId];
+        localStorage.setItem("collapse_" + storyId, JSON.stringify(collapse));
+      }
+    }
 
     // guard: don't create multiple reply boxes to one comment
     if (qS('#reply_form_' + commentId)) { return false; }
@@ -874,7 +888,7 @@ document.addEventListener("DOMContentLoaded", () => {
     const children = qS(comment.parentElement, '#' + comment.id + '~ .comments')
     children.prepend(div)
 
-    fetchWithCSRF('/comments/' + comment.getAttribute('data-shortid') + '/reply')
+    fetchWithCSRF('/comments/' + commentShortId + '/reply')
       .then(response => {
         response.text().then(text => {
           // guard: don't create multiple reply boxes to one comment


### PR DESCRIPTION
<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->

Fixes: #2121.

Adjusted the CSS so the collapse also applies to the reply form. This had the side effect of the reply form being hidden if you're replying to a collapsed comment, so I also added JS to un-collapse the comment when reply is clicked.