### PR TITLE
Improve traffic queries

### DIFF
--- a/db/migrate/20260712205915_add_indexes_to_traffic_related_columns.rb
+++ b/db/migrate/20260712205915_add_indexes_to_traffic_related_columns.rb
@@ -1,11 +1,5 @@
 class AddIndexesToTrafficRelatedColumns < ActiveRecord::Migration[8.0]
   def change
-    # Used by TrafficHelper.traffic_range
-    add_index :comments, "floor(unixepoch(created_at)/900), created_at", name: "index_comments_on_period_and_created_at"
-    add_index :stories, "floor(unixepoch(created_at)/900), created_at", name: "index_stories_on_period_and_created_at"
-    add_index :votes, "floor(unixepoch(updated_at)/900), updated_at", name: "index_votes_on_period_and_updated_at"
-
-    # Used by TrafficHelper.current_activity!
     add_index :comments, :created_at
     add_index :votes, :updated_at
   end

--- a/db/migrate/20260712205915_add_indexes_to_traffic_related_columns.rb
+++ b/db/migrate/20260712205915_add_indexes_to_traffic_related_columns.rb
@@ -1,0 +1,12 @@
+class AddIndexesToTrafficRelatedColumns < ActiveRecord::Migration[8.0]
+  def change
+    # Used by TrafficHelper.traffic_range
+    add_index :comments, "floor(unixepoch(created_at)/900), created_at", name: "index_comments_on_period_and_created_at"
+    add_index :stories, "floor(unixepoch(created_at)/900), created_at", name: "index_stories_on_period_and_created_at"
+    add_index :votes, "floor(unixepoch(updated_at)/900), updated_at", name: "index_votes_on_period_and_updated_at"
+
+    # Used by TrafficHelper.current_activity!
+    add_index :comments, :created_at
+    add_index :votes, :updated_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_06_13_004304) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_12_205915) do
   create_table "action_mailbox_inbound_emails", force: :cascade do |t|
     t.integer "status", default: 0, null: false
     t.string "message_id", null: false
@@ -86,7 +86,9 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_13_004304) do
     t.datetime "last_reply_at"
     t.datetime "last_edited_at", null: false
     t.string "token", null: false
+    t.index "floor(unixepoch(created_at)/900), created_at", name: "index_comments_on_period_and_created_at"
     t.index ["confidence"], name: "confidence_idx"
+    t.index ["created_at"], name: "index_comments_on_created_at"
     t.index ["hat_id"], name: "comments_hat_id_fk"
     t.index ["parent_comment_id"], name: "comments_parent_comment_id_fk"
     t.index ["score"], name: "index_comments_on_score"
@@ -394,6 +396,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_13_004304) do
     t.datetime "updated_at", null: false
     t.datetime "last_edited_at", null: false
     t.string "token", null: false
+    t.index "floor(unixepoch(created_at)/900), created_at", name: "index_stories_on_period_and_created_at"
     t.index ["created_at"], name: "index_stories_on_created_at"
     t.index ["domain_id"], name: "index_stories_on_domain_id"
     t.index ["hotness"], name: "hotness_idx"
@@ -526,8 +529,10 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_13_004304) do
     t.integer "vote", limit: 1, null: false
     t.string "reason", limit: 1, default: "", null: false
     t.datetime "updated_at", precision: nil, null: false
+    t.index "floor(unixepoch(updated_at)/900), updated_at", name: "index_votes_on_period_and_updated_at"
     t.index ["comment_id"], name: "index_votes_on_comment_id"
     t.index ["story_id"], name: "votes_story_id_fk"
+    t.index ["updated_at"], name: "index_votes_on_updated_at"
     t.index ["user_id", "comment_id"], name: "user_id_comment_id"
     t.index ["user_id", "story_id"], name: "user_id_story_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -86,7 +86,6 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_12_205915) do
     t.datetime "last_reply_at"
     t.datetime "last_edited_at", null: false
     t.string "token", null: false
-    t.index "floor(unixepoch(created_at)/900), created_at", name: "index_comments_on_period_and_created_at"
     t.index ["confidence"], name: "confidence_idx"
     t.index ["created_at"], name: "index_comments_on_created_at"
     t.index ["hat_id"], name: "comments_hat_id_fk"
@@ -396,7 +395,6 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_12_205915) do
     t.datetime "updated_at", null: false
     t.datetime "last_edited_at", null: false
     t.string "token", null: false
-    t.index "floor(unixepoch(created_at)/900), created_at", name: "index_stories_on_period_and_created_at"
     t.index ["created_at"], name: "index_stories_on_created_at"
     t.index ["domain_id"], name: "index_stories_on_domain_id"
     t.index ["hotness"], name: "hotness_idx"
@@ -529,7 +527,6 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_12_205915) do
     t.integer "vote", limit: 1, null: false
     t.string "reason", limit: 1, default: "", null: false
     t.datetime "updated_at", precision: nil, null: false
-    t.index "floor(unixepoch(updated_at)/900), updated_at", name: "index_votes_on_period_and_updated_at"
     t.index ["comment_id"], name: "index_votes_on_comment_id"
     t.index ["story_id"], name: "votes_story_id_fk"
     t.index ["updated_at"], name: "index_votes_on_updated_at"


### PR DESCRIPTION
Adds expression indexes to the traffic_range query and additional indexes to the current_activity query to avoid full table scans.

traffic_range query before: 0.52 seconds
after: 0.08 seconds

current_activity! query before: 0.31 seconds
after: 0.00 seconds

Should fix #2139 

traffic range query plan after:

```
QUERY PLAN
|--CO-ROUTINE v
|  `--SCAN votes USING COVERING INDEX index_votes_on_period_and_updated_at
|--MATERIALIZE c
|  `--SCAN comments USING COVERING INDEX index_comments_on_period_and_created_at
|--MATERIALIZE s
|  `--SCAN stories USING COVERING INDEX index_stories_on_period_and_created_at
|--SCAN v
|--BLOOM FILTER ON s (period=?)
|--SEARCH s USING AUTOMATIC COVERING INDEX (period=?)
|--BLOOM FILTER ON c (period=?)
`--SEARCH c USING AUTOMATIC COVERING INDEX (period=?)
```

current_activity! query plan after:

```
QUERY PLAN
|--SCAN CONSTANT ROW
|--SCALAR SUBQUERY 1
|  `--SEARCH votes USING COVERING INDEX index_votes_on_updated_at (updated_at>?)
|--SCALAR SUBQUERY 2
|  `--SEARCH comments USING COVERING INDEX index_comments_on_created_at (created_at>?)
`--SCALAR SUBQUERY 3
   `--SEARCH stories USING COVERING INDEX index_stories_on_created_at (created_at>?)
```