### PR TITLE
Ignore public/cache but keep .gitkeep to hold the folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,10 @@ public/application.js
 public/avatars
 public/sitemap*
 public/story_image
+public/cache
+
+## Override .gitkeep
+!public/cache/.gitkeep
 
 # templates to be created per-site
 app/views/about/about.*


### PR DESCRIPTION
The `public/cache/` folder is deliberately kept live by way of `.gitkeep` in there.

However, it fills up with cached output which needs to be manually avoided when doing a `git add`.

This PR ignores `public/cache` with an override to not ignore `public/cache/.gitkeep`.