### PR TITLE
Copy the response body before force_encoding in story_image

### DIFF
--- a/app/models/story_image.rb
+++ b/app/models/story_image.rb
@@ -59,8 +59,7 @@ class StoryImage
 
     return nil unless content_type == "text/html"
 
-    converted = response.body.force_encoding("utf-8")
-    parsed = Nokogiri::HTML(converted.to_s)
+    parsed = Nokogiri::HTML(String.new(response.body, encoding: "utf-8"))
 
     # Try <meta property="og:image">
     card_image_url = parsed.at_css("meta[property='og:image']")&.attributes&.[]("content")&.text


### PR DESCRIPTION
`force_encoding` mutates its receiver, so this was modifying a string owned by response.

This error was revealed by d5d54ec9, which removed the rescue that had been swallowing it since the spec was added.