### PR TITLE
Performance: Comment.for_presentation to avoid preloading votes: :user

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -64,7 +64,7 @@ class Comment < ApplicationRecord
       .merge(Story.where.not(user: user, user_is_author: true)) # TODO: authorship/beneficial idea
   }
   scope :for_presentation, -> {
-    includes(:user, :hat, moderation: :moderator, story: :user, votes: :user)
+    includes(:user, :hat, moderation: :moderator, story: :user)
   }
   scope :filter_tags, ->(tags) {
     tags.empty? ? all : joins(:story).where(


### PR DESCRIPTION
Since previous work in #1748 it hasn't been necessary to include `votes: :user`, and doing so has been adding GC pressure to comment loading.

Fixes #2163 