### PR TITLE
docs: fix typo conection -> connection

### DIFF
--- a/docs/SETUP_DEVCONTAINER.md
+++ b/docs/SETUP_DEVCONTAINER.md
@@ -36,7 +36,7 @@ Solution:
 * Run `rails db:setup`
 
 **Docker container starts, but devcontainer hangs forever and never attaches**
-"Close the remote conection" and then "Reopen in container" - this is an issue where VS Code is trying to attach before the devcontainer is truly ready.
+"Close the remote connection" and then "Reopen in container" - this is an issue where VS Code is trying to attach before the devcontainer is truly ready.
 
 # Setting up Git
 


### PR DESCRIPTION
Corrects the misspelling `conection` -> `connection` in `docs/SETUP_DEVCONTAINER.md`.

Documentation only, no behaviour change.