### PR TITLE
Make 2fa secret easier to copy during enrollment

### DIFF
--- a/app/views/settings/twofa_enroll.html.erb
+++ b/app/views/settings/twofa_enroll.html.erb
@@ -16,7 +16,9 @@ target="_blank">TOTP</a> application of choice:
   Or to add to a device manually enter the secret:
   <details>
     <summary>Reveal Secret</summary>
-    <%= raw @qr_secret %>
+    <p>
+      <pre><%= raw @qr_secret %></pre>
+    </p>
   </details>
 </p>
 


### PR DESCRIPTION
<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
Hello! I ran into this while setting up Two Factor Authentication on my account. I found that it was very slightly annoying to copy/paste the 2fa secret code. When double-clicking on the secret code, instead of only selecting the code, I also selected "Reveal Secret":

<img width="365" height="66" alt="Before - summary is selected along with the details (2fa secret)" src="https://github.com/user-attachments/assets/74b96548-1c95-4a3f-ad82-fec6a7913e49" />

I think it'd be nicer if only the code was selected so that I could paste it directly into my password manager, like this:

<img width="336" height="77" alt="After - only 2fa secret is selected" src="https://github.com/user-attachments/assets/fab0cfea-23db-4426-97e7-99bdc91c8210" />

I also thought the monospace font was more fitting, but let me know if you disagree.

By the way, this was only a test secret, don't worry. :)