### PR TITLE
Fix force_open being applied too broadly

### DIFF
--- a/app/views/comments/_threads.html.erb
+++ b/app/views/comments/_threads.html.erb
@@ -31,7 +31,7 @@
     <li class="comments_subtree">
 
     <%
-      force_open = true
+      force_open = false
       show_tree_lines = true
       # show "on: <title>" for comments from merged stories + on non-story pages
       show_story ||= story.try(:id) != comment.story_id


### PR DESCRIPTION
force_open used to be false in this location, by virtue of the default being false and a typo meaning this line originally read `force_option = true`. Having it be true here means that every comment is force-opened, even those the user has flagged or that have a sufficiently low score.

Fixes: 7a80cc1 (whose commit message was jadedly prophetic!)

<!--
I (@pushcx) try to timebox non-urgent Lobsters maintenance to the scheduled office hours streams (https://push.cx/stream), so it may take me a couple days to respond. If you don't want your issue or PR reviewed on a stream, say so and I won't.

If your PR is part of your classwork as a student, please explain what your assignment is. It helps me give you better feedback.

Do not submit code written by LLM-powered coding tools because of the uncertainty around their output's copyright: 
https://en.wikipedia.org/wiki/Artificial_intelligence_and_copyright
-->
