### PR TITLE
fix tags dropdown alignment on mobile #2093

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1117,42 +1117,54 @@ div#story_preview {
 	margin-left: 3.5em;
 }
 
-div#story_box input#story_url {
-	width: 512px;
+#story_box .labelled_grid {
+	grid-template-columns: minmax(6rem, min-content) 1fr;
 }
-div#story_box button#story_fetch_title {
-	height: 27px;
-	padding-top: 1px;
-	padding-bottom: 1px;
-	width: 84px;
+#story_box .labelled_grid > .url-updated,
+#story_box .labelled_grid > .title-reminder,
+#story_box .labelled_grid > .self-promo-warning,
+#story_box .labelled_grid > .hint,
+#story_box .labelled_grid > .markdown_help,
+#story_box .labelled_grid > details {
+	grid-column: 1 / -1;
 }
-div#story_box input#story_title,
-div#story_box input#story_moderation_reason,
-div#story_box input#story_merge_story_short_id,
-div#domain_box input[type=text] {
-	width: 600px;
+#story_box .labelled_grid > .markdown_help {
+	margin-bottom: 1em;
+}
+#story_box .labelled_grid details ul {
+	padding-left: 1em;
+}
+#story_box .inline-row {
+	display: flex;
+	gap: 0.5em;
+	align-items: center;
+}
+#story_box .inline-row input {
+	flex: 1;
+	min-width: 0;
+}
+#story_box .inline-row button {
+	line-height: normal;
+	padding: 3px 10px;
+	white-space: nowrap;
 }
 #story_box .url-updated,
 #story_box .title-reminder,
-#story_box .title-reminder-thanks,
-#story_box .self-promo-warning
-{
+#story_box .self-promo-warning {
 	display: none;
 }
-#story_box details ul {
-	padding-left: 1em;
+#story_box .title-reminder-thanks {
+	display: none;
 }
 .slide-down {
 	display: block !important;
 	transition: height .5s ease !important;
 }
-div#story_box #story_tags {
-	width: 624px;
-	overflow-x: auto;
+#story_box .ts-wrapper {
+	max-width: 100%;
 }
-div#story_box textarea {
-	height: 2rem;
-	width: 600px;
+#story_box textarea {
+	min-height: 3rem;
 }
 
 
@@ -1793,18 +1805,11 @@ input[type="submit"].link_post.pushover_button {
 	}
 
 
-	div#story_box .actions {
-		margin-left: 7em;
-		width: 610px;
-	}
 	#story_holder .ts-control {
 		display: inline-block;
 		width: 611px;
 	}
 
-	#story_box .markdown_help summary {
-		width: calc(7em + 610px);
-	}
 }
 
 @media only screen and (max-width: 480px) {
@@ -2017,13 +2022,14 @@ input[type="submit"].link_post.pushover_button {
 	div#story_box input,
 	div#story_box button,
 	div#story_box textarea,
-	div#story_box #story_tagsa,
+	div#story_box .inline-row,
 	div.actions {
 		margin: 0 !important;
 	}
 
-	div#story_box #story_tags {
-		min-width: 305px !important;
+	#story_holder .ts-wrapper {
+		max-width: 100%;
+		box-sizing: border-box;
 	}
 
 	div#gravatar {

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -279,9 +279,9 @@ export class _LobstersFunction {
         }
         url_field.value = data.url
         button.textContent = old_text
+        button.removeAttribute("disabled");
+        Lobster.checkStoryTitle();
       });
-    button.removeAttribute("disabled");
-    Lobster.checkStoryTitle();
   }
 
   removeFlagModal() {

--- a/app/views/stories/_form.html.erb
+++ b/app/views/stories/_form.html.erb
@@ -1,50 +1,41 @@
 <%# locals: (story:, f:, suggesting: false) -%>
 <%= render :partial => "stories/form_errors", :locals => { :f => f, :story => f.object, suggesting: suggesting } %>
 
-<div class="box">
+<div class="labelled_grid">
   <% unless suggesting %>
-    <div class="boxline">
     <% if f.object.url_is_editable_by_user?(@user) %>
-      <%= f.label :url, "URL" %>
-      <%= f.text_field :url %>
-      <%= button_tag raw("Fetch&nbsp;Title"), :id => "story_fetch_title",
-        :type => "button" %>
-    <% elsif !f.object.new_record? && !f.object.url.blank? %>
-      <%= f.label :url, "URL" %>
-      <div class="d">
-      <a href="<%= f.object.url %>"><%= f.object.url %></a>
+      <%= f.label :url %>
+      <div class="inline-row">
+        <%= f.text_field :url %>
+        <%= button_tag "Fetch Title", :id => "story_fetch_title",
+          :type => "button" %>
       </div>
+    <% elsif !f.object.new_record? && !f.object.url.blank? %>
+      <%= f.label :url %>
+      <div><a href="<%= f.object.url %>"><%= f.object.url %></a></div>
     <% end %>
-    <p class="actions url-updated">
+    <p class="url-updated">
       The URL above has been updated to use the <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel#canonical">canonical URL</a> given by the server.
     </p>
-    </div>
   <% end %>
 
-  <div class="boxline">
-    <%= f.label :title, "Title" %>
-    <%= f.text_field :title, required: true, minlength: Story::TITLE_MIN_LENGTH, maxlength: Story::TITLE_MAX_LENGTH %>
-    <p class="actions title-reminder">
-      Please remove extraneous components from titles such as the name of the site, blog, section, and author.
-      <span class="title-reminder-thanks">
-        Thanks!
-      </span>
-    </p>
-  </div>
+  <%= f.label :title %>
+  <%= f.text_field :title, required: true, minlength: Story::TITLE_MIN_LENGTH, maxlength: Story::TITLE_MAX_LENGTH %>
+  <p class="title-reminder">
+    Please remove extraneous components from titles such as the name of the site, blog, section, and author.
+    <span class="title-reminder-thanks">Thanks!</span>
+  </p>
 
   <% if f.object.id && !suggesting && f.object.suggested_title_times.any? %>
-    <div class="boxline actions">
+    <p class="hint">
       Users have suggested setting this story's title to:
-      <br>
       <% f.object.suggested_title_times.each do |st| %>
-        <%= st.times %>: <%= st.title %><br>
+        <br><%= st.times %>: <%= st.title %>
       <% end %>
-    </div>
+    </p>
   <% end %>
 
-  <div class="boxline" style="margin-bottom: 2px; display: flex;">
-  <%= f.label :tags, "Tags",
-    :style => "line-height: 2.3em; float: none" %>
+  <%= f.label :tags %>
   <%= f.select "tags", options_for_select(
     Tag.all_with_filtered_counts_for(@user).map{|t|
       html = "<strong>#{h(t.tag)}</strong> - #{h(t.description.to_s)}"
@@ -59,33 +50,28 @@
 
       [ "#{t.tag} - #{t.description}", t.tag, { "data-title" => ERB::Util.html_escape(html), "data-tag-css" => t.css_class, "data-vibe" => (t.tag == "vibecoding") ? 'ai' : '' } ]},
     f.object.tags.map(&:tag)), {}, { multiple: true, required: true } %>
-  </div>
 
   <% if f.object.id && !suggesting && f.object.suggested_tagging_times.any? %>
-    <div class="boxline actions">
+    <p class="hint">
       Users have suggested setting this story's tags to:
-      <br>
       <% f.object.suggested_tagging_times.includes(:tag).each do |st| %>
-        <%= st.times %>: <%= tag_link(st.tag) %><br>
+        <br><%= st.times %>: <%= tag_link(st.tag) %>
       <% end %>
-    </div>
+    </p>
   <% end %>
 
   <% unless suggesting %>
-    <div class="boxline">
-      <%= f.label :description, "Text" %>
-      <%= f.text_area :description, rows: 8, placeholder: "Use this for stories without a URL, to link additional context, or to paste abstracts from PDF papers.
+    <%= f.label :description %>
+    <%= f.text_area :description, rows: 8, placeholder: "Use this for stories without a URL, to link additional context, or to paste abstracts from PDF papers.
 
 Please don't use this to promote the story, summarize the post, or explain why you posted it.
 See the guidelines below for more." %>
+
     <%= render :partial => "global/markdownhelp", :locals => { allow_images: @story.can_have_images? } %>
-    </div>
 
-
-    <%= tag.details class: "boxline actions", open: show_guidelines?(@user) ? true : nil do %>
+    <%= tag.details open: show_guidelines?(@user) ? true : nil do %>
       <summary>Story submission guidelines</summary>
       <ul>
-
         <li><p>
           Ideally, use the story's original title and
           <strong>remove the name of the site, blog, event, section, and author</strong>.
@@ -104,7 +90,7 @@ See the guidelines below for more." %>
         </p></li>
 
         <li><p>
-        When submitting a URL, the text field is optional and should only
+        When submitting a URL, the text box is optional and should only
         be used when additional context or explanation of the URL is
         needed.  Commentary or opinion should be reserved for a comment,
         so that it can be voted on separately from the story.
@@ -120,37 +106,41 @@ See the guidelines below for more." %>
         to <%= Rails.application.name %>, drag this bookmarklet to your
         bookmark bar:
         [<a href="javascript:{window.open(%22<%= Rails.application.root_url
-        %>stories/new?url=%22+encodeURIComponent(document.location)+<%
+        %>stories/new?url=%22+encodeURIComponent(document.location)+<%-
         %>%22&title=%22+encodeURIComponent(document.title));%20void(0);}<%
         %>">Submit to <%= Rails.application.name %></a>].
         You'll be taken to this page with the viewed page's URL and title.
         (It can't recognize and remove blog/author names for you, though.)
         </p></li>
-
       </ul>
     <% end %>
   <% end %>
 </div>
+
 <% unless suggesting %>
   <div class="box">
-    <div class="boxline">
-      <%= f.label :user_is_author, "Author" %>
-      <%= f.check_box :user_is_author %>
-      <%= f.label :user_is_author,
-        (f.object.id && f.object.user_id != @user.id ? "Submitter is" : "I am") +
-        " the author of the story at this URL (or this text)",
-        :class => "normal" %>
-    </div>
-    <p class="actions self-promo-warning">
-      If you're new here, please review the <a href="/about#self-promo">self-promo guideline</a>.
-    </p>
-    <div class="boxline">
-      <%= f.label :user_is_following, "Follow" %>
-      <%= f.check_box :user_is_following %>
-      <%= f.label :user_is_following,
-        (f.object.id && f.object.user_id == @user.id ? 'Follow' : "Submitter is following") +
-        " this story to receive replies via e-mail and Pushover",
-        :class => "normal" %>
+    <div class="labelled_grid">
+      <label class="for_checkbox"><%= f.label :user_is_author, "Author" %></label>
+      <div>
+        <%= f.check_box :user_is_author %>
+        <%= f.label :user_is_author,
+          (f.object.id && f.object.user_id != @user.id ? "Submitter is" : "I am") +
+          " the author of the story at this URL (or this text)",
+          :class => "normal" %>
+      </div>
+
+      <p class="self-promo-warning">
+        If you're new here, please review the <a href="/about#self-promo">self-promo guideline</a>.
+      </p>
+
+      <label class="for_checkbox"><%= f.label :user_is_following, "Follow" %></label>
+      <div>
+        <%= f.check_box :user_is_following %>
+        <%= f.label :user_is_following,
+          (f.object.id && f.object.user_id == @user.id ? 'Follow' : "Submitter is following") +
+          " this story to receive replies via e-mail and Pushover",
+          :class => "normal" %>
+      </div>
     </div>
   </div>
 <% end %>


### PR DESCRIPTION
Fixes #2093.

The story form used fixed pixel widths (`#story_tags { width: 624px }`, `input { width: 600px }`) in `box`/`boxline` divs, so on narrow mobile viewports the tags dropdown overflowed the screen. Refactor to a `labelled_grid` (CSS grid) and let the Tom Select wrapper width-constrain to the viewport. Also move `removeAttribute("disabled")` and `checkStoryTitle()` inside the fetch callback so they run after the request completes.

<img width="1860" height="886" alt="screenshot-2026-07-25_01-09-57" src="https://github.com/user-attachments/assets/7b3c224f-0fa4-4b1f-b37b-53339c45d52b" />
<img width="322" height="685" alt="screenshot-2026-07-25_01-10-15" src="https://github.com/user-attachments/assets/21996876-f07f-41cf-86ae-471f977b14c6" />