### PR TITLE
Add comentr-curator to the robots.txt allowlist

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,6 +1,7 @@
 # PR https://github.com/lobsters/lobsters to be added to the list.
 User-agent: Applebot
 User-agent: BingBot
+User-agent: comentr-curator
 User-agent: DuckDuckBot
 User-agent: GoogleBot
 User-agent: ia_archiver


### PR DESCRIPTION
Your `robots.txt` invites allowlist requests by PR, so here's one.

**What it is:** [comentr.com](https://comentr.com) is a link-aggregation community platform. Its crawler reads `lobste.rs/rss`, posts each story as a link thread pointing at the lobste.rs URL, and sends readers there. It cites and refers rather than reproducing.

**Honouring the group's `Content-Signal: ai-input=no, ai-train=no, search=yes`:**

| Signal | How |
|---|---|
| `ai-train=no` | Nothing fetched is used for model training. |
| `ai-input=no` | The source is configured **link-only** on our side, so no Lobsters text is passed to an LLM. Threads carry the headline and the link, nothing else. |
| `search=yes` | Discovery and referral is the entire purpose. |

The link-only setting is [in our catalog](https://github.com/comentr/comentr-server), not just a promise here — joining this group while summarising your text would break the terms on the first poll.

**Crawler behaviour:**

- User-agent: `comentr-curator/0.1 (+https://comentr.com/bot)`
- Requests `robots.txt` before every fetch and **fails closed** on anything it cannot read or parse — including non-definitive statuses. That's how we noticed we were denied rather than quietly ignoring it.
- Honours `Crawl-delay`.
- Polls the feed every 2 hours; no article-page crawling for this source, since it's link-only.

Happy to adjust the interval, change the token, or have this closed if it's unwelcome — no hard feelings either way.

For full disclosure: we're pre-launch, so this is a small amount of traffic today.
