### PR TITLE
add timestamp to slow query log

### DIFF
--- a/config/initializers/slow_query_log.rb
+++ b/config/initializers/slow_query_log.rb
@@ -1,6 +1,7 @@
 if ENV["ENABLE_SLOW_QUERY_LOGS"] == "true"
   threshold = ENV["SLOW_QUERY_THRESHOLD_MS"].present? ? ENV["SLOW_QUERY_THRESHOLD_MS"].to_f : 100
   logger = ActiveSupport::Logger.new(Rails.root.join("log/slow_query.log"))
+  logger.formatter = Logger::Formatter.new
 
   ActiveSupport::Notifications.subscribe("sql.active_record") do |event|
     if event.duration > threshold


### PR DESCRIPTION
Slow query logs should now display a timestamp for easier debugging.

```
W, [2026-07-12T07:57:53.045335 #432526]  WARN -- : [SLOW QUERY] ...
```