### PR TITLE
fix frozen string warning in StoryImage

### DIFF
--- a/app/models/story_image.rb
+++ b/app/models/story_image.rb
@@ -59,7 +59,7 @@ class StoryImage
 
     return nil unless content_type == "text/html"
 
-    converted = response.body.force_encoding("utf-8")
+    converted = response.body.dup.force_encoding("utf-8")
     parsed = Nokogiri::HTML(converted.to_s)
 
     # Try <meta property="og:image">


### PR DESCRIPTION
Running `bundle exec rspec` produces a warning:

```
/home/tom/work/lobsters/app/models/story_image.rb:62: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
```