### PR TITLE
remove parent argument from styled_user_link

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -36,7 +36,7 @@ module UsersHelper
     end
   end
 
-  def styled_user_link user, content = nil, parent = nil, html_options = {}
+  def styled_user_link user, content = nil, html_options = {}
     html_options[:class] ||= []
     if content.is_a?(Story) && content.user_is_author?
       html_options[:class].push "user_is_author"


### PR DESCRIPTION
the parent argument isn't being used in styled_user_link even though it was introduced in https://github.com/lobsters/lobsters/pull/2028/changes#diff-0a32d4e9f83e8c59487817bce4ccece334edc27596e9c7c9e8e2888ed4b0fc97R39

An unintended side effect is that anything with a styled_user_link that specified html_options via hash was now getting ignored in a bunch of places, including the issue described in https://github.com/lobsters/lobsters/issues/2152

The fix is to simply revert back to not having a parent argument and it should fix all the issues related to this change.