### PR TITLE
fix dead attribute check in token.rb

### DIFF
--- a/app/models/concerns/token.rb
+++ b/app/models/concerns/token.rb
@@ -3,7 +3,7 @@ module Token
 
   included do
     after_initialize do
-      self.token ||= TypeID.new(self.class.to_s.parameterize) if new_record? || attributes.include?(:token)
+      self.token ||= TypeID.new(self.class.to_s.parameterize) if new_record? || has_attribute?(:token)
     end
 
     validates :token,


### PR DESCRIPTION
Fixes #2164.

`attributes.include?(:token)` is always false because `attributes` uses string keys, not symbols, so the check is dead code. Replace with `has_attribute?(:token)` as suggested in the issue.

`bundle exec rake build` passes (842 examples, 0 failures).