### PR TITLE
Performance: Get traffic:intensity direct from Keystore without Rails.cache overhead

### DIFF
--- a/app/helpers/traffic_helper.rb
+++ b/app/helpers/traffic_helper.rb
@@ -56,7 +56,7 @@ module TrafficHelper
   end
 
   def self.cached_current_intensity
-    Rails.cache.fetch("traffic:intensity", expires_in: 60) { Keystore.value_for("traffic:intensity") || 0.5 }
+    Keystore.value_for("traffic:intensity") || 0.5
   end
 
   def self.novelty_logo


### PR DESCRIPTION
Despite a stated goal in #1585 to migrate away from Keystore, the current traffic_helper cached value was still keystore but wrapped in a `rails.cache` that is on a short TTL, shorter than the job that populates the traffic:intensity value.

Without this PR:

On a cache hit, it is doing a SELECT to get the value from SolidCache.

On a cache miss, which is frequent, it is doing a SELECT to get the value, finding the cache expired, then getting the value from Keystore, then doing an UPSERT to write the value back to SolidCache.

Both of these operations are more expensive than reading the value from Keystore directly, so much so that on my local environment I ended up moving SolidCache to `tmpfs` to mitigate the performance impact.

This PR restores getting the value from Keystore directly. This should help toward #1814 