### PR TITLE
Performance: Compare invited_by_user_id instead of full user object to avoid loading extra data

### DIFF
--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -85,8 +85,6 @@ class Story < ApplicationRecord
       .filter_tags(exclude_tags || [])
       .positive_ranked
       .order(:hotness)
-      # solves n+1 user query in home#index
-      .includes(user: [:invited_by_user])
   }
 
   scope :tagged, ->(user, tags) {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -658,6 +658,6 @@ class User < ApplicationRecord
   end
 
   def recently_invited_by?(user)
-    invited_by_user == user && created_at.after?(MENTORSHIP_DAYS.days.ago)
+    created_at.after?(MENTORSHIP_DAYS.days.ago) && invited_by_user_id == user.id
   end
 end

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -50,4 +50,38 @@ describe UsersHelper do
       expect(helper.you_invited(you: viewing_user, user: old_invited_user)).to eq(nil)
     end
   end
+
+  describe "recently_invited_by" do
+    let(:viewing_user) { create(:user) }
+    let(:new_invited_user) {
+      create(:user, created_at: 1.days.ago,
+        invited_by_user: viewing_user)
+    }
+    let(:old_invited_user) {
+      create(:user, created_at: (User::MENTORSHIP_DAYS + 1).days.ago,
+        invited_by_user: viewing_user)
+    }
+    let(:new_unrelated_user) { create(:user, created_at: 1.days.ago) }
+
+    it "doesn't load the invited_by_user for users you invited" do
+      # refetch the user
+      new_invited_user.reload
+      new_invited_user.recently_invited_by?(viewing_user)
+      expect(new_invited_user.association(:invited_by_user).loaded?).to eq(false)
+    end
+
+    it "doesn't load the invited_by_user for users you didn't invite" do
+      # refetch the user
+      new_unrelated_user.reload
+      new_unrelated_user.recently_invited_by?(viewing_user)
+      expect(new_unrelated_user.association(:invited_by_user).loaded?).to eq(false)
+    end
+
+    it "doesn't load the invited_by_user for users invited a while ago" do
+      # refetch the user
+      old_invited_user.reload
+      old_invited_user.recently_invited_by?(viewing_user)
+      expect(old_invited_user.association(:invited_by_user).loaded?).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
Fixes an issue on story list pages where loading author relationships causes n+1 queries.

The same underlying issue was previously worked around in story.rb by preloading all the data upfront, but was limited to fixing the `hottest` scope.

This was also affecting pages with comments.

This PR fixes both by comparing `invited_by_user` using the id directly. This avoids loading the rest of the object. This PR also eliminates the preload since it is no longer needed.

Fixes #2161 