### PR TITLE
Fix upvote arrow not showing as orange in /inbox/all (fixes #2128)

### DIFF
--- a/app/controllers/inbox_controller.rb
+++ b/app/controllers/inbox_controller.rb
@@ -63,6 +63,6 @@ class InboxController < ApplicationController
 
   def apply_current_vote
     comment_notifications = @notifications.filter { |n| n.notifiable_type == "Comment" }.map(&:notifiable)
-    comment_notifications = CommentVoteHydrator.new(comment_notifications, @user)
+    comment_notifications = CommentVoteHydrator.new(comment_notifications, @user).to_a
   end
 end

--- a/spec/controllers/inbox_controller_spec.rb
+++ b/spec/controllers/inbox_controller_spec.rb
@@ -60,5 +60,17 @@ describe InboxController do
       # Already read notification remains unchanged, ie read_at is not updated
       expect(notification.read_at).to eq read_at
     end
+
+    it 'When a comment is viewed in the inbox and the "mark as read" button is clicked, it changes into a upvoter.' do
+      comment = create(:comment, user: author, comment: "@#{author.username}")
+      vote = create(:vote, comment: comment, user: recipient, story: comment.story)
+      notification = recipient.notifications.create(notifiable: comment)
+
+      stub_login_as recipient
+      get :all
+
+      notification = @controller.view_assigns["notifications"].first
+      expect(notification.notifiable).to be_current_upvoted
+    end
   end
 end


### PR DESCRIPTION
<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->

The vote arrow for already-voted comments in the comment list did not appear orange when /inbox/all was loaded. The issue was that CommentVoteHydrator was not being enumerated, even though it implements Enumerable. Added .to_a to CommentVoteHydrator.new(comment_notifications, @user) in the apply_current_vote method.

Fixes #2128

<img width="792" height="982" alt="image" src="https://github.com/user-attachments/assets/e68fdfac-06be-4589-b071-8a0619d6125e" />
