### PR TITLE
Allow development on remote access via http://hostname

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -5,6 +5,9 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # Fixes remote development whenever accessed via http://example:3000
+  config.hosts.clear
+
   # In the development environment your application's code is reloaded any time
   # it changes. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.


### PR DESCRIPTION
<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->

We currently allow access from anywhere in development via 0.0.0.0, but Rails has built-in Host header security filtering that blocks connections like http://example:3000. This is useful if you're developing on a remote box with Tailscale or a similar approach. 