### PR TITLE
Remove ref tracking query param from submitted URLs

### DIFF
--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -1185,15 +1185,15 @@ class Story < ApplicationRecord
     # strip out tracking query params
     if (match = u.match(/\A([^?]+)\?(.+)\z/))
       params = match[2].split(/[&?]/)
-      # utm_ is google and many others; sk is medium; si/pp is youtube
-      params.reject! { |p|
-        p.match(/^utm_(source|medium|campaign|term|content|referrer)=|^sk=|^gclid=|^fbclid=|^linkId=|^pp=|^si=|^trk=/x)
-      }
       params.reject! { |p|
         if /^lobsters|^src=lobsters|^ref=lobsters/x.match?(p)
           ModNote.tattle_on_traffic_attribution!(self)
           true
         end
+      }
+      # utm_ is google and many others; sk is medium; si/pp is youtube; ref is several analytics platforms
+      params.reject! { |p|
+        p.match(/^utm_(source|medium|campaign|term|content|referrer)=|^sk=|^gclid=|^fbclid=|^linkId=|^pp=|^si=|^trk=|^ref=/x)
       }
       u = match[1] << (params.any? ? "?#{params.join("&")}" : "")
     end

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -66,6 +66,12 @@ describe Story do
     expect(Story.new(url: "http://a.com?linkId=track").url).to eq("http://a.com")
   end
 
+  it "removes ref tracking parameter" do
+    expect(Story.new(url: "http://a.com?ref=z.com").url).to eq("http://a.com")
+    expect(Story.new(url: "http://a.com?ref=z.com&b=c").url).to eq("http://a.com?b=c")
+    expect(Story.new(url: "http://a.com?b=c&ref=z.com&d=e").url).to eq("http://a.com?b=c&d=e")
+  end
+
   it "checks for invalid urls" do
     expect(Story.new(url: "http://example.com").tap(&:valid?).errors[:url]).to be_empty
 


### PR DESCRIPTION
Removes the `ref` parameter from submitted story URLs. Fixes #2111.

It's is not as ubiquitous as Google Analytics' `utm_` parameters, but [Plausible](https://plausible.io/docs/custom-query-params), [Fathom](https://usefathom.com/docs/start/dashboard#refs), and [SimpleAnalytics](https://docs.simpleanalytics.com/how-to-use-url-parameters#using-a-url-parameter) document support for tracking it. In addition, lobste.rs itself [has code](https://github.com/lobsters/lobsters/blob/main/app/models/story.rb#L1193) assuming it's used for tracking/attribution purposes.

Rather than going in the `Utils.normalize` method, I put this next to the other code for stripping tracking parameters. Because this parameter is checked to create a mod note, I also moved the stripping itself after the check for attribution.

I didn't add a DB migration as suggested in [#2111](https://github.com/lobsters/lobsters/issues/2111#issuecomment-4837426170), both because this change affects the actual `url` field as opposed to the `normalized_url` field and because none of the previous changes to strip tracking parameters migrated the data.