### PR TITLE
Use `exists?` instead of `find_by` for boolean checks

### DIFF
--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -778,7 +778,7 @@ class Story < ApplicationRecord
   end
 
   def is_hidden_by_user?(user)
-    !!HiddenStory.find_by(user_id: user.id, story_id: id)
+    HiddenStory.exists?(user_id: user.id, story_id: id)
   end
 
   def is_recent?
@@ -786,7 +786,7 @@ class Story < ApplicationRecord
   end
 
   def is_saved_by_user?(user)
-    !!SavedStory.find_by(user_id: user.id, story_id: id)
+    SavedStory.exists?(user_id: user.id, story_id: id)
   end
 
   def is_unavailable


### PR DESCRIPTION
`exists?` is more efficient than `find_by` when checking for the existence of a record, as it does not instantiate an ActiveRecord object.

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
