### PR TITLE
search: disable autocorrect in text field

### DIFF
--- a/app/views/login/forgot_password.html.erb
+++ b/app/views/login/forgot_password.html.erb
@@ -6,7 +6,7 @@
 <%= form_with url: reset_password_path do |f| %>
   <div class="labelled_grid">
     <%= f.label :email, "E-mail or Username" %>
-    <%= f.text_field :email, size: 40, autofocus: :autofocus, inputmode: :email, autocapitalize: :off %>
+    <%= f.text_field :email, size: 40, autofocus: :autofocus, inputmode: :email, autocapitalize: :off, autocorrect: :off %>
   </div>
 
   <%= f.submit "Reset Password" %>

--- a/app/views/login/index.html.erb
+++ b/app/views/login/index.html.erb
@@ -8,7 +8,7 @@
   <%= form_with url: login_path do |form| %>
     <div class="labelled_grid">
       <%= form.label :email, "E-mail or Username" %>
-      <%= form.text_field :email, size: 40, inputmode: :email, autofocus: :autofocus, autocapitalize: :off %>
+      <%= form.text_field :email, size: 40, inputmode: :email, autofocus: :autofocus, autocapitalize: :off, autocorrect: :off %>
 
       <%= form.label :password, "Password" %>
       <%= form.password_field :password, :size => 30 %>

--- a/app/views/messages/_form.html.erb
+++ b/app/views/messages/_form.html.erb
@@ -7,7 +7,7 @@
         <%= f.hidden_field :recipient_username  %>
     <% else %>
       <%= f.label :recipient_username, "To" %>
-      <%= f.text_field :recipient_username, required: true, autocapitalize: :off %>
+      <%= f.text_field :recipient_username, required: true, autocapitalize: :off, autocorrect: :off %>
     <% end %>
 
     <%= f.label :subject, "Subject" %>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -1,7 +1,7 @@
 <%# locals: () -%>
 <%= form_with url: '/search', method: :get, html: { aria: {label: "Search"} }, class: "search-form" do |f| %>
   <div class="boxline">
-    <%= f.text_field "q", { aria: { label: "Search query" }, value: @search.q, size: 40, autocapitalize: :off, type: "search" }.
+    <%= f.text_field "q", { aria: { label: "Search query" }, value: @search.q, size: 40, autocapitalize: :off, spellcheck: :false, autocorrect: :off, type: "search" }.
       merge(@search.q.present? ? {} : { :autofocus => "autofocus" }) %>
     <input type="submit" value="Search">
   </div>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -1,7 +1,7 @@
 <%# locals: () -%>
 <%= form_with url: '/search', method: :get, html: { aria: {label: "Search"} }, class: "search-form" do |f| %>
   <div class="boxline">
-    <%= f.text_field "q", { aria: { label: "Search query" }, value: @search.q, size: 40, autocapitalize: :off, type: "search" }.
+    <%= f.text_field "q", { aria: { label: "Search query" }, value: @search.q, size: 40, autocapitalize: :off, autocorrect: :off, type: "search" }.
       merge(@search.q.present? ? {} : { :autofocus => "autofocus" }) %>
     <input type="submit" value="Search">
   </div>

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -13,7 +13,7 @@
       <div class="labelled_grid">
         <%= f.label :username, "Username" %>
         <div>
-          <%= f.text_field :username, required: true, size: 15, autocapitalize: :off, pattern: Username.username_regex_html, aria: {describedby: "usernamehint"} %>
+          <%= f.text_field :username, required: true, size: 15, autocapitalize: :off, pattern: Username.username_regex_html, aria: {describedby: "usernamehint"}, autocorrect: :off %>
           <div class="hint" id="usernamehint">
             Format: <tt><%= Username.username_regex_s %></tt><br>
             Creates a <%= link_to 'modlog', moderations_path %> entry like "changed own username from '<%= @edit_user.username %>' to 'NewUsername'"

--- a/app/views/signup/invited.html.erb
+++ b/app/views/signup/invited.html.erb
@@ -17,7 +17,7 @@
 
     <%= f.label :username, "Username" %>
     <div>
-      <%= f.text_field :username, required: true, autocapitalize: :off %>
+      <%= f.text_field :username, required: true, autocapitalize: :off, autocorrect: :off %>
       <div class="hint">
         <tt><%= Username.username_regex_s %></tt>
       </div>


### PR DESCRIPTION
When visiting lobsters on mobile, a papercut I run into frequently is that the phone's autocorrect ends up trying to "correct" domain names in `domain:` searches. I noticed that the search field disables autocapitalization, but not autocorrect. I feel like it'd be useful to disable autocorrect as well so this doesn't happen. I also disabled spellcheck, but can back that part out if you prefer.