### PR TITLE
Peformance Improvement: Preload comments in /threads

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -396,6 +396,7 @@ class CommentsController < ApplicationController
       .merge(Story.not_deleted(@user))
       .for_presentation
       .joins(:story)
+      .load
     @threads = CommentVoteHydrator.new(@threads, @user)
   end
 


### PR DESCRIPTION
Someone mentioned on IRC that the /threads endpoint is the slowest one for them. I looked for quick wins and this is what I found:

Local testing required comment queries of ~160ms twice for the comments which is by far the most expensive query on this page.

previously the #.empty? check along with an non-empty set of comments would lead to doubling the queries needed.

Preload this so we only need to query the comments once.

There might still be room for improvement to optimize the `@threads` query but for now this should cut the query time in half for the most expensive part of the request.