### PR TITLE
Experimental recursive CTE optimisations

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -592,12 +592,12 @@ class Comment < ApplicationRecord
     return Comment.none unless story.id # unsaved Stories have no comments
 
     Comment.with_recursive(comment_tree: [
-      Comment.joins(:story).where("(stories.id = #{story.id} or stories.merged_story_id = #{story.id}) and parent_comment_id is null").select("comments.id, comments.depth + comments.confidence AS priority"),
+      Comment.joins(:story).where("(stories.id = #{story.id} or stories.merged_story_id = #{story.id}) and parent_comment_id is null").select("comments.*, comments.depth + comments.confidence AS priority"),
       # work around Rails bug from https://github.com/rails/rails/pull/51549 that generates invalid
       # SQLite-style SQL by wrapping parens around the recursive case if it has an 'order' clause.
       # Comment.joins("JOIN comment_tree ON comment_tree.id = comments.parent_comment_id").order("depth desc", "confidence desc")
-      Arel.sql('SELECT "comments".id, "comments".depth + "comments".confidence AS priority FROM "comments" JOIN comment_tree ON comment_tree.id = comments.parent_comment_id ORDER BY priority desc, comments.id asc')
+      Arel.sql('SELECT "comments".*, "comments".depth + "comments".confidence AS priority FROM "comments" JOIN comment_tree ON comment_tree.id = comments.parent_comment_id ORDER BY priority desc, comments.id asc')
     ])
-      .from("comment_tree").joins("CROSS JOIN comments ON comment_tree.id = comments.id")
+      .from("comment_tree as comments")
   end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -591,28 +591,13 @@ class Comment < ApplicationRecord
   def self.story_threads(story)
     return Comment.none unless story.id # unsaved Stories have no comments
 
-    story_ids = [story.id] + Story.where(merged_story_id: story.id).pluck(:id)
-
-    inner_join = <<~SQL
-      inner join (
-        with recursive confidence as (
-          select
-            c.id,
-            cast(confidence_order as blob) as confidence_order_path
-            from comments c
-            join stories on stories.id = c.story_id
-            where stories.id in (#{story_ids.join(", ")}) and parent_comment_id is null
-          union all
-          select
-            c.id,
-            cast(concat(substring(confidence.confidence_order_path, 1, 3 * (depth + 1)), c.confidence_order) as blob)
-          from comments c join confidence on c.parent_comment_id = confidence.id
-        )
-        select * from confidence
-      ) confidence
-      on comments.id = confidence.id
-    SQL
-
-    Comment.joins(inner_join).where(story_id: story_ids).order("confidence.confidence_order_path")
+    Comment.with_recursive(comment_tree: [
+      Comment.joins(:story).where("(stories.id = #{story.id} or stories.merged_story_id = #{story.id}) and parent_comment_id is null").select("comments.id, comments.depth + comments.confidence AS priority"),
+      # work around Rails bug from https://github.com/rails/rails/pull/51549 that generates invalid
+      # SQLite-style SQL by wrapping parens around the recursive case if it has an 'order' clause.
+      # Comment.joins("JOIN comment_tree ON comment_tree.id = comments.parent_comment_id").order("depth desc", "confidence desc")
+      Arel.sql('SELECT "comments".id, "comments".depth + "comments".confidence AS priority FROM "comments" JOIN comment_tree ON comment_tree.id = comments.parent_comment_id ORDER BY priority desc, comments.id asc')
+    ])
+      .from("comment_tree").joins("CROSS JOIN comments ON comment_tree.id = comments.id")
   end
 end

--- a/db/migrate/20260716231808_add_comment_tree_index.rb
+++ b/db/migrate/20260716231808_add_comment_tree_index.rb
@@ -1,0 +1,9 @@
+class AddCommentTreeIndex < ActiveRecord::Migration[8.0]
+  def up
+    execute "CREATE INDEX index_comment_tree ON comments (parent_comment_id, depth + confidence, id)"
+  end
+
+  def down
+    execute "DROP INDEX index_comment_tree"
+  end
+end


### PR DESCRIPTION
I've been messing around locally to try and optimise the recursive CTEs for `story_threads`.

This attempt is based on these things:
- SQLite looks to have to do a lot of shuffling of data around for everything inside a recursive CTE. Therefore, this makes the CTE only have a column for the comment ID and one for "priority" - as confidence is always between 0 and 1, we can just add it to the comment depth to get a priority level for traversing each comment.
- A covering index is added specifically for this recursive CTE
- A `CROSS JOIN` is used to join the CTE to `comments` - this [lets us force a join order](https://sqlite.org/optoverview.html#crossjoin). As we know any one story will only contain a fraction of all the site comments, we want to scan the CTE and then look up comments by their ID, rather than the other way around even including a bloom filter.

This looks to be an improvement locally, but I dare not make any predictions about how it will behave on the production database. I've thrown the kitchen-sink here in the hopes that at least some of it is helpful, even if some of it is better off reverted!

I get the following query and query plan for this locally:

```sql
WITH RECURSIVE "comment_tree" AS ( SELECT comments.id, comments.depth + comments.confidence AS priority FROM "comments" INNER JOIN "stories" ON "stories"."id" = "comments"."story_id" WHERE ((stories.id = 90 or stories.merged_story_id = 90) and parent_comment_id is null) UNION ALL SELECT "comments".id, "comments".depth + "comments".confidence AS priority FROM "comments" JOIN comment_tree ON comment_tree.id = comments.parent_comment_id ORDER BY priority desc, comments.id asc ) SELECT "comments".* FROM comment_tree CROSS JOIN comments ON comment_tree.id = comments.id;
```

```
QUERY PLAN
|--CO-ROUTINE comment_tree
|  |--SETUP
|  |  |--SEARCH comments USING INDEX comments_parent_comment_id_fk (parent_comment_id=?)
|  |  `--SEARCH stories USING INTEGER PRIMARY KEY (rowid=?)
|  `--RECURSIVE STEP
|     |--SCAN comment_tree
|     `--SEARCH comments USING COVERING INDEX index_comment_tree (parent_comment_id=?)
|--SCAN comment_tree
`--SEARCH comments USING INTEGER PRIMARY KEY (rowid=?)
```