### PR TITLE
Generate cacheable image URL for text stories

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -182,7 +182,7 @@ class StoriesController < ApplicationController
           {property: "og:site_name", content: Rails.application.name},
           {property: "og:title", content: @story.title},
           {property: "og:description", content: @story.comments_count.to_s + " " + "comment".pluralize(@story.comments_count)},
-          {property: "og:image", content: Routes.story_image_url(@story)},
+          {property: "og:image", content: Routes.story_image_or_logo_url(@story)},
           {property: "article:author", content: Routes.user_url(@story.user)}
         ]
         @meta_tags << {property: "article:author", content: "https://#{@story.user.mastodon_instance}/@#{@story.user.mastodon_username}"} if @story.user.mastodon_username.present?

--- a/extras/routes.rb
+++ b/extras/routes.rb
@@ -40,5 +40,10 @@ class Routes
     def url_or_comments_url story, *options
       story.url.presence || title_url(story, *options)
     end
+
+    def story_image_or_logo_url story, *options
+      return Rails.application.root_url + "touch-icon-144.png" if story.url.blank?
+      story_image_url(story, *options)
+    end
   end
 end


### PR DESCRIPTION
StoryImageController would send this logo anyway, but using the direct URL to it means it can be served without hitting Rails.

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
