### PR TITLE
Fix numeric truncation in flagged_commenters calculation

### DIFF
--- a/app/models/flagged_commenters.rb
+++ b/app/models/flagged_commenters.rb
@@ -67,9 +67,9 @@ class FlaggedCommenters
           sum(flags) as n_flags,
           sum(flags)/count(distinct comments.id) as average_flags,
           (
-            count(distinct if(flags > 0, comments.id, null)) /
+            count(distinct if(flags > 0, comments.id, null)) * 100.0 /
             count(distinct comments.id)
-          ) * 100 as percent_flagged")
+          ) as percent_flagged")
         .having("n_comments > 4 and n_stories > 1 and n_flags >= 10 and percent_flagged > 10")
         .order(sigma: :desc)
         .limit(30)


### PR DESCRIPTION
SQLite has different behaviour of integer division ( integer truncation ) than MariaDB had ( decimal results ).

With multiplication by 100 after the division, `percent_flagged` always became 0% ( for almost everything )  or 100% .

This PR fixes that behaviour by multiplying by 100.0 in the numerator, therefore implicitly casting it to float earlier.

Fixes #2166