### PR TITLE
Remove unreferenced dead code

### DIFF
--- a/app/helpers/traffic_helper.rb
+++ b/app/helpers/traffic_helper.rb
@@ -6,7 +6,6 @@
 # intensity: what % of the range the current activity is (0-100)
 module TrafficHelper
   PERIOD_LENGTH = 15 # minutes
-  CACHE_FOR = 5 # minutes
 
   def self.traffic_range
     div = PERIOD_LENGTH * 60

--- a/app/models/keystore.rb
+++ b/app/models/keystore.rb
@@ -40,31 +40,6 @@ class Keystore < ApplicationRecord
     end
   end
 
-  def self.find_or_create_key_for_update(key, init = nil)
-    loop do
-      found = lock(true).find_by(key: key)
-      return found if found
-
-      begin
-        create! do |kv|
-          kv.key = key
-          kv.value = init
-          kv.save!
-        end
-      rescue ActiveRecord::RecordNotUnique
-        nil
-      end
-    end
-  end
-
-  def self.decrement_value_for(key, amount = -1)
-    increment_value_for(key, amount)
-  end
-
-  def self.decremented_value_for(key, amount = -1)
-    incremented_value_for(key, amount)
-  end
-
   # deliberately no lock/transaction as TrafficHelper is on the hot path of every request
   def self.readthrough_cache(key, &blk)
     if (found = value_for(key))

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -674,10 +674,6 @@ class Story < ApplicationRecord
     HtmlEncoder.decode(s.to_s)
   end
 
-  def domain_search_url
-    "/search?order=newest&q=domain:#{domain}"
-  end
-
   def fix_bogus_chars
     # this is needlessly complicated to work around character encoding issues
     # that arise when doing just self.title.to_s.gsub(160.chr, "")
@@ -1105,14 +1101,6 @@ class Story < ApplicationRecord
 
   def to_param
     short_id
-  end
-
-  def update_availability
-    if is_unavailable && !unavailable_at
-      self.unavailable_at = Time.current
-    elsif unavailable_at && !is_unavailable
-      self.unavailable_at = nil
-    end
   end
 
   # this is less evil than it looks because commonmark produces consistent html:

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -431,13 +431,6 @@ class User < ApplicationRecord
     end
   end
 
-  def undelete!
-    User.transaction do
-      self.deleted_at = nil
-      save!
-    end
-  end
-
   def disable_2fa!
     self.totp_secret = nil
     save!
@@ -544,11 +537,6 @@ class User < ApplicationRecord
 
   def raw_about
     Markdowner.to_raw(about)
-  end
-
-  def mastodon_acct
-    raise unless mastodon_username.present? && mastodon_instance.present?
-    "@#{mastodon_username}@#{mastodon_instance}"
   end
 
   def most_common_story_tag

--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -48,10 +48,6 @@ class Vote < ApplicationRecord
     "Q" => "Low Quality"
   }).freeze
 
-  def on_comment?
-    comment_id.present?
-  end
-
   def on_story?
     comment_id.blank?
   end
@@ -80,18 +76,6 @@ class Vote < ApplicationRecord
     Vote.where(user_id: user, story_id: stories,
       comment_id: nil).find_each do |v|
       votes[v.story_id] = {vote: v.vote, reason: v.reason}
-    end
-
-    votes
-  end
-
-  def self.comment_votes_by_user_for_story_hash(user_id, story_id)
-    votes = {}
-
-    Vote.where(
-      user_id: user_id, story_id: story_id
-    ).where.not(comment_id: nil).find_each do |v|
-      votes[v.comment_id] = {vote: v.vote, reason: v.reason}
     end
 
     votes

--- a/extras/github.rb
+++ b/extras/github.rb
@@ -9,14 +9,6 @@ class Github
     Rails.application.credentials.github&.client_id.present?
   end
 
-  def self.oauth_consumer
-    OAuth::Consumer.new(
-      Rails.application.credentials.github.client_id,
-      Rails.application.credentials.github.client_secret,
-      site: "https://api.github.com"
-    )
-  end
-
   def self.token_and_user_from_code(code)
     s = Sponge.new
     res = s.fetch(


### PR DESCRIPTION
Found these leftovers using [rubydex](https://github.com/shopify/rubydex)

- `TrafficHelper::CACHE_FOR` became unused after e334ae41 stopped using time-based traffic cache keys.
- `Keystore.find_or_create_key_for_update` became unused after b45d1750 switched the remaining code to `upsert`.
- `Keystore.decrement_value_for` and `decremented_value_for` came over in the initial Rails conversion (093747b7) and don't seem to have ever had callers.
- `Story#domain_search_url` became unused after f718da18 switched domain links to `for_domain_url`.
- `Story#update_availability` was added in 9c73c87d but never used.
- `User#undelete!` became unused after 6fb659f8 stopped automatically reactivating deleted users on login.
- `User#mastodon_acct` became unused after f1a253c1 started building the Mastodon author URL directly.
- `Vote#on_comment?` was added in bb5e53e9 but never used.
- `Vote.comment_votes_by_user_for_story_hash` became unused after c05d00ad moved comment vote loading into `CommentVoteHydrator`.
- `Github.oauth_consumer` was added in fcb24439 but the GitHub flow used `Sponge` directly, so it was never used.