### PR TITLE
Fix slow /upvote

### DIFF
--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -862,7 +862,7 @@ class Story < ApplicationRecord
 
     Comment.joins(:story)
       .where(story: {merged_story_id: id})
-      .or(Comment.where(story_id: id))
+      .or(Story.where('"story"."id" = ?', id))
   end
 
   def merge_story_short_id=(sid)


### PR DESCRIPTION
The query was performing a table scan on comments.

Change it so that it uses only indexes.

Closes #2135

The query used to run around 750ms for me, now it runs under 1ms for me.

Here's the new explain for the query:

```
sqlite> explain query plan SELECT "comments".* FROM "comments" INNER JOIN "stories" "story" ON "story"."id" = "comments"."story_id" WHERE ("story"."merged_story_id" = 119993 OR ("story"."id" = 119993));
QUERY PLAN
|--MULTI-INDEX OR
|  |--INDEX 1
|  |  `--SEARCH story USING COVERING INDEX index_stories_on_merged_story_id_and_hotness (merged_story_id=?)
|  `--INDEX 2
|     `--SEARCH story USING INTEGER PRIMARY KEY (rowid=?)
`--SEARCH comments USING INDEX story_id_short_id (story_id=?)
```