### PR TITLE
bump sqlite3 from 2.7.4 to 2.9.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -399,10 +399,8 @@ GEM
       fugit (~> 1.11.0)
       railties (>= 7.1)
       thor (>= 1.3.1)
-    sqlite3 (2.7.4)
+    sqlite3 (2.9.5)
       mini_portile2 (~> 2.8.0)
-    sqlite3 (2.7.4-arm64-darwin)
-    sqlite3 (2.7.4-x86_64-linux-gnu)
     stackprof (0.2.27)
     standard (1.52.0)
       language_server-protocol (~> 3.17.0.2)
@@ -678,9 +676,7 @@ CHECKSUMS
   snaky_hash (2.0.3) sha256=25a3d299566e8153fb02fa23fd9a9358845950f7a523ddbbe1fa1e0d79a6d456
   solid_cache (1.0.7) sha256=58e690ccee057be7351f21b1940d5f9cf6bb132074316e70478e554a79e6a490
   solid_queue (1.2.1) sha256=7976b3690a08080ef63d1b11281f0b77398f7697dbeda0e2c5532682639d4b15
-  sqlite3 (2.7.4) sha256=7fbc1fdb18ba1c0798fb298cb3c35c35bb1743b832a9aeb91add026a5614889c
-  sqlite3 (2.7.4-arm64-darwin) sha256=d5b09cd4e9542aa05f0db0eb7dd868102cc23072ae378e0453e59e0efaed89b8
-  sqlite3 (2.7.4-x86_64-linux-gnu) sha256=0755b458f5501e89c0d5a0003afc4fdd6fd059eb1fb1424221532917096da4be
+  sqlite3 (2.9.5) sha256=04572973a3f943ad50a8adfffc8dd752a5f06e4c3db2026f71838fed8a982606
   stackprof (0.2.27) sha256=aff6d28656c852e74cf632cc2046f849033dc1dedffe7cb8c030d61b5745e80c
   standard (1.52.0) sha256=ec050e63228e31fabe40da3ef96da7edda476f7acdf3e7c2ad47b6e153f6a076
   standard-custom (1.0.2) sha256=424adc84179a074f1a2a309bb9cf7cd6bfdb2b6541f20c6bf9436c0ba22a652b


### PR DESCRIPTION
The [changelog between the two versions](https://github.com/sparklemotion/sqlite3-ruby/compare/v2.7.4...v2.9.5#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed).

This includes changes in upstream sqlite3 containing [3.51.0 - 3.51.3](https://www.sqlite.org/releaselog/3_51_3.html) and [3.53.0 - 3.53.3](https://www.sqlite.org/releaselog/3_53_3.html).

There's a lot in these changelogs, including the fix for the recent [WAL-reset bug](https://lobste.rs/s/mqpba7/sqlite_wal_reset_database_corruption_bug).